### PR TITLE
Feature/delete installation folder dont set game as removed

### DIFF
--- a/src/main/events/library/delete-game-folder.ts
+++ b/src/main/events/library/delete-game-folder.ts
@@ -12,10 +12,18 @@ const deleteGameFolder = async (
   gameId: number
 ): Promise<void> => {
   const game = await gameRepository.findOne({
-    where: {
-      id: gameId,
-      isDeleted: false,
-    },
+    where: [
+      {
+        id: gameId,
+        isDeleted: false,
+        status: "removed",
+      },
+      {
+        id: gameId,
+        progress: 1,
+        isDeleted: false,
+      },
+    ],
   });
 
   if (!game) return;
@@ -33,7 +41,6 @@ const deleteGameFolder = async (
       );
     }
 
-    console.log("folder exists");
     return new Promise<void>((resolve, reject) => {
       fs.rm(
         folderPath,
@@ -48,7 +55,6 @@ const deleteGameFolder = async (
         }
       );
     }).then(async () => {
-      console.log("resolved");
       await gameRepository.update(
         { id: gameId },
         { downloadPath: null, folderName: null }

--- a/src/main/services/steam.ts
+++ b/src/main/services/steam.ts
@@ -30,6 +30,6 @@ export const getSteamAppDetails = async (
     })
     .catch((err) => {
       logger.error(err, { method: "getSteamAppDetails" });
-      throw new Error(err);
+      return null;
     });
 };

--- a/src/renderer/src/hooks/use-download.ts
+++ b/src/renderer/src/hooks/use-download.ts
@@ -52,7 +52,6 @@ export function useDownload() {
 
     try {
       await window.electron.deleteGameFolder(gameId);
-      await window.electron.removeGame(gameId);
       updateLibrary();
     } finally {
       dispatch(removeGameFromDeleting(gameId));

--- a/src/renderer/src/pages/downloads/downloads.tsx
+++ b/src/renderer/src/pages/downloads/downloads.tsx
@@ -47,17 +47,21 @@ export function Downloads() {
       complete: [],
     };
 
-    const result = library.reduce((prev, next) => {
-      if (lastPacket?.game.id === next.id) {
-        return { ...prev, downloading: [...prev.downloading, next] };
-      }
+    const result = library
+      .filter((game) => {
+        return game.downloadPath;
+      })
+      .reduce((prev, next) => {
+        if (lastPacket?.game.id === next.id) {
+          return { ...prev, downloading: [...prev.downloading, next] };
+        }
 
-      if (next.downloadQueue || next.status === "paused") {
-        return { ...prev, queued: [...prev.queued, next] };
-      }
+        if (next.downloadQueue || next.status === "paused") {
+          return { ...prev, queued: [...prev.queued, next] };
+        }
 
-      return { ...prev, complete: [...prev.complete, next] };
-    }, initialValue);
+        return { ...prev, complete: [...prev.complete, next] };
+      }, initialValue);
 
     const queued = orderBy(
       result.queued,
@@ -66,7 +70,7 @@ export function Downloads() {
     );
 
     const complete = orderBy(result.complete, (game) =>
-      game.status === "complete" ? 0 : 1
+      game.progress === 1 ? 0 : 1
     );
 
     return {

--- a/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
+++ b/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
@@ -77,11 +77,13 @@ export function HeroPanelActions() {
       if (game) {
         await removeGameFromLibrary(game.id);
       } else {
+        const gameExecutablePath = await selectGameExecutable();
+
         await window.electron.addGameToLibrary(
           objectID!,
           gameTitle,
           "steam",
-          null
+          gameExecutablePath
         );
       }
 
@@ -224,7 +226,7 @@ export function HeroPanelActions() {
   if (game) {
     return (
       <>
-        {game?.progress === 1 && game?.folderName && (
+        {game.progress === 1 && game.downloadPath && (
           <>
             <BinaryNotFoundModal
               visible={showBinaryNotFoundModal}
@@ -242,9 +244,9 @@ export function HeroPanelActions() {
           </>
         )}
 
-        {game?.progress === 1 && !game?.folderName && showDownloadOptionsButton}
+        {game.progress === 1 && !game.downloadPath && showDownloadOptionsButton}
 
-        {game?.progress !== 1 && toggleGameOnLibraryButton}
+        {game.progress !== 1 && toggleGameOnLibraryButton}
 
         {isGameRunning ? (
           <Button

--- a/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
+++ b/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
@@ -77,13 +77,11 @@ export function HeroPanelActions() {
       if (game) {
         await removeGameFromLibrary(game.id);
       } else {
-        const gameExecutablePath = await selectGameExecutable();
-
         await window.electron.addGameToLibrary(
           objectID!,
           gameTitle,
           "steam",
-          gameExecutablePath
+          null
         );
       }
 
@@ -110,11 +108,6 @@ export function HeroPanelActions() {
         return;
       }
 
-      if (game?.executablePath) {
-        window.electron.openGame(game.id, game.executablePath);
-        return;
-      }
-
       const gameExecutablePath = await selectGameExecutable();
       if (gameExecutablePath)
         window.electron.openGame(game.id, gameExecutablePath);
@@ -136,6 +129,17 @@ export function HeroPanelActions() {
     >
       {game ? <NoEntryIcon /> : <PlusCircleIcon />}
       {game ? t("remove_from_library") : t("add_to_library")}
+    </Button>
+  );
+
+  const showDownloadOptionsButton = (
+    <Button
+      onClick={openRepacksModal}
+      theme="outline"
+      disabled={deleting}
+      className={styles.heroPanelAction}
+    >
+      {t("open_download_options")}
     </Button>
   );
 
@@ -188,14 +192,7 @@ export function HeroPanelActions() {
   if (game?.status === "removed") {
     return (
       <>
-        <Button
-          onClick={openRepacksModal}
-          theme="outline"
-          disabled={deleting}
-          className={styles.heroPanelAction}
-        >
-          {t("open_download_options")}
-        </Button>
+        {showDownloadOptionsButton}
 
         <Button
           onClick={() => removeGameFromLibrary(game.id).then(updateGame)}
@@ -227,7 +224,7 @@ export function HeroPanelActions() {
   if (game) {
     return (
       <>
-        {game?.progress === 1 ? (
+        {game?.progress === 1 && game?.folderName && (
           <>
             <BinaryNotFoundModal
               visible={showBinaryNotFoundModal}
@@ -243,9 +240,11 @@ export function HeroPanelActions() {
               {t("install")}
             </Button>
           </>
-        ) : (
-          toggleGameOnLibraryButton
         )}
+
+        {game?.progress === 1 && !game?.folderName && showDownloadOptionsButton}
+
+        {game?.progress !== 1 && toggleGameOnLibraryButton}
 
         {isGameRunning ? (
           <Button


### PR DESCRIPTION
- Removes settings game as `removed` after removing game installer
- Sets downloadPath and folderName as null after removing game installer
- Filters games that don't have downloadPath from downloads page
- On Game Details page for games that are in the library:
  - Shows `Install` button only if game has progress === 1 and has `downloadPath`
  - Shows `Open download options` button if game has progress === 1 and does not have `downloadPath`
  - Shows button to Add/Remove from library only if progress !== 1 (i.e. game was added to library manually) 