### PR TITLE
Style: Added Button to Add Links of Comunity

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -188,6 +188,7 @@
     "save_changes": "Save changes",
     "changes_saved": "Changes successfully saved",
     "download_sources_description": "Hydra will fetch the download links from these sources. The source URL must be a direct link to a .json file containing the download links.",
+    "library_sources_description": "Hydra Library of Sources",
     "validate_download_source": "Validate",
     "remove_download_source": "Remove",
     "add_download_source": "Add source",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -184,6 +184,7 @@
     "save_changes": "Salvar mudanças",
     "changes_saved": "Ajustes salvos com sucesso",
     "download_sources_description": "Hydra vai buscar links de download em todas as fontes habilitadas. A URL da fonte deve ser um link direto para um arquivo .json contendo uma lista de links.",
+    "library_sources_description": "Biblioteca Hydra de Fontes",
     "validate_download_source": "Validar",
     "remove_download_source": "Remover",
     "add_download_source": "Adicionar fonte",

--- a/src/renderer/src/pages/settings/settings-download-sources.tsx
+++ b/src/renderer/src/pages/settings/settings-download-sources.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import * as styles from "./settings-download-sources.css";
 import type { DownloadSource } from "@types";
-import { NoEntryIcon, PlusCircleIcon, SyncIcon } from "@primer/octicons-react";
+import { NoEntryIcon, PlusCircleIcon, SyncIcon, BookIcon } from "@primer/octicons-react";
 import { AddDownloadSourceModal } from "./add-download-source-modal";
 import { useToast } from "@renderer/hooks";
 import { DownloadSourceStatus } from "@shared";
@@ -102,6 +102,14 @@ export function SettingsDownloadSources() {
         >
           <PlusCircleIcon />
           {t("add_download_source")}
+        </Button>
+
+        <Button
+          type="button"
+          theme="outline"
+          onClick={() => window.open("https://hydralinks.cloud", "_blank")}
+        > <BookIcon />
+          {t("library_sources_description")}
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary

I added a new button on the download sources settings page. This new button opens the link to the "Hydra Font Library" (https://hydralinks.cloud). I also updated the translation files in Portuguese and English to include this new description.

## Change Type

- [x] New feature
- [x] Translation update

### **Test Configuration**:

- Operating System: [Win 11]
- Browser: [Opera]
- Node Version: [20.17]

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local tests pass with my changes

###**Images**:

![image](https://github.com/user-attachments/assets/8d24b259-5d7f-48a2-a9ab-5f205e3640cc)
![image](https://github.com/user-attachments/assets/39a91987-f551-492d-bdc2-5f0eaa22b669)
