### PR TITLE
style(downloads): make game actions buttons the same size in smaller devices and crop repack title

### DIFF
--- a/src/renderer/src/pages/downloads/downloads.css.ts
+++ b/src/renderer/src/pages/downloads/downloads.css.ts
@@ -21,6 +21,11 @@ export const downloadTitle = style({
   },
 });
 
+export const repackTitle = style({
+  maxHeight: "40px",
+  overflow: "hidden",
+});
+
 export const downloaderName = style({
   color: "#c0c1c7",
   fontSize: "10px",
@@ -112,14 +117,16 @@ export const downloadDetails = style({
 
 export const downloadRightContent = style({
   display: "flex",
+  alignItems: "center",
   padding: `${SPACING_UNIT * 2}px`,
   flex: "1",
   gap: `${SPACING_UNIT}px`,
 });
 
 export const downloadActions = style({
+  height: "fit-content",
   display: "flex",
-  alignItems: "center",
+  alignItems: "stretch",
   gap: `${SPACING_UNIT}px`,
 });
 

--- a/src/renderer/src/pages/downloads/downloads.tsx
+++ b/src/renderer/src/pages/downloads/downloads.tsx
@@ -101,7 +101,7 @@ export function Downloads() {
     if (game.progress === 1) {
       return (
         <>
-          <p>{game.repack?.title}</p>
+          <p className={styles.repackTitle}>{game.repack?.title}</p>
           <p>{t("completed")}</p>
         </>
       );


### PR DESCRIPTION
**Summary:**

This pull request introduces changes to improve the responsiveness of the game card, particularly for smaller devices.

**The main changes include:**

1. Addition of a new class to the game repack title: The game repack title often has a large amount of text, which can be difficult to display on smaller devices. To address this, a new class has been added that limits the maximum height of the title and hides any overflow. This ensures that the title is displayed in a consistent and readable way across all device sizes.
2. Modifications to the game card component: The game action buttons previously varied in size depending on the device size. To provide a more consistent user experience, the buttons have been updated to maintain the same size regardless of the device size.

These changes aim to improve the user experience on smaller devices and ensure that the game card displays correctly and consistently across a range of device sizes.

**Before:**
![image](https://github.com/hydralauncher/hydra/assets/84390534/0d542537-e397-43fc-8574-536cf878ad45)

**After:**
![image](https://github.com/hydralauncher/hydra/assets/84390534/b85a53af-8ed5-401f-a699-26a6fcf6d0f3)
