### PR TITLE
add most played, trending 7day, trending 30days, trending quarterly.

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,7 +2,10 @@
   "home": {
     "featured": "Featured",
     "recently_added": "Recently added",
-    "trending": "Trending",
+    "trending_7day": "Weekly Trending",
+    "trending_30day": "Monthly Trending ",
+    "trending_90day": "Quarter Trending",
+    "most_played": "Most Played",
     "surprise_me": "Surprise me",
     "no_results": "No results found"
   },

--- a/src/renderer/src/pages/home/home.tsx
+++ b/src/renderer/src/pages/home/home.tsx
@@ -13,7 +13,7 @@ import * as styles from "./home.css";
 import { vars } from "../../theme.css";
 import Lottie from "lottie-react";
 
-const categories: CatalogueCategory[] = ["trending", "recently_added"];
+const categories: CatalogueCategory[] = ["trending_7day", "trending_30day", "trending_90day", "most_played", "recently_added" ];
 
 export function Home() {
   const { t } = useTranslation("home");
@@ -28,7 +28,10 @@ export function Home() {
   const [catalogue, setCatalogue] = useState<
     Record<CatalogueCategory, CatalogueEntry[]>
   >({
-    trending: [],
+    trending_7day: [],
+    trending_30day: [],
+    trending_90day: [],
+    most_played: [],
     recently_added: [],
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export type GameShop = "steam" | "epic";
-export type CatalogueCategory = "recently_added" | "trending";
+export type CatalogueCategory = "recently_added" | "trending_7day" | "trending_30day" | "trending_90day" | "most_played";
 
 export interface SteamGenre {
   id: string;


### PR DESCRIPTION
![image](https://github.com/hydralauncher/hydra/assets/10378013/7d235a3e-eb68-46de-80d3-f5354069356d)


I felt like something was missing with only having 30 day as the trending tab.

I added most played, then trending based on days.

Let me know if you want to implement this!


maybe this belongs in the catalog instead.

