### PR TITLE
Correção na frase, estava incorreta

### DIFF
--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -154,7 +154,7 @@
   "binary_not_found_modal": {
     "title": "Programas não instalados",
     "description": "Não foram encontrados no seu sistema os executáveis do Wine ou Lutris",
-    "instructions": "Verifique a forma correta de instalar algum deles na sua distro Linux para que o jogo possa ser executado normalmente"
+    "instructions": "Verifique a forma correta de instalar algum deles no seu distro Linux, garantindo assim a execução normal do jogo"
   },
   "catalogue": {
     "next_page": "Próxima página",


### PR DESCRIPTION
A frase **"** _Verifique a forma correta de instalar algum deles na sua distro Linux para que o jogo possa ser executado normalmente_   **"**  estava incorreta que futuramente causaria uma má interpretação e a frase estava em desconcordancia com a lingua portuguesa, Brasil. Com a nova correção deixa mais clara a mensagem.
A análise morfológica e sintática da frase indicava erro. Agora a frase esta correta:

Análise morfológica:

Verifique: verbo no modo imperativo, segunda pessoa do singular.
a: artigo definido feminino singular.
forma: substantivo feminino singular.
correta: adjetivo feminino singular.
de: preposição.
instalar: verbo no infinitivo.
algum: pronome indefinido masculino singular.
deles: pronome pessoal oblíquo masculino plural.
no: contração da preposição "em" com o artigo definido "o".
seu: pronome possessivo masculino singular.
distro: substantivo masculino singular.
Linux: substantivo próprio masculino singular.
garantindo: verbo no gerúndio.
assim: advérbio.
a: artigo definido feminino singular.
execução: substantivo feminino singular.
normal: adjetivo feminino singular.
do: contração da preposição "de" com o artigo definido "o".
jogo: substantivo masculino singular.