### PR TITLE
feat: move surprise me button to header

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3,7 +3,6 @@
     "featured": "Featured",
     "recently_added": "Recently added",
     "trending": "Trending",
-    "surprise_me": "✨ Surprise me",
     "no_results": "No results found"
   },
   "sidebar": {
@@ -22,6 +21,7 @@
     "catalogue": "Catalogue",
     "downloads": "Downloads",
     "search_results": "Search results",
+    "surprise_me": "✨ Surprise me",
     "settings": "Settings"
   },
   "bottom_panel": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -3,7 +3,6 @@
     "featured": "Destacado",
     "recently_added": "Recién Añadidos",
     "trending": "Tendencias",
-    "surprise_me": "✨ ¡Sorpréndeme!",
     "no_results": "No se encontraron resultados"
   },
   "sidebar": {
@@ -22,6 +21,7 @@
     "catalogue": "Catálogo",
     "downloads": "Descargas",
     "search_results": "Resultados de búsqueda",
+    "surprise_me": "✨ ¡Sorpréndeme!",
     "settings": "Ajustes"
   },
   "bottom_panel": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -3,7 +3,6 @@
     "featured": "En vedette",
     "recently_added": "Récemment ajouté",
     "trending": "Tendance",
-    "surprise_me": "✨ Surprenez-moi",
     "no_results": "Aucun résultat trouvé"
   },
   "sidebar": {
@@ -22,6 +21,7 @@
     "catalogue": "Catalogue",
     "downloads": "Téléchargements",
     "search_results": "Résultats de la recherche",
+    "surprise_me": "✨ Surprenez-moi",
     "settings": "Paramètres"
   },
   "bottom_panel": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -3,7 +3,6 @@
     "featured": "Destaque",
     "recently_added": "Novidades",
     "trending": "Populares",
-    "surprise_me": "✨ Me surpreenda",
     "no_results": "Nenhum resultado encontrado"
   },
   "sidebar": {
@@ -22,6 +21,7 @@
     "catalogue": "Catálogo",
     "downloads": "Downloads",
     "search_results": "Resultados da busca",
+    "surprise_me": "✨ Me surpreenda",
     "settings": "Configurações"
   },
   "bottom_panel": {

--- a/src/renderer/components/header/header.tsx
+++ b/src/renderer/components/header/header.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from "@renderer/hooks";
 
 import * as styles from "./header.css";
 import { clearSearch } from "@renderer/features";
+import { Button } from "../button/button";
 
 export interface HeaderProps {
   onSearch: (query: string) => void;
@@ -31,6 +32,8 @@ export function Header({ onSearch, onClear, search }: HeaderProps) {
   );
   const dispatch = useAppDispatch();
 
+  const [isLoadingRandomGame, setIsLoadingRandomGame] = useState(false);
+  
   const [isFocused, setIsFocused] = useState(false);
 
   const { t } = useTranslation("header");
@@ -61,6 +64,19 @@ export function Header({ onSearch, onClear, search }: HeaderProps) {
     navigate(-1);
   };
 
+  const handleRandomizerClick = () => {
+    setIsLoadingRandomGame(true);
+
+    window.electron
+      .getRandomGame()
+      .then((objectID) => {
+        navigate(`/game/steam/${objectID}`);
+      })
+      .finally(() => {
+        setIsLoadingRandomGame(false);
+      });
+  };
+
   return (
     <header
       className={styles.header({
@@ -88,6 +104,14 @@ export function Header({ onSearch, onClear, search }: HeaderProps) {
       </div>
 
       <section className={styles.section}>
+        <Button
+            onClick={handleRandomizerClick}
+            theme="outline"
+            disabled={isLoadingRandomGame}
+          >
+            {t("surprise_me")}
+        </Button>
+
         <div className={styles.search({ focused: isFocused })}>
           <button
             type="button"

--- a/src/renderer/pages/catalogue/catalogue.tsx
+++ b/src/renderer/pages/catalogue/catalogue.tsx
@@ -17,7 +17,6 @@ export function Catalogue() {
   const navigate = useNavigate();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingRandomGame, setIsLoadingRandomGame] = useState(false);
 
   const [currentCategory, setCurrentCategory] = useState(categories.at(0)!);
   const [catalogue, setCatalogue] = useState<
@@ -48,19 +47,6 @@ export function Catalogue() {
     }
   };
 
-  const handleRandomizerClick = () => {
-    setIsLoadingRandomGame(true);
-
-    window.electron
-      .getRandomGame()
-      .then((objectID) => {
-        navigate(`/game/steam/${objectID}`);
-      })
-      .finally(() => {
-        setIsLoadingRandomGame(false);
-      });
-  };
-
   useEffect(() => {
     setIsLoading(true);
     getCatalogue(categories.at(0)!);
@@ -85,14 +71,6 @@ export function Catalogue() {
               </Button>
             ))}
           </div>
-
-          <Button
-            onClick={handleRandomizerClick}
-            theme="outline"
-            disabled={isLoadingRandomGame}
-          >
-            {t("surprise_me")}
-          </Button>
         </section>
 
         <h2>{t(currentCategory)}</h2>


### PR DESCRIPTION
- Moves the `✨ Surprise me` button to app header, so it is always visible, allowing the user to continuously navigate to random games

![image](https://github.com/hydralauncher/hydra/assets/15229294/5ef6cf27-1d1a-4d58-9f95-e4bd638ca661)
