### PR TITLE
feat: Option to choose the number of results on the Catalog page in the configuration menu.

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -123,7 +123,8 @@
     "enable_download_notifications": "When a download is complete",
     "enable_repack_list_notifications": "When a new repack is added",
     "telemetry": "Telemetry",
-    "telemetry_description": "Enable anonymous usage statistics"
+    "telemetry_description": "Enable anonymous usage statistics",
+    "results_per_page": "Results per page"
   },
   "notifications": {
     "download_complete": "Download complete",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -113,7 +113,8 @@
     "enable_download_notifications": "Cuando se completa una descarga",
     "enable_repack_list_notifications": "Cuando se añade un repack nuevo",
     "telemetry": "Telemetría",
-    "telemetry_description": "Habilitar recopilación de datos de manera anónima"
+    "telemetry_description": "Habilitar recopilación de datos de manera anónima",
+    "results_per_page": "Resultados por página"
   },
   "notifications": {
     "download_complete": "Descarga completada",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -113,7 +113,8 @@
     "enable_download_notifications": "Quand un téléchargement est terminé",
     "enable_repack_list_notifications": "Quand un nouveau repack est ajouté",
     "telemetry": "Télémétrie",
-    "telemetry_description": "Activer les statistiques d'utilisation anonymes"
+    "telemetry_description": "Activer les statistiques d'utilisation anonymes",
+    "results_per_page": "Resultats par page"
   },
   "notifications": {
     "download_complete": "Téléchargement terminé",

--- a/src/locales/hu/translation.json
+++ b/src/locales/hu/translation.json
@@ -123,7 +123,8 @@
     "enable_download_notifications": "Amikor egy letöltés befejeződik",
     "enable_repack_list_notifications": "Amikor egy új repack hozzáadásra kerül",
     "telemetry": "Telemetria",
-    "telemetry_description": "Névtelen felhasználási statisztikák engedélyezése"
+    "telemetry_description": "Névtelen felhasználási statisztikák engedélyezése",
+    "results_per_page": "Válaszok oldalszám:"
   },
   "notifications": {
     "download_complete": "Letöltés befejeződött",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -117,7 +117,8 @@
     "enable_download_notifications": "Quando un download è completo",
     "enable_repack_list_notifications": "Quando viene aggiunto un nuovo repack",
     "telemetry": "Telemetria",
-    "telemetry_description": "Abilita statistiche di utilizzo anonime"
+    "telemetry_description": "Abilita statistiche di utilizzo anonime",
+    "results_per_page": "Risultati per pagina"
   },
   "notifications": {
     "download_complete": "Download completato",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -119,7 +119,8 @@
     "enable_download_notifications": "Quando um download for concluído",
     "enable_repack_list_notifications": "Quando a lista de repacks for atualizada",
     "telemetry": "Telemetria",
-    "telemetry_description": "Habilitar estatísticas de uso anônimas"
+    "telemetry_description": "Habilitar estatísticas de uso anônimas",
+    "results_per_page": "Resultados por página"
   },
   "notifications": {
     "download_complete": "Download concluído",

--- a/src/main/entity/user-preferences.entity.ts
+++ b/src/main/entity/user-preferences.entity.ts
@@ -26,6 +26,9 @@ export class UserPreferences {
   @Column("boolean", { default: true })
   telemetryEnabled: boolean;
 
+  @Column("int", { default: 30 })
+  resultsPerPage: number;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/renderer/src/components/radio-field/radio-field.css.ts
+++ b/src/renderer/src/components/radio-field/radio-field.css.ts
@@ -1,0 +1,40 @@
+import { SPACING_UNIT, vars } from "../../theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const radioField = style({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  gap: `${SPACING_UNIT}px`,
+  cursor: "pointer",
+});
+
+export const radio = style({
+  width: "20px",
+  height: "20px",
+  borderRadius: "4px",
+  backgroundColor: vars.color.darkBackground,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  position: "relative",
+  transition: "all ease 0.2s",
+  border: `solid 1px ${vars.color.borderColor}`,
+  ":hover": {
+      borderColor: "rgba(255, 255, 255, 0.5)",
+  },
+});
+
+export const radioInput = style({
+  width: "100%",
+  height: "100%",
+  position: "absolute",
+  margin: "0",
+  padding: "0",
+  opacity: "0",
+  cursor: "pointer",
+});
+
+export const radioLabel = style({
+  cursor: "pointer",
+})

