### PR TITLE
fix: workaround for broken or missing tray icon menu on linux

### DIFF
--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -195,7 +195,7 @@ export class WindowManager {
     this.mainWindow?.focus();
   }
 
-  public static createSystemTray(language: string) {
+  public static async createSystemTray(language: string) {
     let tray: Tray;
 
     if (process.platform === "darwin") {
@@ -263,6 +263,7 @@ export class WindowManager {
         },
       ]);
 
+      tray.setContextMenu(contextMenu);
       return contextMenu;
     };
 
@@ -274,6 +275,8 @@ export class WindowManager {
     tray.setToolTip("Hydra");
 
     if (process.platform !== "darwin") {
+      await updateSystemTray();
+
       tray.addListener("click", () => {
         if (this.mainWindow) {
           if (


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read and understood the [Contributor Guidelines](https://github.com/hydralauncher/hydra?tab=readme-ov-file#ways-you-can-contribute).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
- [x] I have considered, and confirm that this submission is valuable to others.

**Fill in the PR content:**

Hydra's tray icon has been broken for quite some time on Linux. When right clicking, either a blank menu is displayed, or nothing at all. I have experienced this issue on various desktop environments such as Cinnamon, Gnome, and XFCE. This is probably more of an issue with Electron itself. 

This is a workaround that is meant to set the context menu on initial app load, so that Linux users will at least be able to do something with the tray icon. For example, they can now safely "Quit" the app from the tray menu if they have the "Don't hide Hydra when closing" behavior option unchecked. Without this workaround, Linux users either have to keep that option checked to remove the "hide" feature or kill the app from the CLI or their "process manager" if they left it unchecked. 

**Explaining why this is likely an Electron issue:** 
According to the Electron docs - https://www.electronjs.org/docs/latest/api/tray 

The `right-click` instance event is only supported on macOS and Windows. This event listener is being set in Hydra along with the regular `click` event, but it does absolutely nothing on Linux. The event never gets registered, therefore `showContextMenu` never runs. 

The `popUpContextMenu` method is only supported on macOS and Windows. This is what Hydra is using in the `showContextMenu` function. It does absolutely nothing on Linux. 

