### PR TITLE
fix old repacks upload date from 1337x track

### DIFF
--- a/src/main/services/repack-tracker/1337x.ts
+++ b/src/main/services/repack-tracker/1337x.ts
@@ -22,9 +22,11 @@ export const request1337x = async (path: string) =>
   requestWebPage(`https://1337xx.to${path}`);
 
 const formatUploadDate = (str: string) => {
+  let dateSplit = Array.from(str.split(" "));
+  if(dateSplit.length > 3) dateSplit.splice(2, 1);
+  
   const date = new Date();
-
-  const [month, day, year] = str.split(" ");
+  const [month, day, year] = dateSplit;
 
   date.setMonth(months.indexOf(month.replace(".", "")));
   date.setDate(Number(day.substring(0, 2)));


### PR DESCRIPTION
I noticed that with older FitGirl repacks for example the date string could come with an additional space, transforming the year of date into something like this:

![Captura de tela 2024-05-19 112736](https://github.com/hydralauncher/hydra/assets/4674786/f20a5ab0-8cc3-476e-aa21-1e8965a7f5f8)

So I added a small filter to detect if the array is correct and delete the additional space if necessary, in the test below it deleted the white space and returned the correct array.
![Captura de tela 2024-05-19 112858](https://github.com/hydralauncher/hydra/assets/4674786/6238003f-e66a-437d-9fff-e4b14dba0c41)


