### PR TITLE
Fixed it so Ka0s repacks work on linux

### DIFF
--- a/src/main/events/helpers/generate-lutris-yaml.ts
+++ b/src/main/events/helpers/generate-lutris-yaml.ts
@@ -1,9 +1,15 @@
 import { Document as YMLDocument } from "yaml";
 import { Game } from "@main/entity";
 import path from "node:path";
+import fs from "node:fs";
 
 export const generateYML = (game: Game) => {
   const slugifiedGameTitle = game.title.replace(/\s/g, "-").toLocaleLowerCase();
+  const gamePath = path.join(game.downloadPath, game.folderName);
+
+  const files = fs.readdirSync(gamePath);
+  const setupFileName = files.find(file => /^setup\.exe$/i.test(file));
+  const setupPath = setupFileName ? path.join(gamePath, setupFileName) : null;
 
   const doc = new YMLDocument({
     name: game.title,
@@ -27,11 +33,7 @@ export const generateYML = (game: Game) => {
         },
         {
           task: {
-            executable: path.join(
-              game.downloadPath,
-              game.folderName,
-              "setup.exe"
-            ),
+            executable: setupPath, 
             name: "wineexec",
             prefix: "$GAMEDIR",
           },

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -27,8 +27,11 @@ const openGameInstaller = async (
     return true;
   }
 
-  const setupPath = path.join(gamePath, "setup.exe");
-  if (!fs.existsSync(setupPath)) {
+  const files = fs.readdirSync(gamePath);
+  const setupFileName = files.find(file => /^setup\.exe$/i.test(file));
+  const setupPath = setupFileName ? path.join(gamePath, setupFileName) : null;
+
+  if (!setupPath || !fs.existsSync(setupPath)) {
     shell.openPath(gamePath);
     return true;
   }


### PR DESCRIPTION
Fixed it so Ka0s repacks work on linux, its using Setup.exe instead of setup.exe.


Side-note:

Should i implement it so if nether setup.exe or Setup.exe is found it prompts the user to select the installer executable?