### PR TITLE
fix: fix layout shift on sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/sidebar-profile.scss
+++ b/src/renderer/src/components/sidebar/sidebar-profile.scss
@@ -85,5 +85,6 @@
     white-space: nowrap;
     width: 100%;
     text-align: left;
+    line-height: 1.15;
   }
 }


### PR DESCRIPTION
Fix minimal layout shift when running a game and close.

Before:

https://github.com/user-attachments/assets/c5fe46b4-fc58-4b24-ba3c-55f78cf669ef

After:

https://github.com/user-attachments/assets/fde2e78c-a708-43da-b053-ec2231e02867

