### PR TITLE
Feat/enhance get random game

### DIFF
--- a/src/main/events/catalogue/get-random-game.ts
+++ b/src/main/events/catalogue/get-random-game.ts
@@ -27,7 +27,7 @@ const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
       const catalogueResults = await searchGames({ query: game.title });
 
       if (catalogueResults.length) {
-        resultObjectId = catalogueResults[0].objectID;
+        resultObjectId = game.objectID;
       }
     }
     nextGameIndex += 1;

--- a/src/main/events/catalogue/get-random-game.ts
+++ b/src/main/events/catalogue/get-random-game.ts
@@ -1,27 +1,44 @@
 import shuffle from "lodash/shuffle";
 
-import { getRandomSteam250List } from "@main/services";
+import { Steam250Game, getSteam250List } from "@main/services";
 
 import { registerEvent } from "../register-event";
 import { searchGames, searchRepacks } from "../helpers/search-games";
 import { formatName } from "@main/helpers";
 
+let gamesList = new Array<Steam250Game>();
+let nextGameIndex = 0;
+
 const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
-  return getRandomSteam250List().then(async (games) => {
-    const shuffledList = shuffle(games);
+  if (gamesList.length == 0) {
+    console.log("fetching steam 250 pages");
+    gamesList = shuffle(await getSteam250List());
+  } else {
+    console.log("getting cached list");
+  }
 
-    for (const game of shuffledList) {
-      const repacks = searchRepacks(formatName(game.title));
+  let resultObjectId = "";
 
-      if (repacks.length) {
-        const results = await searchGames({ query: game.title });
+  while (!resultObjectId) {
+    const game = gamesList[nextGameIndex];
+    const repacks = searchRepacks(formatName(game.title));
 
-        if (results.length) {
-          return results[0].objectID;
-        }
+    if (repacks.length) {
+      const results = await searchGames({ query: game.title });
+
+      if (results.length) {
+        resultObjectId = results[0].objectID;
       }
     }
-  });
+    nextGameIndex += 1;
+
+    if (nextGameIndex == gamesList.length - 1) {
+      nextGameIndex = 0;
+      gamesList = shuffle(gamesList);
+    }
+  }
+
+  return resultObjectId;
 };
 
 registerEvent(getRandomGame, {

--- a/src/main/events/catalogue/get-random-game.ts
+++ b/src/main/events/catalogue/get-random-game.ts
@@ -6,7 +6,7 @@ import { registerEvent } from "../register-event";
 import { searchGames, searchRepacks } from "../helpers/search-games";
 import { formatName } from "@main/helpers";
 
-let gamesList = new Array<Steam250Game>();
+let gamesList: Steam250Game[] = [];
 let nextGameIndex = 0;
 
 const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
@@ -24,15 +24,15 @@ const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
     const repacks = searchRepacks(formatName(game.title));
 
     if (repacks.length) {
-      const results = await searchGames({ query: game.title });
+      const catalogueResults = await searchGames({ query: game.title });
 
-      if (results.length) {
-        resultObjectId = results[0].objectID;
+      if (catalogueResults.length) {
+        resultObjectId = catalogueResults[0].objectID;
       }
     }
     nextGameIndex += 1;
 
-    if (nextGameIndex == gamesList.length - 1) {
+    if (nextGameIndex == gamesList.length) {
       nextGameIndex = 0;
       gamesList = shuffle(gamesList);
     }

--- a/src/main/events/catalogue/get-random-game.ts
+++ b/src/main/events/catalogue/get-random-game.ts
@@ -5,11 +5,10 @@ import { Steam250Game, getSteam250List } from "@main/services";
 import { registerEvent } from "../register-event";
 import { searchGames, searchRepacks } from "../helpers/search-games";
 
-let gamesList: Steam250Game[] = [];
-let nextGameIndex = 0;
+const state = { games: Array<Steam250Game>(), index: 0 };
 
 const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
-  if (gamesList.length == 0) {
+  if (state.games.length == 0) {
     const steam250List = await getSteam250List();
 
     const filteredSteam250List = steam250List.filter((game) => {
@@ -19,20 +18,20 @@ const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
       return repacks.length && catalogue.length;
     });
 
-    gamesList = shuffle(filteredSteam250List);
+    state.games = shuffle(filteredSteam250List);
   }
 
-  if (gamesList.length == 0) {
+  if (state.games.length == 0) {
     return "";
   }
 
-  const resultObjectId = gamesList[nextGameIndex].objectID;
+  const resultObjectId = state.games[state.index].objectID;
 
-  nextGameIndex += 1;
+  state.index += 1;
 
-  if (nextGameIndex == gamesList.length) {
-    nextGameIndex = 0;
-    gamesList = shuffle(gamesList);
+  if (state.index == state.games.length) {
+    state.index = 0;
+    state.games = shuffle(state.games);
   }
 
   return resultObjectId;

--- a/src/main/events/catalogue/get-random-game.ts
+++ b/src/main/events/catalogue/get-random-game.ts
@@ -20,14 +20,13 @@ const getRandomGame = async (_event: Electron.IpcMainInvokeEvent) => {
   let resultObjectId = "";
 
   while (!resultObjectId) {
-    const game = gamesList[nextGameIndex];
-    const repacks = searchRepacks(formatName(game.title));
+    const nextGame = gamesList[nextGameIndex];
+    const repacks = searchRepacks(formatName(nextGame.title));
 
     if (repacks.length) {
-      const catalogueResults = await searchGames({ query: game.title });
-
+      const catalogueResults = await searchGames({ query: nextGame.title });
       if (catalogueResults.length) {
-        resultObjectId = game.objectID;
+        resultObjectId = nextGame.objectID;
       }
     }
     nextGameIndex += 1;

--- a/src/main/events/catalogue/search-games.ts
+++ b/src/main/events/catalogue/search-games.ts
@@ -6,7 +6,7 @@ const searchGamesEvent = async (
   _event: Electron.IpcMainInvokeEvent,
   query: string
 ): Promise<CatalogueEntry[]> => {
-  return Promise.all(searchGames({ query, take: 12 }));
+  return searchGames({ query, take: 12 });
 };
 
 registerEvent(searchGamesEvent, {

--- a/src/main/events/catalogue/search-games.ts
+++ b/src/main/events/catalogue/search-games.ts
@@ -1,11 +1,15 @@
 import { registerEvent } from "../register-event";
 import { searchGames } from "../helpers/search-games";
+import { CatalogueEntry } from "@types";
 
-registerEvent(
-  (_event: Electron.IpcMainInvokeEvent, query: string) =>
-    searchGames({ query, take: 12 }),
-  {
-    name: "searchGames",
-    memoize: true,
-  }
-);
+const searchGamesEvent = async (
+  _event: Electron.IpcMainInvokeEvent,
+  query: string
+): Promise<CatalogueEntry[]> => {
+  return Promise.all(searchGames({ query, take: 12 }));
+};
+
+registerEvent(searchGamesEvent, {
+  name: "searchGames",
+  memoize: true,
+});

--- a/src/main/events/helpers/search-games.ts
+++ b/src/main/events/helpers/search-games.ts
@@ -42,11 +42,12 @@ export interface SearchGamesArgs {
   skip?: number;
 }
 
-export const searchGames = async ({
+// Check if this function really needed to be an async function
+export const searchGames = ({
   query,
   take,
   skip,
-}: SearchGamesArgs): Promise<CatalogueEntry[]> => {
+}: SearchGamesArgs): CatalogueEntry[] => {
   const results = steamGamesIndex
     .search(formatName(query || ""), { limit: take, offset: skip })
     .map((index) => {
@@ -61,11 +62,9 @@ export const searchGames = async ({
       };
     });
 
-  return Promise.all(results).then((resultsWithRepacks) =>
-    orderBy(
-      resultsWithRepacks,
-      [({ repacks }) => repacks.length, "repacks"],
-      ["desc"]
-    )
+  return orderBy(
+    results,
+    [({ repacks }) => repacks.length, "repacks"],
+    ["desc"]
   );
 };

--- a/src/main/events/helpers/search-games.ts
+++ b/src/main/events/helpers/search-games.ts
@@ -42,7 +42,6 @@ export interface SearchGamesArgs {
   skip?: number;
 }
 
-// Check if this function really needed to be an async function
 export const searchGames = ({
   query,
   take,

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -1,6 +1,10 @@
 import axios from "axios";
 import { JSDOM } from "jsdom";
-import shuffle from "lodash/shuffle";
+
+export interface Steam250Game {
+  title: string;
+  objectID: string;
+}
 
 export const requestSteam250 = async (path: string) => {
   return axios.get(`https://steam250.com${path}`).then((response) => {
@@ -28,7 +32,8 @@ const steam250Paths = [
   "/most_played",
 ];
 
-export const getRandomSteam250List = async () => {
-  const [path] = shuffle(steam250Paths);
-  return requestSteam250(path);
+export const getSteam250List = async () => {
+  const gamesPromises = steam250Paths.map((path) => requestSteam250(path));
+  const gamesList = (await Promise.all(gamesPromises)).flat();
+  return [...new Set(gamesList)];
 };

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -11,17 +11,17 @@ export const requestSteam250 = async (path: string) => {
     const { window } = new JSDOM(response.data);
     const { document } = window;
 
-    return Array.from(document.querySelectorAll(".appline .title a")).map(
-      ($title: HTMLAnchorElement) => {
+    return Array.from(document.querySelectorAll(".appline .title a"))
+      .map(($title: HTMLAnchorElement) => {
         const steamGameUrl = $title.href;
         if (!steamGameUrl) return null;
 
         return {
           title: $title.textContent,
           objectID: steamGameUrl.split("/").pop(),
-        };
-      }
-    );
+        } as Steam250Game;
+      })
+      .filter((game) => game != null);
   });
 };
 

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -7,22 +7,25 @@ export interface Steam250Game {
 }
 
 export const requestSteam250 = async (path: string) => {
-  return axios.get(`https://steam250.com${path}`).then((response) => {
-    const { window } = new JSDOM(response.data);
-    const { document } = window;
+  return axios
+    .get(`https://steam250.com${path}`)
+    .then((response) => {
+      const { window } = new JSDOM(response.data);
+      const { document } = window;
 
-    return Array.from(document.querySelectorAll(".appline .title a"))
-      .map(($title: HTMLAnchorElement) => {
-        const steamGameUrl = $title.href;
-        if (!steamGameUrl) return null;
+      return Array.from(document.querySelectorAll(".appline .title a"))
+        .map(($title: HTMLAnchorElement) => {
+          const steamGameUrl = $title.href;
+          if (!steamGameUrl) return null;
 
-        return {
-          title: $title.textContent,
-          objectID: steamGameUrl.split("/").pop(),
-        } as Steam250Game;
-      })
-      .filter((game) => game != null);
-  });
+          return {
+            title: $title.textContent,
+            objectID: steamGameUrl.split("/").pop(),
+          } as Steam250Game;
+        })
+        .filter((game) => game != null);
+    })
+    .catch((_) => []);
 };
 
 const steam250Paths = [

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -35,5 +35,11 @@ const steam250Paths = [
 export const getSteam250List = async () => {
   const gamesPromises = steam250Paths.map((path) => requestSteam250(path));
   const gamesList = (await Promise.all(gamesPromises)).flat();
-  return [...new Set(gamesList)];
+
+  const gamesMap = gamesList.reduce((map, item) => {
+    map.set(item.objectID, item);
+    return map;
+  }, new Map<string, Steam250Game>());
+
+  return [...gamesMap.values()];
 };

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -39,10 +39,10 @@ export const getSteam250List = async () => {
   const gamesPromises = steam250Paths.map((path) => requestSteam250(path));
   const gamesList = (await Promise.all(gamesPromises)).flat();
 
-  const gamesMap = gamesList.reduce((map, item) => {
+  const gamesMap: Map<string, Steam250Game> = gamesList.reduce((map, item) => {
     map.set(item.objectID, item);
     return map;
-  }, new Map<string, Steam250Game>());
+  }, new Map());
 
   return [...gamesMap.values()];
 };

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -25,7 +25,7 @@ export const requestSteam250 = async (path: string) => {
         })
         .filter((game) => game != null);
     })
-    .catch((_) => []);
+    .catch((_) => [] as Steam250Game[]);
 };
 
 const steam250Paths = [

--- a/src/main/services/steam-250.ts
+++ b/src/main/services/steam-250.ts
@@ -36,8 +36,9 @@ const steam250Paths = [
 ];
 
 export const getSteam250List = async () => {
-  const gamesPromises = steam250Paths.map((path) => requestSteam250(path));
-  const gamesList = (await Promise.all(gamesPromises)).flat();
+  const gamesList = (
+    await Promise.all(steam250Paths.map((path) => requestSteam250(path)))
+  ).flat();
 
   const gamesMap: Map<string, Steam250Game> = gamesList.reduce((map, item) => {
     map.set(item.objectID, item);

--- a/src/renderer/pages/game-details/game-details.tsx
+++ b/src/renderer/pages/game-details/game-details.tsx
@@ -33,6 +33,7 @@ export function GameDetails() {
   const { objectID, shop } = useParams();
 
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingRandomGame, setIsLoadingRandomGame] = useState(false);
   const [color, setColor] = useState("");
   const [gameDetails, setGameDetails] = useState<ShopDetails | null>(null);
   const [howLongToBeat, setHowLongToBeat] = useState<{
@@ -97,6 +98,7 @@ export function GameDetails() {
 
         setGameDetails(result);
         dispatch(setHeaderTitle(result.name));
+        setIsLoadingRandomGame(false);
       })
       .finally(() => {
         setIsLoading(false);
@@ -149,6 +151,7 @@ export function GameDetails() {
   };
 
   const handleRandomizerClick = async () => {
+    setIsLoadingRandomGame(true);
     const randomGameObjectID = await window.electron.getRandomGame();
 
     const searchParams = new URLSearchParams({
@@ -269,6 +272,7 @@ export function GameDetails() {
           className={styles.randomizerButton}
           onClick={handleRandomizerClick}
           theme="outline"
+          disabled={isLoadingRandomGame}
         >
           <div style={{ width: 16, height: 16, position: "relative" }}>
             <Lottie

--- a/src/renderer/pages/game-details/game-details.tsx
+++ b/src/renderer/pages/game-details/game-details.tsx
@@ -53,17 +53,9 @@ export function GameDetails() {
   const [showRepacksModal, setShowRepacksModal] = useState(false);
   const [showSelectFolderModal, setShowSelectFolderModal] = useState(false);
 
-  const randomGameObjectID = useRef<string | null>(null);
-
   const dispatch = useAppDispatch();
 
   const { game: gameDownloading, startDownload, isDownloading } = useDownload();
-
-  const getRandomGame = useCallback(() => {
-    window.electron.getRandomGame().then((objectID) => {
-      randomGameObjectID.current = objectID;
-    });
-  }, []);
 
   const handleImageSettled = useCallback((url: string) => {
     average(url, { amount: 1, format: "hex" })
@@ -89,8 +81,6 @@ export function GameDetails() {
     setIsGamePlaying(false);
     dispatch(setHeaderTitle(""));
 
-    getRandomGame();
-
     window.electron
       .getGameShopDetails(objectID, "steam", getSteamLanguage(i18n.language))
       .then((result) => {
@@ -114,7 +104,7 @@ export function GameDetails() {
 
     getGame();
     setHowLongToBeat({ isLoading: true, data: null });
-  }, [getGame, getRandomGame, dispatch, navigate, objectID, i18n.language]);
+  }, [getGame, dispatch, navigate, objectID, i18n.language]);
 
   const isGameDownloading = isDownloading && gameDownloading?.id === game?.id;
 
@@ -158,16 +148,14 @@ export function GameDetails() {
     });
   };
 
-  const handleRandomizerClick = () => {
-    if (!randomGameObjectID.current) return;
+  const handleRandomizerClick = async () => {
+    const randomGameObjectID = await window.electron.getRandomGame();
 
     const searchParams = new URLSearchParams({
       fromRandomizer: "1",
     });
 
-    navigate(
-      `/game/steam/${randomGameObjectID.current}?${searchParams.toString()}`
-    );
+    navigate(`/game/steam/${randomGameObjectID}?${searchParams.toString()}`);
   };
 
   const fromRandomizer = searchParams.get("fromRandomizer");

--- a/src/renderer/pages/game-details/game-details.tsx
+++ b/src/renderer/pages/game-details/game-details.tsx
@@ -1,6 +1,6 @@
 import Color from "color";
 import { average } from "color.js";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import type {

--- a/src/renderer/pages/home/home.tsx
+++ b/src/renderer/pages/home/home.tsx
@@ -58,14 +58,12 @@ export function Home() {
   const getRandomGame = useCallback(() => {
     setIsLoadingRandomGame(true);
 
-    window.electron
-      .getRandomGame()
-      .then((objectID) => {
+    window.electron.getRandomGame().then((objectID) => {
+      if (objectID) {
         randomGameObjectID.current = objectID;
-      })
-      .finally(() => {
         setIsLoadingRandomGame(false);
-      });
+      }
+    });
   }, []);
 
   const handleRandomizerClick = () => {


### PR DESCRIPTION
### Refactor logic of getting random games

1. On the first call of getRandomGame, Hydra makes all the requests to steam250 pages
2. Removes duplicates games from the list
3. Removes games that are not indexed on Hydra
4. And shuffles the resulting list
5. Now, on each new call to getRandomGame, there's no need to make a new request, it just gets the next game on the list
6. If the end of the list is reached, it is shuffled again and moves the index to the start of the list

### Other adjustments
- Makes the Surprise me button disabled until the game details page finishes loading, preventing a click spam on the button that could cause some strange behaviours on the page