### PR TITLE
Save database to userData instead of appData

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -46,8 +46,7 @@ export enum GameStatus {
 export const defaultDownloadsPath = path.join(os.homedir(), "downloads");
 
 export const databasePath = path.join(
-  app.getPath("appData"),
-  app.getName(),
+  app.getPath("userData"),
   "hydra.db"
 );
 


### PR DESCRIPTION
According to Electron's documentation, the `userData` folder is the place to store configuration files, and, by default, it already is the `appData` appended with the app name, so this PR should not move the file to another folder. (source: https://www.electronjs.org/docs/latest/api/app#appgetpathname)

The problem of doing the concatenation manually, is that it prevents us to launch the app with the `--user-data-dir` (to save data in a different folder than %APPDATA%), as all the other electron files go to the provided user data directory, except for the hydra.db file, as it does not use the userDir parameter.

e.g.
|Command|Before this PR|After this PR|*|
|-----|----|----|-----|
|Hydra.exe|%APPDATA%\Hydra\\\<electron files> <br> %APPDATA%\Hydra\hydra.db|%APPDATA%\Hydra\\\<electron files> <br> %APPDATA%\Hydra\hydra.db|No change|
|Hydra.exe <br>&nbsp; --user-data-dir=D:\Data| D:\Data\\\<electron files> <br> %APPDATA%\Hydra\hydra.db|D:\Data\\\<electron files> <br> D:\Data\\hydra.db||