### PR TITLE
Fix main window maximization from splash

### DIFF
--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -119,6 +119,9 @@ export class WindowManager {
     this.isReadyToShowMainWindow = true;
     this.splashWindow?.close();
     this.createMainWindow();
+    if (this.splashWindow?.isMaximized()) {
+      this.mainWindow?.maximize();
+    }
   }
 
   public static redirect(hash: string) {


### PR DESCRIPTION
The code checks whether the initial window is maximized, if so, it leaves the main window also maximized.