--- a/src/renderer/src/components/radio-field/radio-field.css.ts
+++ b/src/renderer/src/components/radio-field/radio-field.css.ts
@@ -12,7 +12,7 @@ export const radioField = style({
 export const radio = style({
   width: "20px",
   height: "20px",
-  borderRadius: "4px",
+  borderRadius: "50%",
   backgroundColor: vars.color.darkBackground,
   display: "flex",
   justifyContent: "center",

--- a/src/renderer/src/components/radio-field/radio-field.tsx
+++ b/src/renderer/src/components/radio-field/radio-field.tsx
@@ -1,6 +1,6 @@
 import { useId } from "react";
 import * as styles from "./radio-field.css";
-import { CheckIcon } from "@primer/octicons-react";
+import { DotFillIcon } from "@primer/octicons-react";
 
 export interface RadioFieldProps
   extends React.DetailedHTMLProps<
@@ -22,7 +22,7 @@ export function RadioField({ label, ...props }: RadioFieldProps) {
             className={styles.radioInput}
             {...props}
           />
-          {props.checked && <CheckIcon />}
+          {props.checked && <DotFillIcon />}
         </div>
         <label htmlFor={id} className={styles.radioLabel}>
             {label}

--- a/src/renderer/src/components/radio-field/radio-field.tsx
+++ b/src/renderer/src/components/radio-field/radio-field.tsx
@@ -1,0 +1,32 @@
+import { useId } from "react";
+import * as styles from "./radio-field.css";
+import { CheckIcon } from "@primer/octicons-react";
+
+export interface RadioFieldProps
+  extends React.DetailedHTMLProps<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      HTMLInputElement
+  > {
+  label: string;
+}
+
+export function RadioField({ label, ...props }: RadioFieldProps) {
+  const id = useId();
+
+  return (
+      <div className={styles.radioField}>
+        <div className={styles.radio}>
+          <input
+            id={id}
+            type="radio"
+            className={styles.radioInput}
+            {...props}
+          />
+          {props.checked && <CheckIcon />}
+        </div>
+        <label htmlFor={id} className={styles.radioLabel}>
+            {label}
+        </label>
+      </div>
+    );
+}

--- a/src/renderer/src/pages/catalogue/catalogue.tsx
+++ b/src/renderer/src/pages/catalogue/catalogue.tsx
@@ -38,17 +38,10 @@ export function Catalogue() {
 
   useEffect(() => {
     async function fetchUserPreferences() {
-      try {
-        const [, userPreferences] = await Promise.all([
-          window.electron.getDefaultDownloadsPath(),
-          window.electron.getUserPreferences(),
-        ]);
+        const [ userPreferences ] = await Promise.all([window.electron.getUserPreferences()]);
         const resultsPerPage = userPreferences?.resultsPerPage ?? 30;
         setPaginationSettings({ resultsPerPage });
-      } catch (error) {
-        console.error("Failed to fetch user preferences:", error);
-      }
-    };
+    }
 
     fetchUserPreferences();
   }, []);

--- a/src/renderer/src/pages/catalogue/catalogue.tsx
+++ b/src/renderer/src/pages/catalogue/catalogue.tsx
@@ -34,13 +34,34 @@ export function Catalogue() {
     navigate(`/game/${game.shop}/${game.objectID}`);
   };
 
+  const [paginationSettings, setPaginationSettings] = useState({ resultsPerPage: 30 });
+
+  useEffect(() => {
+    async function fetchUserPreferences() {
+      try {
+        const [, userPreferences] = await Promise.all([
+          window.electron.getDefaultDownloadsPath(),
+          window.electron.getUserPreferences(),
+        ]);
+        const resultsPerPage = userPreferences?.resultsPerPage ?? 30;
+        setPaginationSettings({ resultsPerPage });
+      } catch (error) {
+        console.error("Failed to fetch user preferences:", error);
+      }
+    };
+
+    fetchUserPreferences();
+  }, []);
+
+  const resultsPerPage = paginationSettings.resultsPerPage;
+
   useEffect(() => {
     if (contentRef.current) contentRef.current.scrollTop = 0;
     setIsLoading(true);
     setSearchResults([]);
 
     window.electron
-      .getGames(24, cursor)
+      .getGames(resultsPerPage, cursor)
       .then(({ results, cursor }) => {
         return new Promise((resolve) => {
           setTimeout(() => {
@@ -53,7 +74,7 @@ export function Catalogue() {
       .finally(() => {
         setIsLoading(false);
       });
-  }, [dispatch, cursor, searchParams]);
+  }, [dispatch, cursor, searchParams, resultsPerPage]);
 
   const handleNextPage = () => {
     const params = new URLSearchParams({

--- a/src/renderer/src/pages/settings/settings.css.ts
+++ b/src/renderer/src/pages/settings/settings.css.ts
@@ -20,7 +20,7 @@ export const content = style({
   flexDirection: "column",
 });
 
-export const downloadsPathField = style({
+export const flexRowStyle = style({
   display: "flex",
   gap: `${SPACING_UNIT * 2}px`,
 });

--- a/src/renderer/src/pages/settings/settings.tsx
+++ b/src/renderer/src/pages/settings/settings.tsx
@@ -115,7 +115,7 @@ export function Settings() {
 
         <div className={styles.flexRowStyle}>
           <RadioField
-            label={'24'}
+            label={'30'}
             checked={form.resultsPerPage === 30}
             onChange={() =>
               updateUserPreferences("resultsPerPage", 30)
@@ -123,7 +123,7 @@ export function Settings() {
           />
 
           <RadioField
-            label={'48'}
+            label={'50'}
             checked={form.resultsPerPage === 50}
             onChange={() =>
               updateUserPreferences("resultsPerPage", 50)
@@ -131,7 +131,7 @@ export function Settings() {
           />
 
           <RadioField
-            label={'72'}
+            label={'70'}
             checked={form.resultsPerPage === 70}
             onChange={() =>
               updateUserPreferences("resultsPerPage", 70)
@@ -139,7 +139,7 @@ export function Settings() {
           />
 
           <RadioField
-            label={'96'}
+            label={'100'}
             checked={form.resultsPerPage === 100}
             onChange={() =>
               updateUserPreferences("resultsPerPage", 100)

--- a/src/renderer/src/pages/settings/settings.tsx
+++ b/src/renderer/src/pages/settings/settings.tsx
@@ -4,6 +4,7 @@ import { Button, CheckboxField, TextField } from "@renderer/components";
 import * as styles from "./settings.css";
 import { useTranslation } from "react-i18next";
 import { UserPreferences } from "@types";
+import { RadioField } from "@renderer/components/radio-field/radio-field";
 
 export function Settings() {
   const [form, setForm] = useState({
@@ -11,6 +12,7 @@ export function Settings() {
     downloadNotificationsEnabled: false,
     repackUpdatesNotificationsEnabled: false,
     telemetryEnabled: false,
+    resultsPerPage: 30,
   });
 
   const { t } = useTranslation("settings");
@@ -27,6 +29,7 @@ export function Settings() {
         repackUpdatesNotificationsEnabled:
           userPreferences?.repackUpdatesNotificationsEnabled ?? false,
         telemetryEnabled: userPreferences?.telemetryEnabled ?? false,
+        resultsPerPage: userPreferences?.resultsPerPage ?? 30,
       });
     });
   }, []);
@@ -57,7 +60,7 @@ export function Settings() {
   return (
     <section className={styles.container}>
       <div className={styles.content}>
-        <div className={styles.downloadsPathField}>
+        <div className={styles.flexRowStyle}>
           <TextField
             label={t("downloads_path")}
             value={form.downloadsPath}
@@ -107,6 +110,42 @@ export function Settings() {
             updateUserPreferences("telemetryEnabled", !form.telemetryEnabled)
           }
         />
+
+        <h3>{t("results_per_page")}</h3>
+
+        <div className={styles.flexRowStyle}>
+          <RadioField
+            label={'24'}
+            checked={form.resultsPerPage === 30}
+            onChange={() =>
+              updateUserPreferences("resultsPerPage", 30)
+            }
+          />
+
+          <RadioField
+            label={'48'}
+            checked={form.resultsPerPage === 50}
+            onChange={() =>
+              updateUserPreferences("resultsPerPage", 50)
+            }
+          />
+
+          <RadioField
+            label={'72'}
+            checked={form.resultsPerPage === 70}
+            onChange={() =>
+              updateUserPreferences("resultsPerPage", 70)
+            }
+          />
+
+          <RadioField
+            label={'96'}
+            checked={form.resultsPerPage === 100}
+            onChange={() =>
+              updateUserPreferences("resultsPerPage", 100)
+            }
+          />
+        </div>
       </div>
     </section>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export interface UserPreferences {
   downloadNotificationsEnabled: boolean;
   repackUpdatesNotificationsEnabled: boolean;
   telemetryEnabled: boolean;
+  resultsPerPage: number;
 }
 
 export interface HowLongToBeatCategory {


### PR DESCRIPTION
My idea initially was to do the same with the search page, but my knowledge in Electro is limited and prevented me from doing this, but it is open to anyone who wants to implement it on the search page.