### PR TITLE
feat: add debrid services caching/downloading support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ out
 
 # IntelliJ
 .idea
+
+# Webpack
+.webpack

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ out
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# IntelliJ
+.idea

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+
+if (process.platform === "win32") {
+  if (!fs.existsSync("resources/dist")) {
+    fs.mkdirSync("resources/dist");
+  }
+
+  fs.copyFileSync(
+    "node_modules/ps-list/vendor/fastlist-0.3.0-x64.exe",
+    "resources/dist/fastlist.exe"
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 libtorrent
+pySmartDL
 cx_Freeze
 cx_Logging; sys_platform == 'win32'
 lief; sys_platform == 'win32'

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -138,7 +138,11 @@
     "telemetry": "Telemetry",
     "telemetry_description": "Enable anonymous usage statistics",
     "behavior": "Behavior",
-    "quit_app_instead_hiding": "Close app instead of minimizing to tray"
+    "quit_app_instead_hiding": "Close app instead of minimizing to tray",
+    "debrid_services": "Debrid services",
+    "enable_debrid_services": "Enable Debrid services",
+    "real_debrid": "Real-Debrid",
+    "real_debrid_api_key": "Real-Debrid API Key"
   },
   "notifications": {
     "download_complete": "Download complete",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,6 +12,7 @@
     "settings": "Settings",
     "my_library": "My library",
     "downloading_metadata": "{{title}} (Downloading metadata…)",
+    "debrid_caching": "{{title}} ({{percentage}}% - Debrid caching…)",
     "checking_files": "{{title}} ({{percentage}} - Checking files…)",
     "paused": "{{title}} (Paused)",
     "downloading": "{{title}} ({{percentage}} - Downloading…)",
@@ -33,6 +34,7 @@
   "bottom_panel": {
     "no_downloads_in_progress": "No downloads in progress",
     "downloading_metadata": "Downloading {{title}} metadata…",
+    "debrid_caching": "Caching {{title}} in Debrid… ({{percentage}}% complete)",
     "checking_files": "Checking {{title}} files… ({{percentage}} complete)",
     "downloading": "Downloading {{title}}… ({{percentage}} complete) - Conclusion {{eta}} - {{speed}}"
   },
@@ -55,6 +57,7 @@
     "space_left_on_disk": "{{space}} left on disk",
     "eta": "Conclusion {{eta}}",
     "downloading_metadata": "Downloading metadata…",
+    "debrid_caching": "Caching in Debrid…",
     "checking_files": "Checking files…",
     "filter": "Filter repacks",
     "requirements": "System requirements",
@@ -120,6 +123,7 @@
     "filter": "Filter downloaded games",
     "remove": "Remove",
     "downloading_metadata": "Downloading metadata…",
+    "debrid_caching": "Caching in Debrid…",
     "checking_files": "Checking files…",
     "starting_download": "Starting download…",
     "deleting": "Deleting installer…",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -12,6 +12,7 @@
     "settings": "Paramètres",
     "my_library": "Ma bibliothèque",
     "downloading_metadata": "{{title}} (Téléchargement des métadonnées…)",
+    "debrid_caching": "{{title}} ({{percentage}}% - En attente du débrideur…)",
     "checking_files": "{{title}} ({{percentage}} - Vérification des fichiers…)",
     "paused": "{{title}} (En pause)",
     "downloading": "{{title}} ({{percentage}} - Téléchargement en cours…)",
@@ -30,6 +31,7 @@
   "bottom_panel": {
     "no_downloads_in_progress": "Aucun téléchargement en cours",
     "downloading_metadata": "Téléchargement des métadonnées de {{title}}…",
+    "debrid_caching": "Traitement de {{title}} par le débrideur… ({{percentage}}% complet)",
     "checking_files": "Vérification des fichiers de {{title}}… ({{percentage}} terminé)",
     "downloading": "Téléchargement de {{title}}… ({{percentage}} terminé) - Fin dans {{eta}} - {{speed}}"
   },
@@ -47,6 +49,7 @@
     "space_left_on_disk": "{{space}} restant sur le disque",
     "eta": "Fin dans {{eta}}",
     "downloading_metadata": "Téléchargement des métadonnées en cours…",
+    "debrid_caching": "En attente du débrideur…",
     "checking_files": "Vérification des fichiers…",
     "filter": "Filtrer les repacks",
     "requirements": "Configuration requise",
@@ -99,6 +102,7 @@
     "filter": "Filtrer les jeux téléchargés",
     "remove": "Supprimer",
     "downloading_metadata": "Téléchargement des métadonnées en cours…",
+    "debrid_caching": "En attente du débrideur…",
     "checking_files": "Vérification des fichiers…",
     "starting_download": "Démarrage du téléchargement…",
     "remove_from_list": "Retirer",

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -40,6 +40,7 @@ export enum GameStatus {
   CheckingFiles = "checking_files",
   DownloadingMetadata = "downloading_metadata",
   Cancelled = "cancelled",
+  DebridCaching = "debrid_caching",
 }
 
 export const defaultDownloadsPath = app.getPath("downloads");

--- a/src/main/entity/game.entity.ts
+++ b/src/main/entity/game.entity.ts
@@ -46,6 +46,9 @@ export class Game {
   progress: number;
 
   @Column("float", { default: 0 })
+  debridCachingProgress: number;
+
+  @Column("float", { default: 0 })
   fileVerificationProgress: number;
 
   @Column("int", { default: 0 })

--- a/src/main/entity/user-preferences.entity.ts
+++ b/src/main/entity/user-preferences.entity.ts
@@ -29,6 +29,12 @@ export class UserPreferences {
   @Column("boolean", { default: false })
   preferQuitInsteadOfHiding: boolean;
 
+  @Column("boolean", { default: false })
+  debridServicesEnabled: boolean;
+
+  @Column("text", { nullable: true })
+  realDebridAPIKey: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/main/events/torrenting/cancel-game-download.ts
+++ b/src/main/events/torrenting/cancel-game-download.ts
@@ -19,6 +19,7 @@ const cancelGameDownload = async (
         GameStatus.CheckingFiles,
         GameStatus.Paused,
         GameStatus.Seeding,
+        GameStatus.DebridCaching,
       ]),
     },
   });

