### PR TITLE
Retry obtain $a to avoid null result.

### DIFF
--- a/src/main/services/repack-tracker/1337x.ts
+++ b/src/main/services/repack-tracker/1337x.ts
@@ -34,7 +34,7 @@ const formatUploadDate = (str: string) => {
   return date;
 };
 
-/* TODO: $a will often be null */
+
 const getTorrentDetails = async (path: string) => {
   const response = await request1337x(path);
 
@@ -44,6 +44,8 @@ const getTorrentDetails = async (path: string) => {
   const $a = window.document.querySelector(
     ".torrentdown1"
   ) as HTMLAnchorElement;
+
+  if(!$a) return getTorrentDetails(path)
 
   const $ul = Array.from(
     document.querySelectorAll(".torrent-detail-page .list")


### PR DESCRIPTION
I made a small adjustment to make a new attempt in case $a in getTorrentDetails comes up as null, it's simple but I tested it on all FitGirl pages and I didn't receive any undefined as a magnet, I hope it helps or at least minimizes the problem.

Thanks for developing Hydra :D