### PR TITLE
fix: linux deb download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 libtorrent
-cx_Freeze
+cx_Freeze == 7.2.3
 cx_Logging; sys_platform == 'win32'
 pywin32; sys_platform == 'win32'
 psutil


### PR DESCRIPTION
cx_Freeze version 7.2.4 have a lib import error on python, which causes download-manager to not work on the linux .deb build