--- a/src/main/events/torrenting/pause-game-download.ts
+++ b/src/main/events/torrenting/pause-game-download.ts
@@ -17,6 +17,7 @@ const pauseGameDownload = async (
           GameStatus.Downloading,
           GameStatus.DownloadingMetadata,
           GameStatus.CheckingFiles,
+          GameStatus.DebridCaching,
         ]),
       },
       { status: GameStatus.Paused }

--- a/src/main/events/torrenting/resume-game-download.ts
+++ b/src/main/events/torrenting/resume-game-download.ts
@@ -1,6 +1,6 @@
 import { registerEvent } from "../register-event";
 import { GameStatus } from "../../constants";
-import {gameRepository, userPreferencesRepository} from "../../repository";
+import { gameRepository, userPreferencesRepository } from "../../repository";
 import { getDownloadsPath } from "../helpers/get-downloads-path";
 import { In } from "typeorm";
 import { writePipe } from "@main/services";

--- a/src/main/events/torrenting/start-game-download.ts
+++ b/src/main/events/torrenting/start-game-download.ts
@@ -1,5 +1,5 @@
 import { getSteamGameIconUrl, writePipe } from "@main/services";
-import { gameRepository, repackRepository } from "@main/repository";
+import {gameRepository, repackRepository, userPreferencesRepository} from "@main/repository";
 import { GameStatus } from "@main/constants";
 
 import { registerEvent } from "../register-event";
@@ -43,10 +43,15 @@ const startGameDownload = async (
         GameStatus.Downloading,
         GameStatus.DownloadingMetadata,
         GameStatus.CheckingFiles,
+        GameStatus.DebridCaching
       ]),
     },
     { status: GameStatus.Paused }
   );
