### PR TITLE
feat: force developer to use yarn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/hydralauncher/hydra.git"
   },
   "type": "module",
+  "engines": {
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.19.1"
+  },
   "scripts": {
     "format": "prettier --write .",
     "format-check": "prettier --check .",


### PR DESCRIPTION
This solves alot of issues in PR's that have package-lock.json becuase they did npm install, this update forces an error and exits out when developer runs npm install