### PR TITLE
feat: spanish translation updated

### DIFF
--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -50,7 +50,7 @@
     "developers": "Desarrolladores",
     "genres": "Géneros",
     "tags": "Marcadores",
-    "publishers": "Distribuidoras",
+    "publishers": "Editores",
     "download_sources": "Fuentes de descarga",
     "result_count": "{{resultCount}} resultados",
     "filter_count": "{{filterCount}} disponibles",
@@ -175,7 +175,7 @@
     "backup_from": "Copia de seguridad de {{date}}",
     "custom_backup_location_set": "Se configuró la carpeta de copia de seguridad",
     "clear": "Limpiar",
-    "no_directory_selected": "No se seleccionó un directório"
+    "no_directory_selected": "No se seleccionó un directorio"
   },
   "activation": {
     "title": "Activar Hydra",
@@ -208,7 +208,11 @@
     "queued": "En cola",
     "no_downloads_title": "Esto está tan... vacío",
     "no_downloads_description": "No has descargado nada con Hydra... aún, ¡pero nunca es tarde para comenzar!.",
-    "checking_files": "Verificando archivos…"
+    "checking_files": "Verificando archivos…",
+    "seeding": "Seeding",
+    "stop_seeding": "Detener seeding",
+    "resume_seeding": "Continuar seeding",
+    "options": "Gestionar"
   },
   "settings": {
     "downloads_path": "Ruta de descarga",
@@ -376,7 +380,12 @@
     "subscription_needed": "Se necesita una suscripción a Hydra Cloud necesita para ver este contenido",
     "new_achievements_unlocked": "Desbloqueados {{achievementCount}} nuevos logros de {{gameCount}} juegos",
     "achievement_progress": "{{unlockedCount}}/{{totalCount}} logros",
-    "achievements_unlocked_for_game": "Se han desbloqueado {{achievementCount}} nuevos logros de {{gameTitle}}"
+    "achievements_unlocked_for_game": "Se han desbloqueado {{achievementCount}} nuevos logros de {{gameTitle}}",
+    "hidden_achievement_tooltip": "Este es un logro oculto",
+    "achievement_earn_points": "Obtén {{points}} puntos con este logro",
+    "earned_points": "Puntos obtenidos:",
+    "available_points": "Puntos disponibles:",
+    "how_to_earn_achievements_points": "¿Cómo obtener puntos de logros?"
   },
   "hydra_cloud": {
     "subscription_tour_title": "Suscripción Hydra Cloud",
@@ -386,6 +395,9 @@
     "animated_profile_picture": "Fotos de perfil animadas",
     "premium_support": "Soporte Premium",
     "show_and_compare_achievements": "Muestra y compara tus logros con otros usuarios",
-    "animated_profile_banner": "Fondo de perfil animado"
+    "animated_profile_banner": "Fondo de perfil animado",
+    "hydra_cloud": "Hydra Cloud",
+    "hydra_cloud_feature_found": "¡Has descubierto una característica de Hydra Cloud!",
+    "learn_more": "Aprender más"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -269,7 +269,9 @@
     "user_unblocked": "El usuario ha sido desbloqueado",
     "enable_achievement_notifications": "Cuando un logro se desbloquea",
     "launch_minimized": "Iniciar Hydra minimizado",
-    "disable_nsfw_alert": "Desactivar alerta NSFW"
+    "disable_nsfw_alert": "Desactivar alerta NSFW",
+    "seed_after_download_complete": "Realizar seeding después de que se completa la descarga",
+    "show_hidden_achievement_description": "Ocultar descripción de logros ocultos antes de desbloquearlos"
   },
   "notifications": {
     "download_complete": "Descarga completada",
@@ -370,7 +372,16 @@
     "upload_banner": "Subir un banner",
     "uploading_banner": "Subiendo banner…",
     "background_image_updated": "Imagen de fondo actualizada",
-    "playing": "Jugando {{game}}"
+    "playing": "Jugando {{game}}",
+    "achievements": "logros",
+    "achievements_unlocked": "Logros desbloqueados",
+    "earned_points": "Puntos Obtenidos",
+    "show_achievements_on_profile": "Mostrar tus logros en tu perfil",
+    "show_points_on_profile": "Mostrar tus puntos obtenidos en tu perfil",
+    "games": "Juegos",
+    "ranking_updated_weekly": "El Ranking se actualiza semanalmente",
+    "stats": "Estadísticas",
+    "top_percentile": "Top {{percentile}}%"
   },
   "achievement": {
     "achievement_unlocked": "Logro desbloqueado",


### PR DESCRIPTION
added seeding strings, updated hydra cloud and achievements strings, fixed mistake from previous commits

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [ X ] I have read and understood the [Contributor Guidelines](https://github.com/hydralauncher/hydra?tab=readme-ov-file#ways-you-can-contribute).
- [ X ] I have checked that there are no duplicate pull requests related to this request.
- [ X ] I have considered, and confirm that this submission is valuable to others.
- [ X ] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

- fixed typo from commit 0dea700
- changed string from commit d072a14
- added seeding translations (seeding doesn't have an exactly translation in spanish but added and translated what was needed)
- added strings for achievements and hydra cloud