+
+  const userPreferences = await userPreferencesRepository.findOne({
+    where: { id: 1 },
+  });
 
   if (game) {
     await gameRepository.update(
@@ -66,6 +71,8 @@ const startGameDownload = async (
       game_id: game.id,
       magnet: repack.magnet,
       save_path: downloadPath,
+      debrid_enabled: userPreferences?.debridServicesEnabled ?? false,
+      debrid_api_key: userPreferences?.realDebridAPIKey ?? "",
     });
 
     game.status = GameStatus.DownloadingMetadata;
@@ -89,6 +96,8 @@ const startGameDownload = async (
       game_id: createdGame.id,
       magnet: repack.magnet,
       save_path: downloadPath,
+      debrid_enabled: userPreferences?.debridServicesEnabled ?? false,
+      debrid_api_key: userPreferences?.realDebridAPIKey ?? "",
     });
 
     const { repack: _, ...rest } = createdGame;

--- a/src/main/events/torrenting/start-game-download.ts
+++ b/src/main/events/torrenting/start-game-download.ts
@@ -1,5 +1,9 @@
 import { getSteamGameIconUrl, writePipe } from "@main/services";
-import {gameRepository, repackRepository, userPreferencesRepository} from "@main/repository";
+import {
+  gameRepository,
+  repackRepository,
+  userPreferencesRepository,
+} from "@main/repository";
 import { GameStatus } from "@main/constants";
 
 import { registerEvent } from "../register-event";
@@ -43,7 +47,7 @@ const startGameDownload = async (
         GameStatus.Downloading,
         GameStatus.DownloadingMetadata,
         GameStatus.CheckingFiles,
-        GameStatus.DebridCaching
+        GameStatus.DebridCaching,
       ]),
     },
     { status: GameStatus.Paused }

--- a/src/main/services/torrent-client.ts
+++ b/src/main/services/torrent-client.ts
@@ -23,6 +23,7 @@ enum TorrentState {
   Downloading = 3,
   Finished = 4,
   Seeding = 5,
+  DebridCaching = 6,
 }
 
 export interface TorrentUpdate {
@@ -36,6 +37,7 @@ export interface TorrentUpdate {
   folderName: string;
   fileSize: number;
   bytesDownloaded: number;
+  debridCachingProgress: number;
 }
 
 export const BITTORRENT_PORT = "5881";
@@ -91,6 +93,7 @@ export class TorrentClient {
       return "downloading_metadata";
     if (state === TorrentState.Finished) return "finished";
     if (state === TorrentState.Seeding) return "seeding";
+    if (state === TorrentState.DebridCaching) return "debrid_caching";
     return "";
   }
 
@@ -144,6 +147,10 @@ export class TorrentClient {
         )
       ) {
         updatePayload.progress = payload.progress;
+      }
+
+      if (payload.status === TorrentState.DebridCaching) {
+        updatePayload.debridCachingProgress = payload.debridCachingProgress;
       }
 
       await gameRepository.update({ id: payload.gameId }, updatePayload);

--- a/src/main/services/torrent-client.ts
+++ b/src/main/services/torrent-client.ts
@@ -23,7 +23,7 @@ enum TorrentState {
   Downloading = 3,
   Finished = 4,
   Seeding = 5,
-  DebridCaching = 6,
+  DebridCaching = 8,
 }
 
 export interface TorrentUpdate {

--- a/src/renderer/src/components/bottom-panel/bottom-panel.tsx
+++ b/src/renderer/src/components/bottom-panel/bottom-panel.tsx
@@ -13,7 +13,7 @@ export function BottomPanel() {
 
   const navigate = useNavigate();
 
-  const { game, progress, downloadSpeed, eta, isDownloading } = useDownload();
+  const { game, progress, downloadSpeed, eta, isDownloading, debridCachingProgress } = useDownload();
 
   const [version, setVersion] = useState("");
 
@@ -30,6 +30,12 @@ export function BottomPanel() {
         return t("checking_files", {
           title: game.title,
           percentage: progress,
+        });
+
+      if (game.status === "debrid_caching")
+        return t("debrid_caching", {
+          title: game.title,
+          percentage: debridCachingProgress,
         });
 
       return t("downloading", {

--- a/src/renderer/src/components/bottom-panel/bottom-panel.tsx
+++ b/src/renderer/src/components/bottom-panel/bottom-panel.tsx
@@ -13,7 +13,14 @@ export function BottomPanel() {
 
   const navigate = useNavigate();
 
-  const { game, progress, downloadSpeed, eta, isDownloading, debridCachingProgress } = useDownload();
+  const {
+    game,
+    progress,
+    downloadSpeed,
+    eta,
+    isDownloading,
+    debridCachingProgress,
+  } = useDownload();
 
   const [version, setVersion] = useState("");
 

--- a/src/renderer/src/components/sidebar/sidebar.tsx
+++ b/src/renderer/src/components/sidebar/sidebar.tsx
@@ -61,9 +61,12 @@ export function Sidebar() {
   }, [gameDownloading?.id, updateLibrary]);
 
   const isDownloading = library.some((game) =>
-    ["downloading", "checking_files", "downloading_metadata", "debrid_caching"].includes(
-      game.status
-    )
+    [
+      "downloading",
+      "checking_files",
+      "downloading_metadata",
+      "debrid_caching",
+    ].includes(game.status)
   );
 
   const sidebarRef = useRef<HTMLElement>(null);

--- a/src/renderer/src/components/sidebar/sidebar.tsx
+++ b/src/renderer/src/components/sidebar/sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar() {
   }, [gameDownloading?.id, updateLibrary]);
 
   const isDownloading = library.some((game) =>
-    ["downloading", "checking_files", "downloading_metadata"].includes(
+    ["downloading", "checking_files", "downloading_metadata", "debrid_caching"].includes(
       game.status
     )
   );

--- a/src/renderer/src/hooks/use-download.ts
+++ b/src/renderer/src/hooks/use-download.ts
@@ -111,6 +111,7 @@ export function useDownload() {
   return {
     game: lastPacket?.game,
     bytesDownloaded: lastPacket?.game.bytesDownloaded,
+    debridCachingProgress: lastPacket?.game.debridCachingProgress,
     fileSize: lastPacket?.game.fileSize,
     isVerifying,
     gameId: lastPacket?.game.id,

--- a/src/renderer/src/pages/downloads/downloads.tsx
+++ b/src/renderer/src/pages/downloads/downloads.tsx
@@ -106,7 +106,7 @@ export function Downloads() {
     if (game?.status === "cancelled") return <p>{t("cancelled")}</p>;
     if (game?.status === "downloading_metadata")
       return <p>{t("starting_download")}</p>;
-
+    if (game?.status === "debrid_caching") return <p>{t("debrid_caching")}</p>;
     if (game?.status === "paused") {
       return (
         <>

--- a/src/renderer/src/pages/settings/settings.tsx
+++ b/src/renderer/src/pages/settings/settings.tsx
@@ -12,6 +12,8 @@ export function Settings() {
     repackUpdatesNotificationsEnabled: false,
     telemetryEnabled: false,
     preferQuitInsteadOfHiding: false,
+    debridServicesEnabled: false,
+    realDebridAPIKey: "",
   });
 
   const { t } = useTranslation("settings");
@@ -30,6 +32,8 @@ export function Settings() {
         telemetryEnabled: userPreferences?.telemetryEnabled ?? false,
         preferQuitInsteadOfHiding:
           userPreferences?.preferQuitInsteadOfHiding ?? false,
+        debridServicesEnabled: userPreferences?.debridServicesEnabled ?? false,
+        realDebridAPIKey: userPreferences?.realDebridAPIKey || "",
       });
     });
   }, []);
@@ -121,6 +125,25 @@ export function Settings() {
               "preferQuitInsteadOfHiding",
               !form.preferQuitInsteadOfHiding
             )
+          }
+        />
+
+        <h3>{t("debrid_services")}</h3>
+
+        <CheckboxField
+          label={t("enable_debrid_services")}
+          checked={form.debridServicesEnabled}
+          onChange={() =>
+            updateUserPreferences("debridServicesEnabled", !form.debridServicesEnabled)
+          }
+        />
+
+        <TextField
+          label={t("real_debrid")}
+          placeholder={t("real_debrid_api_key")}
+          value={form.realDebridAPIKey}
+          onChange={(event) =>
+            updateUserPreferences("realDebridAPIKey", event.target.value)
           }
         />
       </div>

--- a/src/renderer/src/pages/settings/settings.tsx
+++ b/src/renderer/src/pages/settings/settings.tsx
@@ -134,7 +134,10 @@ export function Settings() {
           label={t("enable_debrid_services")}
           checked={form.debridServicesEnabled}
           onChange={() =>
-            updateUserPreferences("debridServicesEnabled", !form.debridServicesEnabled)
+            updateUserPreferences(
+              "debridServicesEnabled",
+              !form.debridServicesEnabled
+            )
           }
         />
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,8 @@ export interface UserPreferences {
   repackUpdatesNotificationsEnabled: boolean;
   telemetryEnabled: boolean;
   preferQuitInsteadOfHiding: boolean;
+  debridServicesEnabled: boolean;
+  realDebridAPIKey: string | null;
 }
 
 export interface HowLongToBeatCategory {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,7 @@ export interface Game extends Omit<CatalogueEntry, "cover"> {
   progress: number;
   fileVerificationProgress: number;
   bytesDownloaded: number;
+  debridCachingProgress: number;
   playTimeInMilliseconds: number;
   executablePath: string | null;
   lastTimePlayed: Date | null;

--- a/torrent-client/debrid_downloader.py
+++ b/torrent-client/debrid_downloader.py
@@ -115,7 +115,7 @@ class DebridDownloader:
     def __get_generic_progress(self, status, download_progress):
         if status == 5 or status == 0:
             return 1
-        elif status == 6:
+        elif status == 8:
             return 0
         else:
             return download_progress
@@ -127,6 +127,6 @@ class DebridDownloader:
         elif state == 'finished' or self.is_debrid_caching_failed():
             return 5
         elif state == 'debrid_busy':
-            return 6
+            return 8
         else:
             return 0

--- a/torrent-client/debrid_downloader.py
+++ b/torrent-client/debrid_downloader.py
@@ -1,0 +1,132 @@
+import os
+import time
+from urllib.parse import unquote
+from debrid_services.realdebrid import RealDebrid
+from pySmartDL import SmartDL
+import threading
+
+class DebridDownloader:
+    smartdl_handler = None
+    save_path = ''
+
+    # Debrid service is busy when it is working on caching the torrent, this means that we still don't have the direct link yet
+    is_debrid_busy = False
+    debrid_caching_progress = 0
+    debrid_caching_failed = False
+    debrid_caching_cancelled = False
+
+    def set_api_key(self, api_key):
+        self.api_key = api_key
+        
+    def start_download(self, magnet, save_path):     
+        self.save_path = save_path
+
+        # Generate direct link from magnet link
+        self.debrid_caching_cancelled = False
+        self.is_debrid_busy = True
+        self.__generate_direct_link(magnet, self.__handle_caching_result)
+
+    def pause_download(self):
+        self.debrid_caching_cancelled = True
+        if (self.smartdl_handler):
+            self.smartdl_handler.pause()
+
+    def cancel_download(self):
+        self.debrid_caching_cancelled = True
+        if (self.smartdl_handler):
+            self.smartdl_handler.stop()
+
+    def get_status(self, downloading_game_id):
+        status = self.__get_generic_state('debrid_busy' if self.is_debrid_busy else self.smartdl_handler.get_status())
+        progress = self.__get_generic_progress(status, 0 if self.is_debrid_busy else self.smartdl_handler.get_progress())
+        return {
+            'folderName': '-' if self.is_debrid_busy else os.path.splitext(os.path.basename(self.smartdl_handler.get_dest()))[0],
+            'fileSize': 0 if self.is_debrid_busy else self.smartdl_handler.get_final_filesize(),
+            'gameId': downloading_game_id,
+            'progress': progress,
+            'downloadSpeed': 0 if self.is_debrid_busy else self.smartdl_handler.get_speed(),
+            'timeRemaining': 0 if self.is_debrid_busy else (self.smartdl_handler.get_eta() * 1000),
+            'numPeers': '-',
+            'numSeeds': '-',
+            'status': status,
+            'bytesDownloaded': 0 if self.is_debrid_busy else self.smartdl_handler.get_dl_size(),
+            'debridCachingProgress': self.debrid_caching_progress if self.is_debrid_busy else 100,
+        }
+    
+    def is_debrid_caching_failed(self):
+        return self.debrid_caching_failed
+    
+    # Private methods
+    def __handle_caching_result(self, result):
+        direct_link = unquote(result)
+
+        if self.debrid_caching_failed or result == '':
+            return
+
+        # Format the destination path
+        filename = os.path.basename(direct_link)
+        filename_without_ext = os.path.splitext(filename)[0]
+        dest = os.path.join(self.save_path, filename_without_ext)
+        dest = os.path.join(dest, "")
+
+        self.smartdl_handler = SmartDL(direct_link, dest, verify=False, progress_bar=False, threads=1)
+        self.smartdl_handler.start(blocking=False)
+        self.is_debrid_busy = False
+
+    def __generate_direct_link(self, magnet, callback):
+        # Reset debrid caching status
+        self.debrid_caching_failed = False
+
+        realdebrid = RealDebrid(self.api_key)
+        user_information = realdebrid.get_user_info()
+
+        # Check if the user information is valid, if not, set debrid caching status to failed
+        if 'error' in user_information:
+            self.debrid_caching_failed = True
+            return ''
+
+        torrent_id = realdebrid.add_magnet_link(magnet)['id']
+
+        # By default, select all files in the torrent
+        realdebrid.select_all_files(torrent_id)
+
+        # Start the while loop in a separate thread
+        threading.Thread(target=self.__fetch_torrent_info, args=(realdebrid, torrent_id, callback)).start()
+    
+    def __fetch_torrent_info(self, realdebrid, torrent_id, callback):
+        torrent_info = realdebrid.get_torrent_info(torrent_id)
+        while not self.debrid_caching_cancelled and (torrent_info['status'] != 'downloaded' or torrent_info['progress'] != 100):
+            self.debrid_caching_progress = torrent_info['progress']
+            if torrent_info['status'] in ['magnet_error', 'error', 'virus', 'dead']:
+                self.debrid_caching_failed = True
+                callback('')
+                return
+            time.sleep(1)
+            torrent_info = realdebrid.get_torrent_info(torrent_id)
+        
+        if self.debrid_caching_cancelled:
+            callback('')
+            return
+        
+        torrent_link = torrent_info['links'][0]
+        callback(realdebrid.get_direct_link(torrent_link)['download'])
+
+    # Get progress based on download status, taking into consideration debrid caching status and failures
+    def __get_generic_progress(self, status, download_progress):
+        if status == 5 or status == 0:
+            return 1
+        elif status == 6:
+            return 0
+        else:
+            return download_progress
+
+    # This method converts pySmartDL states to generic states used in the frontend
+    def __get_generic_state(self, state):
+        if state == 'downloading' or state == 'ready':
+            return 3
+        elif state == 'finished' or self.is_debrid_caching_failed():
+            return 5
+        elif state == 'debrid_busy':
+            return 6
+        else:
+            return 0

--- a/torrent-client/debrid_services/realdebrid.py
+++ b/torrent-client/debrid_services/realdebrid.py
@@ -1,0 +1,55 @@
+import requests
+
+class RealDebrid:
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.base_url = "https://api.real-debrid.com/rest/1.0/"
+
+    def get_user_info(self):
+        url = self.base_url + "user"
+        headers = {
+            "Authorization": "Bearer " + self.api_key
+        }
+        response = requests.get(url, headers=headers)
+        return response.json()
+
+    def add_magnet_link(self, magnet):
+        url = self.base_url + "torrents/addMagnet"
+        headers = {
+            "Authorization": "Bearer " + self.api_key
+        }
+        data = {
+            "magnet": magnet
+        }
+        response = requests.post(url, headers=headers, data=data)
+        return response.json()
+
+    def select_all_files(self, torrent_id):
+        url = self.base_url + "torrents/selectFiles/" + torrent_id
+        headers = {
+            "Authorization": "Bearer " + self.api_key
+        }
+        data = {
+            "files": "all"
+        }
+        response = requests.post(url, headers=headers, data=data)
+        return response
+
+    def get_torrent_info(self, torrent_id):
+        url = self.base_url + "torrents/info/" + torrent_id
+        headers = {
+            "Authorization": "Bearer " + self.api_key
+        }
+        response = requests.get(url, headers=headers)
+        return response.json()
+
+    def get_direct_link(self, link):
+        url = self.base_url + "unrestrict/link"
+        headers = {
+            "Authorization": "Bearer " + self.api_key
+        }
+        data = {
+            "link": link
+        }
+        response = requests.post(url, headers=headers, data=data)
+        return response.json()

--- a/torrent-client/setup.py
+++ b/torrent-client/setup.py
@@ -2,7 +2,7 @@ from cx_Freeze import setup, Executable
 
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options = {
-    "packages": ["libtorrent"],
+    "packages": ["libtorrent", "pySmartDL"],
     "build_exe": "hydra-download-manager",
     "include_msvcr": True
 }

--- a/torrent-client/torrent_downloader.py
+++ b/torrent-client/torrent_downloader.py
@@ -1,0 +1,25 @@
+import libtorrent as lt
+
+class TorrentDownloader:
+    torrent_handler = None
+
+    def __init__(self, port):
+        self.session = lt.session({'listen_interfaces': '0.0.0.0:{port}'.format(port=port)})
+
+    def get_handler(self):
+        return self.torrent_handler
+    
+    def start_download(self, magnet, save_path):
+        params = {'url': magnet, 'save_path': save_path}
+        self.torrent_handler = self.session.add_torrent(params)
+        self.torrent_handler.set_flags(lt.torrent_flags.auto_managed)
+        self.torrent_handler.resume()
+
+    def pause_download(self):
+        self.torrent_handler.pause()
+        self.torrent_handler.unset_flags(lt.torrent_flags.auto_managed)
+
+    def cancel_download(self):
+        self.torrent_handler.pause()
+        self.session.remove_torrent(self.torrent_handler)
+        self.torrent_handler = None

--- a/torrent-client/torrent_downloader.py
+++ b/torrent-client/torrent_downloader.py
@@ -23,3 +23,27 @@ class TorrentDownloader:
         self.torrent_handler.pause()
         self.session.remove_torrent(self.torrent_handler)
         self.torrent_handler = None
+
+    def get_status(self, downloading_game_id):
+        info = self.torrent_handler.get_torrent_info()
+        status = self.torrent_handler.status()
+        return {
+            'folderName': info.name() if info else "",
+            'fileSize': info.total_size() if info else 0,
+            'gameId': downloading_game_id,
+            'progress': status.progress,
+            'downloadSpeed': status.download_rate,
+            'timeRemaining': self.__get_eta(status),
+            'numPeers': status.num_peers,
+            'numSeeds': status.num_seeds,
+            'status': status.state,
+            'bytesDownloaded': status.progress * info.total_size() if info else status.all_time_download,
+        }
+    
+    def __get_eta(self, status):
+        remaining_bytes = status.total_wanted - status.total_wanted_done
+
+        if remaining_bytes >= 0 and status.download_rate > 0:
+            return (remaining_bytes / status.download_rate) * 1000
+        else:
+            return 1


### PR DESCRIPTION
_I felt like I had to reopen this PR after resolving the conflicts since the electron-builder migration. I've seen there is already another open PR that adds Debrid support but lacks some stuff such as Caching status or handling invalid responses from Real-Debrid._

This PR adds support for Debrid services to cache and download games/torrents

Debrid services are used to generate direct HTTP/S links for torrent files, this makes downloading games much faster since it doesn't rely on seeders anymore. It also improves security in countries or places where torrenting is illegal or traceable.

In this PR, I first added a settings section in the launcher to enable/disable using Debrid services, as well as an input field to specify an API key for Real-Debrid (Eventually, more services can be added soon)
On Python's end, I separated the libtorrent logic into a separate class (TorrentDownloader) and added a new class (DebridDownloader) that handles communication with Debrid services as well as downloading from HTTP/S links using pySmartDL library
A new state was added to the front end, which is DebridCaching. When using Debrid services, you usually get a direct link for a torrent file almost instantly when it's cached in the servers. However, when using a new torrent, Debrid services take a while to download the torrent on the servers to be able to generate a direct link. During this time, DebridCaching status is sent, alongside the progress of this caching process.