### PR TITLE
Can you run it feature

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -80,6 +80,7 @@
     "requirements": "System requirements",
     "minimum": "Minimum",
     "recommended": "Recommended",
+    "your_system": "Your System",
     "paused": "Paused",
     "release_date": "Released on {{date}}",
     "publisher": "Published by {{publisher}}",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -67,6 +67,7 @@
     "requirements": "Requisitos de sistema",
     "minimum": "Mínimos",
     "recommended": "Recomendados",
+    "your_system": "Seu Sistema",
     "paused": "Pausado",
     "release_date": "Lançado em {{date}}",
     "publisher": "Publicado por {{publisher}}",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, net, protocol } from "electron";
+import { app, BrowserWindow, net, protocol, ipcMain } from "electron";
 import updater from "electron-updater";
 import i18n from "i18next";
 import path from "node:path";
@@ -139,6 +139,30 @@ app.on("second-instance", (_event, commandLine) => {
 
 app.on("open-url", (_event, url) => {
   handleDeepLinkPath(url);
+});
+
+ipcMain.handle("get-system-info", async () => {
+  const os = require("os");
+  const osInfo = `${os.type()} ${os.arch()} ${os.release()}`;
+  const cpuModel = os.cpus()[0]?.model || "-";
+  const ramMB = Math.round(os.totalmem() / 1024 / 1024);
+  let gpuModel = "Não disponível";
+  try {
+    const gpuInfo: any = await (app as any).getGPUInfo("basic");
+    if (
+      gpuInfo.graphics &&
+      gpuInfo.graphics.length > 0 &&
+      gpuInfo.graphics[0].device
+    ) {
+      gpuModel = gpuInfo.graphics[0].device;
+    }
+  } catch {}
+  return {
+    os: osInfo,
+    cpu: cpuModel,
+    ram: `${ramMB} MB`,
+    gpu: gpuModel,
+  };
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -156,7 +156,9 @@ ipcMain.handle("get-system-info", async () => {
     ) {
       gpuModel = gpuInfo.graphics[0].device;
     }
-  } catch {}
+  } catch (error){
+    console.error(error);
+  }
   return {
     os: osInfo,
     cpu: cpuModel,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -228,6 +228,7 @@ contextBridge.exposeInMainWorld("electron", {
     ipcRenderer.invoke("getDiskFreeSpace", path),
   checkFolderWritePermission: (path: string) =>
     ipcRenderer.invoke("checkFolderWritePermission", path),
+  getSystemInfo: () => ipcRenderer.invoke("get-system-info"),
 
   /* Cloud save */
   uploadSaveGame: (

--- a/src/renderer/src/pages/game-details/sidebar/cpu.json
+++ b/src/renderer/src/pages/game-details/sidebar/cpu.json
@@ -1,0 +1,23134 @@
+[
+    {
+        "CPU": "AArch64",
+        "Benchmark": "833"
+    },
+    {
+        "CPU": "AArch64 rev 2 (aarch64)",
+        "Benchmark": "2,409"
+    },
+    {
+        "CPU": "AArch64 rev 4 (aarch64)",
+        "Benchmark": "1,813"
+    },
+    {
+        "CPU": "AC8257V/WAB",
+        "Benchmark": "788"
+    },
+    {
+        "CPU": "AC8259V/WAB",
+        "Benchmark": "910"
+    },
+    {
+        "CPU": "Allwinner A133",
+        "Benchmark": "668"
+    },
+    {
+        "CPU": "Allwinner A523",
+        "Benchmark": "1,914"
+    },
+    {
+        "CPU": "Allwinner A527",
+        "Benchmark": "2,297"
+    },
+    {
+        "CPU": "Allwinner A733",
+        "Benchmark": "3,392"
+    },
+    {
+        "CPU": "Allwinner H618",
+        "Benchmark": "623"
+    },
+    {
+        "CPU": "Allwinner h728",
+        "Benchmark": "1,953"
+    },
+    {
+        "CPU": "AMD 3015Ce",
+        "Benchmark": "2,099"
+    },
+    {
+        "CPU": "AMD 3015e",
+        "Benchmark": "2,657"
+    },
+    {
+        "CPU": "AMD 3020e",
+        "Benchmark": "2,412"
+    },
+    {
+        "CPU": "AMD 4700S",
+        "Benchmark": "17,756"
+    },
+    {
+        "CPU": "AMD A10 Micro-6700T APU",
+        "Benchmark": "1,426"
+    },
+    {
+        "CPU": "AMD A10 PRO-7350B APU",
+        "Benchmark": "1,867"
+    },
+    {
+        "CPU": "AMD A10 PRO-7800B APU",
+        "Benchmark": "3,317"
+    },
+    {
+        "CPU": "AMD A10 PRO-7850B APU",
+        "Benchmark": "3,441"
+    },
+    {
+        "CPU": "AMD A10-4600M APU",
+        "Benchmark": "1,94"
+    },
+    {
+        "CPU": "AMD A10-4655M APU",
+        "Benchmark": "1,651"
+    },
+    {
+        "CPU": "AMD A10-4657M APU",
+        "Benchmark": "1,759"
+    },
+    {
+        "CPU": "AMD A10-5700 APU",
+        "Benchmark": "2,739"
+    },
+    {
+        "CPU": "AMD A10-5745M APU",
+        "Benchmark": "1,771"
+    },
+    {
+        "CPU": "AMD A10-5750M APU",
+        "Benchmark": "2,062"
+    },
+    {
+        "CPU": "AMD A10-5757M APU",
+        "Benchmark": "1,996"
+    },
+    {
+        "CPU": "AMD A10-5800B APU",
+        "Benchmark": "3,057"
+    },
+    {
+        "CPU": "AMD A10-5800K APU",
+        "Benchmark": "2,955"
+    },
+    {
+        "CPU": "AMD A10-6700 APU",
+        "Benchmark": "3,112"
+    },
+    {
+        "CPU": "AMD A10-6700T APU",
+        "Benchmark": "2,299"
+    },
+    {
+        "CPU": "AMD A10-6790K APU",
+        "Benchmark": "3,108"
+    },
+    {
+        "CPU": "AMD A10-6800B APU",
+        "Benchmark": "3,155"
+    },
+    {
+        "CPU": "AMD A10-6800K APU",
+        "Benchmark": "3,198"
+    },
+    {
+        "CPU": "AMD A10-7300 APU",
+        "Benchmark": "1,744"
+    },
+    {
+        "CPU": "AMD A10-7400P",
+        "Benchmark": "2,12"
+    },
+    {
+        "CPU": "AMD A10-7700K APU",
+        "Benchmark": "3,181"
+    },
+    {
+        "CPU": "AMD A10-7800 APU",
+        "Benchmark": "3,216"
+    },
+    {
+        "CPU": "AMD A10-7850K APU",
+        "Benchmark": "3,388"
+    },
+    {
+        "CPU": "AMD A10-7860K",
+        "Benchmark": "3,269"
+    },
+    {
+        "CPU": "AMD A10-7870K",
+        "Benchmark": "3,496"
+    },
+    {
+        "CPU": "AMD A10-7890K",
+        "Benchmark": "3,543"
+    },
+    {
+        "CPU": "AMD A10-8700P",
+        "Benchmark": "2,248"
+    },
+    {
+        "CPU": "AMD A10-8750",
+        "Benchmark": "3,244"
+    },
+    {
+        "CPU": "AMD A10-8850",
+        "Benchmark": "3,438"
+    },
+    {
+        "CPU": "AMD A10-9600P",
+        "Benchmark": "2,359"
+    },
+    {
+        "CPU": "AMD A10-9620P",
+        "Benchmark": "2,521"
+    },
+    {
+        "CPU": "AMD A10-9630P",
+        "Benchmark": "2,946"
+    },
+    {
+        "CPU": "AMD A10-9700",
+        "Benchmark": "3,557"
+    },
+    {
+        "CPU": "AMD A10-9700E",
+        "Benchmark": "3,235"
+    },
+    {
+        "CPU": "AMD A12-9700P",
+        "Benchmark": "2,427"
+    },
+    {
+        "CPU": "AMD A12-9720P",
+        "Benchmark": "2,639"
+    },
+    {
+        "CPU": "AMD A12-9730P",
+        "Benchmark": "3,027"
+    },
+    {
+        "CPU": "AMD A12-9800",
+        "Benchmark": "3,684"
+    },
+    {
+        "CPU": "AMD A12-9800E",
+        "Benchmark": "3,471"
+    },
+    {
+        "CPU": "AMD A4 Micro-6400T APU",
+        "Benchmark": "1,082"
+    },
+    {
+        "CPU": "AMD A4 PRO-3340B",
+        "Benchmark": "1,709"
+    },
+    {
+        "CPU": "AMD A4 PRO-7300B APU",
+        "Benchmark": "1,458"
+    },
+    {
+        "CPU": "AMD A4 PRO-7350B",
+        "Benchmark": "1,544"
+    },
+    {
+        "CPU": "AMD A4-1200 APU",
+        "Benchmark": "375"
+    },
+    {
+        "CPU": "AMD A4-1250 APU",
+        "Benchmark": "418"
+    },
+    {
+        "CPU": "AMD A4-1350 APU",
+        "Benchmark": "911"
+    },
+    {
+        "CPU": "AMD A4-3300 APU",
+        "Benchmark": "965"
+    },
+    {
+        "CPU": "AMD A4-3300M APU",
+        "Benchmark": "723"
+    },
+    {
+        "CPU": "AMD A4-3305M APU",
+        "Benchmark": "762"
+    },
+    {
+        "CPU": "AMD A4-3310MX APU",
+        "Benchmark": "782"
+    },
+    {
+        "CPU": "AMD A4-3320M APU",
+        "Benchmark": "668"
+    },
+    {
+        "CPU": "AMD A4-3330MX APU",
+        "Benchmark": "756"
+    },
+    {
+        "CPU": "AMD A4-3400 APU",
+        "Benchmark": "1,089"
+    },
+    {
+        "CPU": "AMD A4-3420 APU",
+        "Benchmark": "1,067"
+    },
+    {
+        "CPU": "AMD A4-4000 APU",
+        "Benchmark": "1,157"
+    },
+    {
+        "CPU": "AMD A4-4020 APU",
+        "Benchmark": "1,269"
+    },
+    {
+        "CPU": "AMD A4-4300M APU",
+        "Benchmark": "977"
+    },
+    {
+        "CPU": "AMD A4-4355M APU",
+        "Benchmark": "806"
+    },
+    {
+        "CPU": "AMD A4-5000 APU",
+        "Benchmark": "1,286"
+    },
+    {
+        "CPU": "AMD A4-5050 APU",
+        "Benchmark": "1,328"
+    },
+    {
+        "CPU": "AMD A4-5100 APU",
+        "Benchmark": "1,26"
+    },
+    {
+        "CPU": "AMD A4-5150M APU",
+        "Benchmark": "957"
+    },
+    {
+        "CPU": "AMD A4-5300 APU",
+        "Benchmark": "1,366"
+    },
+    {
+        "CPU": "AMD A4-5300B APU",
+        "Benchmark": "1,254"
+    },
+    {
+        "CPU": "AMD A4-6210 APU",
+        "Benchmark": "1,505"
+    },
+    {
+        "CPU": "AMD A4-6250J APU",
+        "Benchmark": "1,671"
+    },
+    {
+        "CPU": "AMD A4-6300 APU",
+        "Benchmark": "1,422"
+    },
+    {
+        "CPU": "AMD A4-6300B APU",
+        "Benchmark": "1,328"
+    },
+    {
+        "CPU": "AMD A4-6320 APU",
+        "Benchmark": "1,53"
+    },
+    {
+        "CPU": "AMD A4-7210 APU",
+        "Benchmark": "1,663"
+    },
+    {
+        "CPU": "AMD A4-7300 APU",
+        "Benchmark": "1,534"
+    },
+    {
+        "CPU": "AMD A4-9120",
+        "Benchmark": "1,224"
+    },
+    {
+        "CPU": "AMD A4-9120C",
+        "Benchmark": "864"
+    },
+    {
+        "CPU": "AMD A4-9120e",
+        "Benchmark": "854"
+    },
+    {
+        "CPU": "AMD A4-9125",
+        "Benchmark": "1,21"
+    },
+    {
+        "CPU": "AMD A6 Micro-6500T APU",
+        "Benchmark": "1,146"
+    },
+    {
+        "CPU": "AMD A6 PRO-7050B APU",
+        "Benchmark": "1,01"
+    },
+    {
+        "CPU": "AMD A6 PRO-7400B",
+        "Benchmark": "1,64"
+    },
+    {
+        "CPU": "AMD A6-1450 APU",
+        "Benchmark": "1,054"
+    },
+    {
+        "CPU": "AMD A6-3400M APU",
+        "Benchmark": "1,218"
+    },
+    {
+        "CPU": "AMD A6-3410MX APU",
+        "Benchmark": "1,27"
+    },
+    {
+        "CPU": "AMD A6-3420M APU",
+        "Benchmark": "1,302"
+    },
+    {
+        "CPU": "AMD A6-3430MX APU",
+        "Benchmark": "1,389"
+    },
+    {
+        "CPU": "AMD A6-3500 APU",
+        "Benchmark": "1,438"
+    },
+    {
+        "CPU": "AMD A6-3600 APU",
+        "Benchmark": "1,697"
+    },
+    {
+        "CPU": "AMD A6-3620 APU",
+        "Benchmark": "1,869"
+    },
+    {
+        "CPU": "AMD A6-3650 APU",
+        "Benchmark": "2,09"
+    },
+    {
+        "CPU": "AMD A6-3670 APU",
+        "Benchmark": "2,181"
+    },
+    {
+        "CPU": "AMD A6-4400M APU",
+        "Benchmark": "998"
+    },
+    {
+        "CPU": "AMD A6-4455M APU",
+        "Benchmark": "792"
+    },
+    {
+        "CPU": "AMD A6-5200 APU",
+        "Benchmark": "1,673"
+    },
+    {
+        "CPU": "AMD A6-5345M APU",
+        "Benchmark": "1,122"
+    },
+    {
+        "CPU": "AMD A6-5350M APU",
+        "Benchmark": "1,205"
+    },
+    {
+        "CPU": "AMD A6-5357M APU",
+        "Benchmark": "1,192"
+    },
+    {
+        "CPU": "AMD A6-5400B APU",
+        "Benchmark": "1,459"
+    },
+    {
+        "CPU": "AMD A6-5400K APU",
+        "Benchmark": "1,276"
+    },
+    {
+        "CPU": "AMD A6-6310 APU",
+        "Benchmark": "1,68"
+    },
+    {
+        "CPU": "AMD A6-6400B APU",
+        "Benchmark": "1,639"
+    },
+    {
+        "CPU": "AMD A6-6400K APU",
+        "Benchmark": "1,514"
+    },
+    {
+        "CPU": "AMD A6-6420B APU",
+        "Benchmark": "1,55"
+    },
+    {
+        "CPU": "AMD A6-6420K APU",
+        "Benchmark": "1,571"
+    },
+    {
+        "CPU": "AMD A6-7000",
+        "Benchmark": "1,01"
+    },
+    {
+        "CPU": "AMD A6-7310 APU",
+        "Benchmark": "1,729"
+    },
+    {
+        "CPU": "AMD A6-7400K APU",
+        "Benchmark": "1,662"
+    },
+    {
+        "CPU": "AMD A6-7470K",
+        "Benchmark": "1,799"
+    },
+    {
+        "CPU": "AMD A6-7480",
+        "Benchmark": "1,817"
+    },
+    {
+        "CPU": "AMD A6-8500P",
+        "Benchmark": "1,445"
+    },
+    {
+        "CPU": "AMD A6-8550",
+        "Benchmark": "1,762"
+    },
+    {
+        "CPU": "AMD A6-9200",
+        "Benchmark": "1,146"
+    },
+    {
+        "CPU": "AMD A6-9210",
+        "Benchmark": "1,254"
+    },
+    {
+        "CPU": "AMD A6-9220",
+        "Benchmark": "1,296"
+    },
+    {
+        "CPU": "AMD A6-9220C",
+        "Benchmark": "1,053"
+    },
+    {
+        "CPU": "AMD A6-9220e",
+        "Benchmark": "960"
+    },
+    {
+        "CPU": "AMD A6-9225",
+        "Benchmark": "1,336"
+    },
+    {
+        "CPU": "AMD A6-9230",
+        "Benchmark": "1,303"
+    },
+    {
+        "CPU": "AMD A6-9400",
+        "Benchmark": "2,717"
+    },
+    {
+        "CPU": "AMD A6-9500",
+        "Benchmark": "1,879"
+    },
+    {
+        "CPU": "AMD A6-9500E",
+        "Benchmark": "1,725"
+    },
+    {
+        "CPU": "AMD A8 PRO-7150B APU",
+        "Benchmark": "1,528"
+    },
+    {
+        "CPU": "AMD A8 PRO-7600B APU",
+        "Benchmark": "2,944"
+    },
+    {
+        "CPU": "AMD A8-3500M APU",
+        "Benchmark": "1,394"
+    },
+    {
+        "CPU": "AMD A8-3510MX APU",
+        "Benchmark": "1,631"
+    },
+    {
+        "CPU": "AMD A8-3520M APU",
+        "Benchmark": "1,453"
+    },
+    {
+        "CPU": "AMD A8-3530MX APU",
+        "Benchmark": "1,608"
+    },
+    {
+        "CPU": "AMD A8-3550MX APU",
+        "Benchmark": "1,687"
+    },
+    {
+        "CPU": "AMD A8-3800 APU",
+        "Benchmark": "2,043"
+    },
+    {
+        "CPU": "AMD A8-3820 APU",
+        "Benchmark": "2,185"
+    },
+    {
+        "CPU": "AMD A8-3850 APU",
+        "Benchmark": "2,409"
+    },
+    {
+        "CPU": "AMD A8-3870K APU",
+        "Benchmark": "2,345"
+    },
+    {
+        "CPU": "AMD A8-4500M APU",
+        "Benchmark": "1,695"
+    },
+    {
+        "CPU": "AMD A8-4555M APU",
+        "Benchmark": "1,344"
+    },
+    {
+        "CPU": "AMD A8-5500 APU",
+        "Benchmark": "2,619"
+    },
+    {
+        "CPU": "AMD A8-5500B APU",
+        "Benchmark": "2,588"
+    },
+    {
+        "CPU": "AMD A8-5545M APU",
+        "Benchmark": "1,625"
+    },
+    {
+        "CPU": "AMD A8-5550M APU",
+        "Benchmark": "1,816"
+    },
+    {
+        "CPU": "AMD A8-5557M APU",
+        "Benchmark": "1,831"
+    },
+    {
+        "CPU": "AMD A8-5600K APU",
+        "Benchmark": "2,866"
+    },
+    {
+        "CPU": "AMD A8-6410 APU",
+        "Benchmark": "1,771"
+    },
+    {
+        "CPU": "AMD A8-6500 APU",
+        "Benchmark": "2,842"
+    },
+    {
+        "CPU": "AMD A8-6500B APU",
+        "Benchmark": "2,783"
+    },
+    {
+        "CPU": "AMD A8-6500T APU",
+        "Benchmark": "1,983"
+    },
+    {
+        "CPU": "AMD A8-6600K APU",
+        "Benchmark": "2,999"
+    },
+    {
+        "CPU": "AMD A8-7050",
+        "Benchmark": "1,068"
+    },
+    {
+        "CPU": "AMD A8-7100 APU",
+        "Benchmark": "1,647"
+    },
+    {
+        "CPU": "AMD A8-7200P",
+        "Benchmark": "2,158"
+    },
+    {
+        "CPU": "AMD A8-7410 APU",
+        "Benchmark": "1,815"
+    },
+    {
+        "CPU": "AMD A8-7500",
+        "Benchmark": "3,411"
+    },
+    {
+        "CPU": "AMD A8-7600 APU",
+        "Benchmark": "3,214"
+    },
+    {
+        "CPU": "AMD A8-7650K",
+        "Benchmark": "3,119"
+    },
+    {
+        "CPU": "AMD A8-7670K",
+        "Benchmark": "3,23"
+    },
+    {
+        "CPU": "AMD A8-7680",
+        "Benchmark": "3,592"
+    },
+    {
+        "CPU": "AMD A8-7690K",
+        "Benchmark": "2,157"
+    },
+    {
+        "CPU": "AMD A8-8600P",
+        "Benchmark": "2,464"
+    },
+    {
+        "CPU": "AMD A8-8650",
+        "Benchmark": "2,996"
+    },
+    {
+        "CPU": "AMD A8-9600",
+        "Benchmark": "3,298"
+    },
+    {
+        "CPU": "AMD A9-9400",
+        "Benchmark": "1,332"
+    },
+    {
+        "CPU": "AMD A9-9410",
+        "Benchmark": "1,548"
+    },
+    {
+        "CPU": "AMD A9-9420",
+        "Benchmark": "1,525"
+    },
+    {
+        "CPU": "AMD A9-9420e",
+        "Benchmark": "1,108"
+    },
+    {
+        "CPU": "AMD A9-9425",
+        "Benchmark": "1,52"
+    },
+    {
+        "CPU": "AMD A9-9430",
+        "Benchmark": "1,699"
+    },
+    {
+        "CPU": "AMD A9-9820",
+        "Benchmark": "3,958"
+    },
+    {
+        "CPU": "AMD Athlon 1500+",
+        "Benchmark": "191"
+    },
+    {
+        "CPU": "AMD Athlon 1640B",
+        "Benchmark": "412"
+    },
+    {
+        "CPU": "AMD Athlon 200GE",
+        "Benchmark": "4,089"
+    },
+    {
+        "CPU": "AMD Athlon 220GE",
+        "Benchmark": "4,429"
+    },
+    {
+        "CPU": "AMD Athlon 240GE",
+        "Benchmark": "4,561"
+    },
+    {
+        "CPU": "AMD Athlon 2650e",
+        "Benchmark": "274"
+    },
+    {
+        "CPU": "AMD Athlon 2800+",
+        "Benchmark": "291"
+    },
+    {
+        "CPU": "AMD Athlon 2850e",
+        "Benchmark": "333"
+    },
+    {
+        "CPU": "AMD Athlon 3000G",
+        "Benchmark": "4,455"
+    },
+    {
+        "CPU": "AMD Athlon 300GE",
+        "Benchmark": "4,299"
+    },
+    {
+        "CPU": "AMD Athlon 300U",
+        "Benchmark": "3,874"
+    },
+    {
+        "CPU": "AMD Athlon 320GE",
+        "Benchmark": "4,399"
+    },
+    {
+        "CPU": "AMD Athlon 5000 Dual-Core",
+        "Benchmark": "872"
+    },
+    {
+        "CPU": "AMD Athlon 5150 APU",
+        "Benchmark": "1,404"
+    },
+    {
+        "CPU": "AMD Athlon 5200 Dual-Core",
+        "Benchmark": "869"
+    },
+    {
+        "CPU": "AMD Athlon 5350 APU",
+        "Benchmark": "1,804"
+    },
+    {
+        "CPU": "AMD Athlon 5370 APU",
+        "Benchmark": "1,927"
+    },
+    {
+        "CPU": "AMD Athlon 64 2000+",
+        "Benchmark": "154"
+    },
+    {
+        "CPU": "AMD Athlon 64 2600+",
+        "Benchmark": "243"
+    },
+    {
+        "CPU": "AMD Athlon 64 2800+",
+        "Benchmark": "295"
+    },
+    {
+        "CPU": "AMD Athlon 64 3000+",
+        "Benchmark": "334"
+    },
+    {
+        "CPU": "AMD Athlon 64 3100+",
+        "Benchmark": "484"
+    },
+    {
+        "CPU": "AMD Athlon 64 3200+",
+        "Benchmark": "305"
+    },
+    {
+        "CPU": "AMD Athlon 64 3300+",
+        "Benchmark": "375"
+    },
+    {
+        "CPU": "AMD Athlon 64 3400+",
+        "Benchmark": "317"
+    },
+    {
+        "CPU": "AMD Athlon 64 3500+",
+        "Benchmark": "377"
+    },
+    {
+        "CPU": "AMD Athlon 64 3700+",
+        "Benchmark": "394"
+    },
+    {
+        "CPU": "AMD Athlon 64 3800+",
+        "Benchmark": "292"
+    },
+    {
+        "CPU": "AMD Athlon 64 4000+",
+        "Benchmark": "340"
+    },
+    {
+        "CPU": "AMD Athlon 64 FX-55",
+        "Benchmark": "404"
+    },
+    {
+        "CPU": "AMD Athlon 64 FX-57",
+        "Benchmark": "517"
+    },
+    {
+        "CPU": "AMD Athlon 64 FX-59",
+        "Benchmark": "465"
+    },
+    {
+        "CPU": "AMD Athlon 64 FX-60 Dual Core",
+        "Benchmark": "709"
+    },
+    {
+        "CPU": "AMD Athlon 64 FX-62 Dual Core",
+        "Benchmark": "993"
+    },
+    {
+        "CPU": "AMD Athlon 64 FX-74",
+        "Benchmark": "972"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 3400+",
+        "Benchmark": "531"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 3600+",
+        "Benchmark": "618"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 3800+",
+        "Benchmark": "629"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 4000+",
+        "Benchmark": "692"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 4200+",
+        "Benchmark": "729"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 4400+",
+        "Benchmark": "671"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 4600+",
+        "Benchmark": "720"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 4800+",
+        "Benchmark": "719"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 5000+",
+        "Benchmark": "801"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 5200+",
+        "Benchmark": "850"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 5400+",
+        "Benchmark": "907"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 5600+",
+        "Benchmark": "909"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 5800+",
+        "Benchmark": "653"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 6000+",
+        "Benchmark": "936"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core 6400+",
+        "Benchmark": "982"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core BE-2300",
+        "Benchmark": "594"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual Core BE-2350",
+        "Benchmark": "573"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual-Core TK-42",
+        "Benchmark": "577"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual-Core TK-53",
+        "Benchmark": "602"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual-Core TK-55",
+        "Benchmark": "518"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 Dual-Core TK-57",
+        "Benchmark": "624"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 QL-60",
+        "Benchmark": "651"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 QL-62",
+        "Benchmark": "525"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 QL-64",
+        "Benchmark": "605"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 QL-65",
+        "Benchmark": "637"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 QL-66",
+        "Benchmark": "641"
+    },
+    {
+        "CPU": "AMD Athlon 64 X2 QL-67",
+        "Benchmark": "582"
+    },
+    {
+        "CPU": "AMD Athlon 7450 Dual-Core",
+        "Benchmark": "789"
+    },
+    {
+        "CPU": "AMD Athlon 7550 Dual-Core",
+        "Benchmark": "900"
+    },
+    {
+        "CPU": "AMD Athlon 7750 Dual-Core",
+        "Benchmark": "1,005"
+    },
+    {
+        "CPU": "AMD Athlon 7850 Dual-Core",
+        "Benchmark": "1,058"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 4050e",
+        "Benchmark": "674"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 4450B",
+        "Benchmark": "723"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 4450e",
+        "Benchmark": "710"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 4850B",
+        "Benchmark": "727"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 4850e",
+        "Benchmark": "783"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 5000B",
+        "Benchmark": "856"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 5050e",
+        "Benchmark": "846"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 5200B",
+        "Benchmark": "823"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 5400B",
+        "Benchmark": "914"
+    },
+    {
+        "CPU": "AMD Athlon Dual Core 5600B",
+        "Benchmark": "737"
+    },
+    {
+        "CPU": "AMD Athlon Gold 3150C",
+        "Benchmark": "3,292"
+    },
+    {
+        "CPU": "AMD Athlon Gold 3150G",
+        "Benchmark": "6,922"
+    },
+    {
+        "CPU": "AMD Athlon Gold 3150U",
+        "Benchmark": "3,961"
+    },
+    {
+        "CPU": "AMD Athlon Gold 7220U",
+        "Benchmark": "4,89"
+    },
+    {
+        "CPU": "AMD Athlon Gold PRO 3150G",
+        "Benchmark": "5,698"
+    },
+    {
+        "CPU": "AMD Athlon Gold PRO 3150GE",
+        "Benchmark": "7,006"
+    },
+    {
+        "CPU": "AMD Athlon Gold PRO 4150GE",
+        "Benchmark": "8,259"
+    },
+    {
+        "CPU": "AMD Athlon II 160u",
+        "Benchmark": "358"
+    },
+    {
+        "CPU": "AMD Athlon II 170u",
+        "Benchmark": "355"
+    },
+    {
+        "CPU": "AMD Athlon II Dual-Core M300",
+        "Benchmark": "670"
+    },
+    {
+        "CPU": "AMD Athlon II Dual-Core M320",
+        "Benchmark": "749"
+    },
+    {
+        "CPU": "AMD Athlon II Dual-Core M340",
+        "Benchmark": "807"
+    },
+    {
+        "CPU": "AMD Athlon II N330 Dual-Core",
+        "Benchmark": "665"
+    },
+    {
+        "CPU": "AMD Athlon II N350 Dual-Core",
+        "Benchmark": "856"
+    },
+    {
+        "CPU": "AMD Athlon II N370 Dual-Core",
+        "Benchmark": "899"
+    },
+    {
+        "CPU": "AMD Athlon II Neo K125",
+        "Benchmark": "315"
+    },
+    {
+        "CPU": "AMD Athlon II Neo K145",
+        "Benchmark": "298"
+    },
+    {
+        "CPU": "AMD Athlon II Neo K325 Dual-Core",
+        "Benchmark": "417"
+    },
+    {
+        "CPU": "AMD Athlon II Neo K345 Dual-Core",
+        "Benchmark": "527"
+    },
+    {
+        "CPU": "AMD Athlon II Neo N36L Dual-Core",
+        "Benchmark": "487"
+    },
+    {
+        "CPU": "AMD Athlon II P320 Dual-Core",
+        "Benchmark": "700"
+    },
+    {
+        "CPU": "AMD Athlon II P340 Dual-Core",
+        "Benchmark": "718"
+    },
+    {
+        "CPU": "AMD Athlon II P360 Dual-Core",
+        "Benchmark": "748"
+    },
+    {
+        "CPU": "AMD Athlon II X2 210e",
+        "Benchmark": "1,089"
+    },
+    {
+        "CPU": "AMD Athlon II X2 215",
+        "Benchmark": "998"
+    },
+    {
+        "CPU": "AMD Athlon II X2 220",
+        "Benchmark": "1,038"
+    },
+    {
+        "CPU": "AMD Athlon II X2 235e",
+        "Benchmark": "1,079"
+    },
+    {
+        "CPU": "AMD Athlon II X2 240",
+        "Benchmark": "1,052"
+    },
+    {
+        "CPU": "AMD Athlon II X2 240e",
+        "Benchmark": "1,007"
+    },
+    {
+        "CPU": "AMD Athlon II X2 245",
+        "Benchmark": "1,13"
+    },
+    {
+        "CPU": "AMD Athlon II X2 245e",
+        "Benchmark": "1,126"
+    },
+    {
+        "CPU": "AMD Athlon II X2 250",
+        "Benchmark": "1,17"
+    },
+    {
+        "CPU": "AMD Athlon II X2 250e",
+        "Benchmark": "1,202"
+    },
+    {
+        "CPU": "AMD Athlon II X2 250u",
+        "Benchmark": "598"
+    },
+    {
+        "CPU": "AMD Athlon II X2 255",
+        "Benchmark": "1,209"
+    },
+    {
+        "CPU": "AMD Athlon II X2 260",
+        "Benchmark": "1,214"
+    },
+    {
+        "CPU": "AMD Athlon II X2 260u",
+        "Benchmark": "713"
+    },
+    {
+        "CPU": "AMD Athlon II X2 265",
+        "Benchmark": "1,29"
+    },
+    {
+        "CPU": "AMD Athlon II X2 270",
+        "Benchmark": "1,32"
+    },
+    {
+        "CPU": "AMD Athlon II X2 270u",
+        "Benchmark": "675"
+    },
+    {
+        "CPU": "AMD Athlon II X2 280",
+        "Benchmark": "1,355"
+    },
+    {
+        "CPU": "AMD Athlon II X2 4300e",
+        "Benchmark": "990"
+    },
+    {
+        "CPU": "AMD Athlon II X2 4400e",
+        "Benchmark": "944"
+    },
+    {
+        "CPU": "AMD Athlon II X2 4450e",
+        "Benchmark": "867"
+    },
+    {
+        "CPU": "AMD Athlon II X2 B22",
+        "Benchmark": "1,064"
+    },
+    {
+        "CPU": "AMD Athlon II X2 B24",
+        "Benchmark": "1,111"
+    },
+    {
+        "CPU": "AMD Athlon II X2 B26",
+        "Benchmark": "1,237"
+    },
+    {
+        "CPU": "AMD Athlon II X2 B28",
+        "Benchmark": "1,284"
+    },
+    {
+        "CPU": "AMD Athlon II X3 400e",
+        "Benchmark": "1,32"
+    },
+    {
+        "CPU": "AMD Athlon II X3 405e",
+        "Benchmark": "1,331"
+    },
+    {
+        "CPU": "AMD Athlon II X3 415e",
+        "Benchmark": "1,441"
+    },
+    {
+        "CPU": "AMD Athlon II X3 420e",
+        "Benchmark": "1,557"
+    },
+    {
+        "CPU": "AMD Athlon II X3 425",
+        "Benchmark": "1,591"
+    },
+    {
+        "CPU": "AMD Athlon II X3 435",
+        "Benchmark": "1,633"
+    },
+    {
+        "CPU": "AMD Athlon II X3 440",
+        "Benchmark": "1,719"
+    },
+    {
+        "CPU": "AMD Athlon II X3 445",
+        "Benchmark": "1,804"
+    },
+    {
+        "CPU": "AMD Athlon II X3 450",
+        "Benchmark": "1,872"
+    },
+    {
+        "CPU": "AMD Athlon II X3 455",
+        "Benchmark": "1,915"
+    },
+    {
+        "CPU": "AMD Athlon II X3 460",
+        "Benchmark": "2,008"
+    },
+    {
+        "CPU": "AMD Athlon II X4 553",
+        "Benchmark": "2,418"
+    },
+    {
+        "CPU": "AMD Athlon II X4 555",
+        "Benchmark": "2,526"
+    },
+    {
+        "CPU": "AMD Athlon II X4 557",
+        "Benchmark": "2,567"
+    },
+    {
+        "CPU": "AMD Athlon II X4 559",
+        "Benchmark": "2,652"
+    },
+    {
+        "CPU": "AMD Athlon II X4 600e",
+        "Benchmark": "1,795"
+    },
+    {
+        "CPU": "AMD Athlon II X4 605e",
+        "Benchmark": "1,966"
+    },
+    {
+        "CPU": "AMD Athlon II X4 610e",
+        "Benchmark": "1,959"
+    },
+    {
+        "CPU": "AMD Athlon II X4 615e",
+        "Benchmark": "2"
+    },
+    {
+        "CPU": "AMD Athlon II X4 620",
+        "Benchmark": "2,02"
+    },
+    {
+        "CPU": "AMD Athlon II X4 630",
+        "Benchmark": "2,173"
+    },
+    {
+        "CPU": "AMD Athlon II X4 631 Quad-Core",
+        "Benchmark": "2,118"
+    },
+    {
+        "CPU": "AMD Athlon II X4 635",
+        "Benchmark": "2,242"
+    },
+    {
+        "CPU": "AMD Athlon II X4 638 Quad-Core",
+        "Benchmark": "2,26"
+    },
+    {
+        "CPU": "AMD Athlon II X4 640",
+        "Benchmark": "2,264"
+    },
+    {
+        "CPU": "AMD Athlon II X4 641 Quad-Core",
+        "Benchmark": "2,313"
+    },
+    {
+        "CPU": "AMD Athlon II X4 645",
+        "Benchmark": "2,373"
+    },
+    {
+        "CPU": "AMD Athlon II X4 650",
+        "Benchmark": "2,457"
+    },
+    {
+        "CPU": "AMD Athlon II X4 651 Quad-Core",
+        "Benchmark": "2,443"
+    },
+    {
+        "CPU": "AMD Athlon II X4 655",
+        "Benchmark": "2,078"
+    },
+    {
+        "CPU": "AMD Athlon L110",
+        "Benchmark": "211"
+    },
+    {
+        "CPU": "AMD Athlon LE-1600",
+        "Benchmark": "412"
+    },
+    {
+        "CPU": "AMD Athlon LE-1620",
+        "Benchmark": "421"
+    },
+    {
+        "CPU": "AMD Athlon LE-1640",
+        "Benchmark": "430"
+    },
+    {
+        "CPU": "AMD Athlon LE-1660",
+        "Benchmark": "416"
+    },
+    {
+        "CPU": "AMD Athlon Neo MV-40",
+        "Benchmark": "278"
+    },
+    {
+        "CPU": "AMD Athlon Neo X2 Dual Core 6850e",
+        "Benchmark": "456"
+    },
+    {
+        "CPU": "AMD Athlon Neo X2 Dual Core L325",
+        "Benchmark": "556"
+    },
+    {
+        "CPU": "AMD Athlon Neo X2 Dual Core L335",
+        "Benchmark": "529"
+    },
+    {
+        "CPU": "AMD Athlon PRO 200GE",
+        "Benchmark": "3,816"
+    },
+    {
+        "CPU": "AMD Athlon PRO 300GE",
+        "Benchmark": "4,371"
+    },
+    {
+        "CPU": "AMD Athlon PRO 300U",
+        "Benchmark": "4,08"
+    },
+    {
+        "CPU": "AMD Athlon PRO 3045B",
+        "Benchmark": "2,77"
+    },
+    {
+        "CPU": "AMD Athlon Silver 3050C",
+        "Benchmark": "2,879"
+    },
+    {
+        "CPU": "AMD Athlon Silver 3050e",
+        "Benchmark": "2,906"
+    },
+    {
+        "CPU": "AMD Athlon Silver 3050GE",
+        "Benchmark": "4,545"
+    },
+    {
+        "CPU": "AMD Athlon Silver 3050U",
+        "Benchmark": "2,953"
+    },
+    {
+        "CPU": "AMD Athlon Silver 7120U",
+        "Benchmark": "3,048"
+    },
+    {
+        "CPU": "AMD Athlon Silver PRO 3125GE",
+        "Benchmark": "4,633"
+    },
+    {
+        "CPU": "AMD Athlon TF-20",
+        "Benchmark": "265"
+    },
+    {
+        "CPU": "AMD Athlon TF-36",
+        "Benchmark": "338"
+    },
+    {
+        "CPU": "AMD Athlon X2 215",
+        "Benchmark": "996"
+    },
+    {
+        "CPU": "AMD Athlon X2 240",
+        "Benchmark": "921"
+    },
+    {
+        "CPU": "AMD Athlon X2 240e",
+        "Benchmark": "1,015"
+    },
+    {
+        "CPU": "AMD Athlon X2 250",
+        "Benchmark": "855"
+    },
+    {
+        "CPU": "AMD Athlon X2 255",
+        "Benchmark": "938"
+    },
+    {
+        "CPU": "AMD Athlon X2 280",
+        "Benchmark": "1,327"
+    },
+    {
+        "CPU": "AMD Athlon X2 340 Dual Core",
+        "Benchmark": "1,333"
+    },
+    {
+        "CPU": "AMD Athlon X2 370K Dual Core",
+        "Benchmark": "1,504"
+    },
+    {
+        "CPU": "AMD Athlon X2 450",
+        "Benchmark": "1,295"
+    },
+    {
+        "CPU": "AMD Athlon X2 Dual Core 3250e",
+        "Benchmark": "325"
+    },
+    {
+        "CPU": "AMD Athlon X2 Dual Core 6850e",
+        "Benchmark": "564"
+    },
+    {
+        "CPU": "AMD Athlon X2 Dual Core BE-2300",
+        "Benchmark": "570"
+    },
+    {
+        "CPU": "AMD Athlon X2 Dual Core BE-2350",
+        "Benchmark": "591"
+    },
+    {
+        "CPU": "AMD Athlon X2 Dual Core BE-2400",
+        "Benchmark": "674"
+    },
+    {
+        "CPU": "AMD Athlon X2 Dual Core L310",
+        "Benchmark": "343"
+    },
+    {
+        "CPU": "AMD Athlon X3 425",
+        "Benchmark": "1,516"
+    },
+    {
+        "CPU": "AMD Athlon X3 435",
+        "Benchmark": "1,781"
+    },
+    {
+        "CPU": "AMD Athlon X3 440",
+        "Benchmark": "1,438"
+    },
+    {
+        "CPU": "AMD Athlon X3 445",
+        "Benchmark": "1,626"
+    },
+    {
+        "CPU": "AMD Athlon X3 455",
+        "Benchmark": "1,783"
+    },
+    {
+        "CPU": "AMD Athlon X4 530",
+        "Benchmark": "1,786"
+    },
+    {
+        "CPU": "AMD Athlon X4 620",
+        "Benchmark": "1,81"
+    },
+    {
+        "CPU": "AMD Athlon X4 640",
+        "Benchmark": "2,115"
+    },
+    {
+        "CPU": "AMD Athlon X4 730",
+        "Benchmark": "2,278"
+    },
+    {
+        "CPU": "AMD Athlon X4 740 Quad Core",
+        "Benchmark": "2,641"
+    },
+    {
+        "CPU": "AMD Athlon X4 750 Quad Core",
+        "Benchmark": "2,751"
+    },
+    {
+        "CPU": "AMD Athlon X4 750K Quad Core",
+        "Benchmark": "2,883"
+    },
+    {
+        "CPU": "AMD Athlon X4 760K Quad Core",
+        "Benchmark": "2,987"
+    },
+    {
+        "CPU": "AMD Athlon X4 830",
+        "Benchmark": "2,901"
+    },
+    {
+        "CPU": "AMD Athlon X4 840",
+        "Benchmark": "3,325"
+    },
+    {
+        "CPU": "AMD Athlon X4 845",
+        "Benchmark": "3,788"
+    },
+    {
+        "CPU": "AMD Athlon X4 850",
+        "Benchmark": "2,657"
+    },
+    {
+        "CPU": "AMD Athlon X4 860K",
+        "Benchmark": "3,432"
+    },
+    {
+        "CPU": "AMD Athlon X4 870K",
+        "Benchmark": "3,42"
+    },
+    {
+        "CPU": "AMD Athlon X4 880K",
+        "Benchmark": "3,664"
+    },
+    {
+        "CPU": "AMD Athlon X4 950",
+        "Benchmark": "3,576"
+    },
+    {
+        "CPU": "AMD Athlon X4 970",
+        "Benchmark": "3,472"
+    },
+    {
+        "CPU": "AMD Athlon XP 1500+",
+        "Benchmark": "167"
+    },
+    {
+        "CPU": "AMD Athlon XP 1600+",
+        "Benchmark": "174"
+    },
+    {
+        "CPU": "AMD Athlon XP 1700+",
+        "Benchmark": "176"
+    },
+    {
+        "CPU": "AMD Athlon XP 1800+",
+        "Benchmark": "195"
+    },
+    {
+        "CPU": "AMD Athlon XP 1900+",
+        "Benchmark": "203"
+    },
+    {
+        "CPU": "AMD Athlon XP 2000+",
+        "Benchmark": "195"
+    },
+    {
+        "CPU": "AMD Athlon XP 2100+",
+        "Benchmark": "210"
+    },
+    {
+        "CPU": "AMD Athlon XP 2200+",
+        "Benchmark": "214"
+    },
+    {
+        "CPU": "AMD Athlon XP 2400+",
+        "Benchmark": "234"
+    },
+    {
+        "CPU": "AMD Athlon XP 2500+",
+        "Benchmark": "231"
+    },
+    {
+        "CPU": "AMD Athlon XP 2600+",
+        "Benchmark": "242"
+    },
+    {
+        "CPU": "AMD Athlon XP 2700+",
+        "Benchmark": "256"
+    },
+    {
+        "CPU": "AMD Athlon XP 2800+",
+        "Benchmark": "260"
+    },
+    {
+        "CPU": "AMD Athlon XP 2900+",
+        "Benchmark": "276"
+    },
+    {
+        "CPU": "AMD Athlon XP 3000+",
+        "Benchmark": "262"
+    },
+    {
+        "CPU": "AMD Athlon XP 3100+",
+        "Benchmark": "282"
+    },
+    {
+        "CPU": "AMD Athlon XP 3200+",
+        "Benchmark": "281"
+    },
+    {
+        "CPU": "AMD Athlon XP1600+",
+        "Benchmark": "183"
+    },
+    {
+        "CPU": "AMD Athlon XP2400+",
+        "Benchmark": "243"
+    },
+    {
+        "CPU": "AMD Athlon64 X2 Dual Core 4600+",
+        "Benchmark": "803"
+    },
+    {
+        "CPU": "AMD BC-250",
+        "Benchmark": "13,201"
+    },
+    {
+        "CPU": "AMD C-30",
+        "Benchmark": "178"
+    },
+    {
+        "CPU": "AMD C-50",
+        "Benchmark": "258"
+    },
+    {
+        "CPU": "AMD C-60",
+        "Benchmark": "290"
+    },
+    {
+        "CPU": "AMD C-60 APU",
+        "Benchmark": "316"
+    },
+    {
+        "CPU": "AMD C-70 APU",
+        "Benchmark": "315"
+    },
+    {
+        "CPU": "AMD Custom APU 0932",
+        "Benchmark": "9,43"
+    },
+    {
+        "CPU": "AMD E-240",
+        "Benchmark": "195"
+    },
+    {
+        "CPU": "AMD E-300 APU",
+        "Benchmark": "339"
+    },
+    {
+        "CPU": "AMD E-350",
+        "Benchmark": "426"
+    },
+    {
+        "CPU": "AMD E-350 APU",
+        "Benchmark": "423"
+    },
+    {
+        "CPU": "AMD E-350D APU",
+        "Benchmark": "486"
+    },
+    {
+        "CPU": "AMD E-450 APU",
+        "Benchmark": "436"
+    },
+    {
+        "CPU": "AMD E1 Micro-6200T APU",
+        "Benchmark": "600"
+    },
+    {
+        "CPU": "AMD E1-1200 APU",
+        "Benchmark": "380"
+    },
+    {
+        "CPU": "AMD E1-1500 APU",
+        "Benchmark": "387"
+    },
+    {
+        "CPU": "AMD E1-2100 APU",
+        "Benchmark": "410"
+    },
+    {
+        "CPU": "AMD E1-2200 APU",
+        "Benchmark": "474"
+    },
+    {
+        "CPU": "AMD E1-2500 APU",
+        "Benchmark": "591"
+    },
+    {
+        "CPU": "AMD E1-6010 APU",
+        "Benchmark": "538"
+    },
+    {
+        "CPU": "AMD E1-6015 APU",
+        "Benchmark": "581"
+    },
+    {
+        "CPU": "AMD E1-6050J APU",
+        "Benchmark": "1,385"
+    },
+    {
+        "CPU": "AMD E1-7010 APU",
+        "Benchmark": "607"
+    },
+    {
+        "CPU": "AMD E2-1800 APU",
+        "Benchmark": "446"
+    },
+    {
+        "CPU": "AMD E2-2000 APU",
+        "Benchmark": "496"
+    },
+    {
+        "CPU": "AMD E2-3000 APU",
+        "Benchmark": "743"
+    },
+    {
+        "CPU": "AMD E2-3000M APU",
+        "Benchmark": "668"
+    },
+    {
+        "CPU": "AMD E2-3200 APU",
+        "Benchmark": "968"
+    },
+    {
+        "CPU": "AMD E2-3800 APU",
+        "Benchmark": "1,16"
+    },
+    {
+        "CPU": "AMD E2-6110 APU",
+        "Benchmark": "1,219"
+    },
+    {
+        "CPU": "AMD E2-7015",
+        "Benchmark": "611"
+    },
+    {
+        "CPU": "AMD E2-7015 APU",
+        "Benchmark": "653"
+    },
+    {
+        "CPU": "AMD E2-7110 APU",
+        "Benchmark": "1,507"
+    },
+    {
+        "CPU": "AMD E2-9000",
+        "Benchmark": "950"
+    },
+    {
+        "CPU": "AMD E2-9000e",
+        "Benchmark": "887"
+    },
+    {
+        "CPU": "AMD E2-9010",
+        "Benchmark": "1,073"
+    },
+    {
+        "CPU": "AMD E2-9030",
+        "Benchmark": "983"
+    },
+    {
+        "CPU": "AMD Embedded G-Series GX-215JJ Radeon R2E",
+        "Benchmark": "1,097"
+    },
+    {
+        "CPU": "AMD Embedded G-Series GX-224IJ Radeon R4E",
+        "Benchmark": "1,271"
+    },
+    {
+        "CPU": "AMD Embedded G-Series GX-420GI Radeon R7E",
+        "Benchmark": "1,6"
+    },
+    {
+        "CPU": "AMD Embedded R-Series RX-216GD",
+        "Benchmark": "1,628"
+    },
+    {
+        "CPU": "AMD Embedded R-Series RX-418GD Radeon R6",
+        "Benchmark": "3,426"
+    },
+    {
+        "CPU": "AMD Embedded R-Series RX-421BD",
+        "Benchmark": "3,302"
+    },
+    {
+        "CPU": "AMD Embedded R-Series RX-421ND",
+        "Benchmark": "3,024"
+    },
+    {
+        "CPU": "AMD EPYC 3101 4-Core",
+        "Benchmark": "6,05"
+    },
+    {
+        "CPU": "AMD EPYC 3151",
+        "Benchmark": "8,306"
+    },
+    {
+        "CPU": "AMD EPYC 3201",
+        "Benchmark": "8,672"
+    },
+    {
+        "CPU": "AMD EPYC 3251",
+        "Benchmark": "13,757"
+    },
+    {
+        "CPU": "AMD EPYC 3451",
+        "Benchmark": "19,532"
+    },
+    {
+        "CPU": "AMD EPYC 4124P",
+        "Benchmark": "18,637"
+    },
+    {
+        "CPU": "AMD EPYC 4244P",
+        "Benchmark": "27,154"
+    },
+    {
+        "CPU": "AMD EPYC 4245P",
+        "Benchmark": "31,255"
+    },
+    {
+        "CPU": "AMD EPYC 4344P",
+        "Benchmark": "33,831"
+    },
+    {
+        "CPU": "AMD EPYC 4345P",
+        "Benchmark": "37,671"
+    },
+    {
+        "CPU": "AMD EPYC 4364P",
+        "Benchmark": "34,811"
+    },
+    {
+        "CPU": "AMD EPYC 4464P",
+        "Benchmark": "47,46"
+    },
+    {
+        "CPU": "AMD EPYC 4484PX",
+        "Benchmark": "51,115"
+    },
+    {
+        "CPU": "AMD EPYC 4564P",
+        "Benchmark": "65,913"
+    },
+    {
+        "CPU": "AMD EPYC 4565P",
+        "Benchmark": "63,879"
+    },
+    {
+        "CPU": "AMD EPYC 4584PX",
+        "Benchmark": "60,41"
+    },
+    {
+        "CPU": "AMD EPYC 7232P",
+        "Benchmark": "17,731"
+    },
+    {
+        "CPU": "AMD EPYC 7251",
+        "Benchmark": "14,935"
+    },
+    {
+        "CPU": "AMD EPYC 7252",
+        "Benchmark": "19,411"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7252",
+        "Benchmark": "32,437"
+    },
+    {
+        "CPU": "AMD EPYC 7261",
+        "Benchmark": "11,149"
+    },
+    {
+        "CPU": "AMD EPYC 7262",
+        "Benchmark": "20,779"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7262",
+        "Benchmark": "34,227"
+    },
+    {
+        "CPU": "AMD EPYC 7272",
+        "Benchmark": "25,161"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7272",
+        "Benchmark": "42,832"
+    },
+    {
+        "CPU": "AMD EPYC 7281",
+        "Benchmark": "21,621"
+    },
+    {
+        "CPU": "AMD EPYC 7282",
+        "Benchmark": "30,137"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7282",
+        "Benchmark": "51,807"
+    },
+    {
+        "CPU": "AMD EPYC 72F3",
+        "Benchmark": "27,252"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 72F3",
+        "Benchmark": "50,017"
+    },
+    {
+        "CPU": "AMD EPYC 7301",
+        "Benchmark": "14,991"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7301",
+        "Benchmark": "34,148"
+    },
+    {
+        "CPU": "AMD EPYC 7302",
+        "Benchmark": "33,106"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7302",
+        "Benchmark": "51,242"
+    },
+    {
+        "CPU": "AMD EPYC 7302P",
+        "Benchmark": "32,69"
+    },
+    {
+        "CPU": "AMD EPYC 7303",
+        "Benchmark": "28,572"
+    },
+    {
+        "CPU": "AMD EPYC 7313",
+        "Benchmark": "38,644"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7313",
+        "Benchmark": "67,427"
+    },
+    {
+        "CPU": "AMD EPYC 7313P",
+        "Benchmark": "41,609"
+    },
+    {
+        "CPU": "AMD EPYC 7343",
+        "Benchmark": "43,644"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7343",
+        "Benchmark": "73,01"
+    },
+    {
+        "CPU": "AMD EPYC 7351",
+        "Benchmark": "23,226"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7351",
+        "Benchmark": "25,431"
+    },
+    {
+        "CPU": "AMD EPYC 7351P",
+        "Benchmark": "26,042"
+    },
+    {
+        "CPU": "AMD EPYC 7352",
+        "Benchmark": "40,37"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7352",
+        "Benchmark": "65,921"
+    },
+    {
+        "CPU": "AMD EPYC 7371",
+        "Benchmark": "30,782"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7371",
+        "Benchmark": "54,894"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7373X",
+        "Benchmark": "74,709"
+    },
+    {
+        "CPU": "AMD EPYC 73F3",
+        "Benchmark": "46,103"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 73F3",
+        "Benchmark": "72,363"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7401",
+        "Benchmark": "55,28"
+    },
+    {
+        "CPU": "AMD EPYC 7401P",
+        "Benchmark": "27,836"
+    },
+    {
+        "CPU": "AMD EPYC 7402",
+        "Benchmark": "46,012"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7402",
+        "Benchmark": "63,873"
+    },
+    {
+        "CPU": "AMD EPYC 7402P",
+        "Benchmark": "43,684"
+    },
+    {
+        "CPU": "AMD EPYC 7413",
+        "Benchmark": "50,641"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7413",
+        "Benchmark": "74,625"
+    },
+    {
+        "CPU": "AMD EPYC 7443",
+        "Benchmark": "56,686"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7443",
+        "Benchmark": "71,156"
+    },
+    {
+        "CPU": "AMD EPYC 7443P",
+        "Benchmark": "56,981"
+    },
+    {
+        "CPU": "AMD EPYC 7451",
+        "Benchmark": "24,059"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7451",
+        "Benchmark": "52,322"
+    },
+    {
+        "CPU": "AMD EPYC 7452",
+        "Benchmark": "44,996"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7452",
+        "Benchmark": "65,147"
+    },
+    {
+        "CPU": "AMD EPYC 7453",
+        "Benchmark": "48,453"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7453",
+        "Benchmark": "80,327"
+    },
+    {
+        "CPU": "AMD EPYC 7473X",
+        "Benchmark": "59,28"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7473X",
+        "Benchmark": "81,282"
+    },
+    {
+        "CPU": "AMD EPYC 74F3",
+        "Benchmark": "60,666"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 74F3",
+        "Benchmark": "95,621"
+    },
+    {
+        "CPU": "AMD EPYC 7501",
+        "Benchmark": "24,925"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7501",
+        "Benchmark": "61,517"
+    },
+    {
+        "CPU": "AMD EPYC 7502",
+        "Benchmark": "51,695"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7502",
+        "Benchmark": "78,388"
+    },
+    {
+        "CPU": "AMD EPYC 7502P",
+        "Benchmark": "51,054"
+    },
+    {
+        "CPU": "AMD EPYC 7513",
+        "Benchmark": "59,331"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7513",
+        "Benchmark": "96,409"
+    },
+    {
+        "CPU": "AMD EPYC 7532",
+        "Benchmark": "52,22"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7532",
+        "Benchmark": "78,11"
+    },
+    {
+        "CPU": "AMD EPYC 7542",
+        "Benchmark": "45,814"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7542",
+        "Benchmark": "74,148"
+    },
+    {
+        "CPU": "AMD EPYC 7543",
+        "Benchmark": "61,788"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7543",
+        "Benchmark": "97,843"
+    },
+    {
+        "CPU": "AMD EPYC 7543P",
+        "Benchmark": "66,687"
+    },
+    {
+        "CPU": "AMD EPYC 7551",
+        "Benchmark": "25,606"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7551",
+        "Benchmark": "57,841"
+    },
+    {
+        "CPU": "AMD EPYC 7551P",
+        "Benchmark": "38,198"
+    },
+    {
+        "CPU": "AMD EPYC 7552",
+        "Benchmark": "57,414"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7552",
+        "Benchmark": "72,235"
+    },
+    {
+        "CPU": "AMD EPYC 7571",
+        "Benchmark": "27,445"
+    },
+    {
+        "CPU": "AMD EPYC 7573X",
+        "Benchmark": "69,432"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7573X",
+        "Benchmark": "103,466"
+    },
+    {
+        "CPU": "AMD EPYC 75F3",
+        "Benchmark": "59,972"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 75F3",
+        "Benchmark": "101,429"
+    },
+    {
+        "CPU": "AMD EPYC 7601",
+        "Benchmark": "33,255"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7601",
+        "Benchmark": "53,737"
+    },
+    {
+        "CPU": "AMD EPYC 7642",
+        "Benchmark": "58,795"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7642",
+        "Benchmark": "92,978"
+    },
+    {
+        "CPU": "AMD EPYC 7643",
+        "Benchmark": "76,05"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7643",
+        "Benchmark": "91,554"
+    },
+    {
+        "CPU": "AMD EPYC 7643P",
+        "Benchmark": "77,307"
+    },
+    {
+        "CPU": "AMD EPYC 7662",
+        "Benchmark": "72,298"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7662",
+        "Benchmark": "97,178"
+    },
+    {
+        "CPU": "AMD EPYC 7663",
+        "Benchmark": "82,087"
+    },
+    {
+        "CPU": "AMD EPYC 7702",
+        "Benchmark": "68,87"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7702",
+        "Benchmark": "93,683"
+    },
+    {
+        "CPU": "AMD EPYC 7702P",
+        "Benchmark": "61,539"
+    },
+    {
+        "CPU": "AMD EPYC 7713",
+        "Benchmark": "82,825"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7713",
+        "Benchmark": "107,426"
+    },
+    {
+        "CPU": "AMD EPYC 7713P",
+        "Benchmark": "81,351"
+    },
+    {
+        "CPU": "AMD EPYC 7742",
+        "Benchmark": "69,14"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7742",
+        "Benchmark": "94,352"
+    },
+    {
+        "CPU": "AMD EPYC 7763",
+        "Benchmark": "84,591"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7763",
+        "Benchmark": "114,618"
+    },
+    {
+        "CPU": "AMD EPYC 7773X",
+        "Benchmark": "91,34"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7773X",
+        "Benchmark": "109,334"
+    },
+    {
+        "CPU": "AMD EPYC 7B12",
+        "Benchmark": "66,044"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7B12",
+        "Benchmark": "95,651"
+    },
+    {
+        "CPU": "AMD EPYC 7B13",
+        "Benchmark": "77,46"
+    },
+    {
+        "CPU": "AMD EPYC 7C13",
+        "Benchmark": "76,367"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7C13",
+        "Benchmark": "81,691"
+    },
+    {
+        "CPU": "AMD EPYC 7D12",
+        "Benchmark": "42,9"
+    },
+    {
+        "CPU": "AMD EPYC 7F32",
+        "Benchmark": "23,198"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7F32",
+        "Benchmark": "40"
+    },
+    {
+        "CPU": "AMD EPYC 7F52",
+        "Benchmark": "41,322"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7F52",
+        "Benchmark": "64,806"
+    },
+    {
+        "CPU": "AMD EPYC 7F72",
+        "Benchmark": "52,74"
+    },
+    {
+        "CPU": "AMD EPYC 7H12",
+        "Benchmark": "69,633"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7H12",
+        "Benchmark": "88,736"
+    },
+    {
+        "CPU": "AMD EPYC 7J13",
+        "Benchmark": "84,786"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7J13",
+        "Benchmark": "119,134"
+    },
+    {
+        "CPU": "AMD EPYC 7K62",
+        "Benchmark": "59,764"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7K62",
+        "Benchmark": "89,427"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7K83",
+        "Benchmark": "102,053"
+    },
+    {
+        "CPU": "AMD EPYC 7R12",
+        "Benchmark": "48,934"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7R12",
+        "Benchmark": "92,961"
+    },
+    {
+        "CPU": "AMD EPYC 7R13 64-Core",
+        "Benchmark": "82,158"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7R13 64-Core",
+        "Benchmark": "101,076"
+    },
+    {
+        "CPU": "AMD EPYC 7R32",
+        "Benchmark": "63,239"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7R32",
+        "Benchmark": "74,52"
+    },
+    {
+        "CPU": "AMD EPYC 7R43",
+        "Benchmark": "83,535"
+    },
+    {
+        "CPU": "AMD EPYC 7T83",
+        "Benchmark": "81,757"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7T83",
+        "Benchmark": "115,522"
+    },
+    {
+        "CPU": "AMD EPYC 7V12",
+        "Benchmark": "70,622"
+    },
+    {
+        "CPU": "AMD EPYC 7V13",
+        "Benchmark": "82,878"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7V13",
+        "Benchmark": "100,318"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7V73X",
+        "Benchmark": "94,451"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 7Y83",
+        "Benchmark": "108,281"
+    },
+    {
+        "CPU": "AMD EPYC 8024P",
+        "Benchmark": "20,556"
+    },
+    {
+        "CPU": "AMD EPYC 8124P",
+        "Benchmark": "36,338"
+    },
+    {
+        "CPU": "AMD EPYC 8224P",
+        "Benchmark": "45,18"
+    },
+    {
+        "CPU": "AMD EPYC 8324P",
+        "Benchmark": "57,127"
+    },
+    {
+        "CPU": "AMD EPYC 8324PN 32-Core",
+        "Benchmark": "8,375"
+    },
+    {
+        "CPU": "AMD EPYC 8434P",
+        "Benchmark": "66,49"
+    },
+    {
+        "CPU": "AMD EPYC 8534P",
+        "Benchmark": "71,9"
+    },
+    {
+        "CPU": "AMD EPYC 9115",
+        "Benchmark": "49,193"
+    },
+    {
+        "CPU": "AMD EPYC 9124",
+        "Benchmark": "43,681"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9124",
+        "Benchmark": "64,668"
+    },
+    {
+        "CPU": "AMD EPYC 9135",
+        "Benchmark": "57,38"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9135",
+        "Benchmark": "93,93"
+    },
+    {
+        "CPU": "AMD EPYC 9174F",
+        "Benchmark": "54,243"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9174F",
+        "Benchmark": "90,483"
+    },
+    {
+        "CPU": "AMD EPYC 9175F",
+        "Benchmark": "65,792"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9175F",
+        "Benchmark": "100,968"
+    },
+    {
+        "CPU": "AMD EPYC 9184X",
+        "Benchmark": "46,875"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9184X",
+        "Benchmark": "84,253"
+    },
+    {
+        "CPU": "AMD EPYC 9224",
+        "Benchmark": "45,223"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9224",
+        "Benchmark": "92,518"
+    },
+    {
+        "CPU": "AMD EPYC 9254",
+        "Benchmark": "64,086"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9254",
+        "Benchmark": "83,17"
+    },
+    {
+        "CPU": "AMD EPYC 9274F",
+        "Benchmark": "73,982"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9274F",
+        "Benchmark": "112,943"
+    },
+    {
+        "CPU": "AMD EPYC 9275F",
+        "Benchmark": "83,835"
+    },
+    {
+        "CPU": "AMD EPYC 9334",
+        "Benchmark": "64,616"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9334",
+        "Benchmark": "109,109"
+    },
+    {
+        "CPU": "AMD EPYC 9354",
+        "Benchmark": "72,615"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9354",
+        "Benchmark": "113,042"
+    },
+    {
+        "CPU": "AMD EPYC 9354P",
+        "Benchmark": "75,106"
+    },
+    {
+        "CPU": "AMD EPYC 9355P",
+        "Benchmark": "97,292"
+    },
+    {
+        "CPU": "AMD EPYC 9374F",
+        "Benchmark": "82,009"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9374F",
+        "Benchmark": "124,597"
+    },
+    {
+        "CPU": "AMD EPYC 9375F",
+        "Benchmark": "95,768"
+    },
+    {
+        "CPU": "AMD EPYC 9384X",
+        "Benchmark": "69,665"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9384X",
+        "Benchmark": "121,56"
+    },
+    {
+        "CPU": "AMD EPYC 9454",
+        "Benchmark": "86,324"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9454",
+        "Benchmark": "129,701"
+    },
+    {
+        "CPU": "AMD EPYC 9454P",
+        "Benchmark": "95,851"
+    },
+    {
+        "CPU": "AMD EPYC 9455P",
+        "Benchmark": "116,642"
+    },
+    {
+        "CPU": "AMD EPYC 9474F",
+        "Benchmark": "105,01"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9474F",
+        "Benchmark": "147,996"
+    },
+    {
+        "CPU": "AMD EPYC 9534",
+        "Benchmark": "89,077"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9534",
+        "Benchmark": "132,873"
+    },
+    {
+        "CPU": "AMD EPYC 9554",
+        "Benchmark": "108,612"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9554",
+        "Benchmark": "146,171"
+    },
+    {
+        "CPU": "AMD EPYC 9554P",
+        "Benchmark": "106,756"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9555",
+        "Benchmark": "180,981"
+    },
+    {
+        "CPU": "AMD EPYC 9555P",
+        "Benchmark": "135,513"
+    },
+    {
+        "CPU": "AMD EPYC 9575F",
+        "Benchmark": "150,439"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9575F",
+        "Benchmark": "192,57"
+    },
+    {
+        "CPU": "AMD EPYC 9634",
+        "Benchmark": "107,944"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9634",
+        "Benchmark": "142,801"
+    },
+    {
+        "CPU": "AMD EPYC 9654",
+        "Benchmark": "119,64"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9654",
+        "Benchmark": "147,946"
+    },
+    {
+        "CPU": "AMD EPYC 9654P",
+        "Benchmark": "116,324"
+    },
+    {
+        "CPU": "AMD EPYC 9655",
+        "Benchmark": "156,085"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9655",
+        "Benchmark": "200,477"
+    },
+    {
+        "CPU": "AMD EPYC 9655P",
+        "Benchmark": "160,417"
+    },
+    {
+        "CPU": "AMD EPYC 9684X",
+        "Benchmark": "121,595"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9684X",
+        "Benchmark": "150,676"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9734",
+        "Benchmark": "130,034"
+    },
+    {
+        "CPU": "AMD EPYC 9745",
+        "Benchmark": "130,698"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9745",
+        "Benchmark": "177,788"
+    },
+    {
+        "CPU": "AMD EPYC 9754",
+        "Benchmark": "98,868"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9754",
+        "Benchmark": "130,045"
+    },
+    {
+        "CPU": "AMD EPYC 9755",
+        "Benchmark": "37,319"
+    },
+    {
+        "CPU": "AMD EPYC 9845",
+        "Benchmark": "152,985"
+    },
+    {
+        "CPU": "AMD EPYC 9965",
+        "Benchmark": "160,778"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9965",
+        "Benchmark": "167,605"
+    },
+    {
+        "CPU": "AMD EPYC 9B45",
+        "Benchmark": "158,79"
+    },
+    {
+        "CPU": "AMD EPYC 9J14",
+        "Benchmark": "124,637"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9J45",
+        "Benchmark": "201,335"
+    },
+    {
+        "CPU": "AMD EPYC 9R14",
+        "Benchmark": "116,475"
+    },
+    {
+        "CPU": "AMD EPYC 9V74",
+        "Benchmark": "117,606"
+    },
+    {
+        "CPU": "[Dual CPU] AMD EPYC 9V94",
+        "Benchmark": "83,538"
+    },
+    {
+        "CPU": "AMD EPYC Embedded 7292P",
+        "Benchmark": "30,542"
+    },
+    {
+        "CPU": "AMD FirePro A320 APU",
+        "Benchmark": "2,153"
+    },
+    {
+        "CPU": "AMD FX-4100 Quad-Core",
+        "Benchmark": "2,622"
+    },
+    {
+        "CPU": "AMD FX-4130 Quad-Core",
+        "Benchmark": "2,713"
+    },
+    {
+        "CPU": "AMD FX-4150 Quad-Core",
+        "Benchmark": "3,327"
+    },
+    {
+        "CPU": "AMD FX-4170 Quad-Core",
+        "Benchmark": "3,064"
+    },
+    {
+        "CPU": "AMD FX-4200 Quad-Core",
+        "Benchmark": "3,119"
+    },
+    {
+        "CPU": "AMD FX-4300 Quad-Core",
+        "Benchmark": "2,99"
+    },
+    {
+        "CPU": "AMD FX-4320",
+        "Benchmark": "3,15"
+    },
+    {
+        "CPU": "AMD FX-4330",
+        "Benchmark": "3,146"
+    },
+    {
+        "CPU": "AMD FX-4350 Quad-Core",
+        "Benchmark": "3,176"
+    },
+    {
+        "CPU": "AMD FX-6100 Six-Core",
+        "Benchmark": "3,698"
+    },
+    {
+        "CPU": "AMD FX-6120 Six-Core",
+        "Benchmark": "3,909"
+    },
+    {
+        "CPU": "AMD FX-6130 Six-Core",
+        "Benchmark": "4,353"
+    },
+    {
+        "CPU": "AMD FX-6200 Six-Core",
+        "Benchmark": "4,093"
+    },
+    {
+        "CPU": "AMD FX-6300 Six-Core",
+        "Benchmark": "4,223"
+    },
+    {
+        "CPU": "AMD FX-6330 Six-Core",
+        "Benchmark": "4,433"
+    },
+    {
+        "CPU": "AMD FX-6350 Six-Core",
+        "Benchmark": "4,623"
+    },
+    {
+        "CPU": "AMD FX-670K Quad-Core",
+        "Benchmark": "2,98"
+    },
+    {
+        "CPU": "AMD FX-7500 APU",
+        "Benchmark": "1,929"
+    },
+    {
+        "CPU": "AMD FX-7600P",
+        "Benchmark": "2,557"
+    },
+    {
+        "CPU": "AMD FX-7600P APU",
+        "Benchmark": "2,856"
+    },
+    {
+        "CPU": "AMD FX-770K Quad-Core",
+        "Benchmark": "3,113"
+    },
+    {
+        "CPU": "AMD FX-8100 Eight-Core",
+        "Benchmark": "4,095"
+    },
+    {
+        "CPU": "AMD FX-8120 Eight-Core",
+        "Benchmark": "4,634"
+    },
+    {
+        "CPU": "AMD FX-8140 Eight-Core",
+        "Benchmark": "4,86"
+    },
+    {
+        "CPU": "AMD FX-8150 Eight-Core",
+        "Benchmark": "5,302"
+    },
+    {
+        "CPU": "AMD FX-8300 Eight-Core",
+        "Benchmark": "5,341"
+    },
+    {
+        "CPU": "AMD FX-8310 Eight-Core",
+        "Benchmark": "5,045"
+    },
+    {
+        "CPU": "AMD FX-8320 Eight-Core",
+        "Benchmark": "5,454"
+    },
+    {
+        "CPU": "AMD FX-8320E Eight-Core",
+        "Benchmark": "5,117"
+    },
+    {
+        "CPU": "AMD FX-8350 Eight-Core",
+        "Benchmark": "6,084"
+    },
+    {
+        "CPU": "AMD FX-8370 Eight-Core",
+        "Benchmark": "6,153"
+    },
+    {
+        "CPU": "AMD FX-8370E Eight-Core",
+        "Benchmark": "5,332"
+    },
+    {
+        "CPU": "AMD FX-870K Quad Core",
+        "Benchmark": "3,227"
+    },
+    {
+        "CPU": "AMD FX-8800P",
+        "Benchmark": "2,829"
+    },
+    {
+        "CPU": "AMD FX-9370 Eight-Core",
+        "Benchmark": "6,336"
+    },
+    {
+        "CPU": "AMD FX-9590 Eight-Core",
+        "Benchmark": "6,794"
+    },
+    {
+        "CPU": "AMD FX-9800P",
+        "Benchmark": "2,495"
+    },
+    {
+        "CPU": "AMD FX-9830P",
+        "Benchmark": "3,301"
+    },
+    {
+        "CPU": "AMD FX-B4150 Quad-Core",
+        "Benchmark": "3,369"
+    },
+    {
+        "CPU": "AMD G-T40E",
+        "Benchmark": "289"
+    },
+    {
+        "CPU": "AMD G-T40N",
+        "Benchmark": "299"
+    },
+    {
+        "CPU": "AMD G-T40R",
+        "Benchmark": "120"
+    },
+    {
+        "CPU": "AMD G-T44R",
+        "Benchmark": "120"
+    },
+    {
+        "CPU": "AMD G-T48E",
+        "Benchmark": "432"
+    },
+    {
+        "CPU": "AMD G-T52R",
+        "Benchmark": "177"
+    },
+    {
+        "CPU": "AMD G-T56E",
+        "Benchmark": "442"
+    },
+    {
+        "CPU": "AMD G-T56N",
+        "Benchmark": "484"
+    },
+    {
+        "CPU": "AMD Geode NX 2400+",
+        "Benchmark": "400"
+    },
+    {
+        "CPU": "AMD GX-210JA SOC",
+        "Benchmark": "248"
+    },
+    {
+        "CPU": "AMD GX-212JC SOC",
+        "Benchmark": "645"
+    },
+    {
+        "CPU": "AMD GX-217GA SOC",
+        "Benchmark": "794"
+    },
+    {
+        "CPU": "AMD GX-218GL SOC",
+        "Benchmark": "754"
+    },
+    {
+        "CPU": "AMD GX-222GC SOC",
+        "Benchmark": "1,044"
+    },
+    {
+        "CPU": "AMD GX-412HC",
+        "Benchmark": "1,095"
+    },
+    {
+        "CPU": "AMD GX-412TC SOC",
+        "Benchmark": "650"
+    },
+    {
+        "CPU": "AMD GX-415GA SOC",
+        "Benchmark": "1,405"
+    },
+    {
+        "CPU": "AMD GX-416RA SOC",
+        "Benchmark": "1,604"
+    },
+    {
+        "CPU": "AMD GX-420CA SOC",
+        "Benchmark": "1,785"
+    },
+    {
+        "CPU": "AMD GX-420MC SOC",
+        "Benchmark": "1,796"
+    },
+    {
+        "CPU": "AMD GX-424CC SOC",
+        "Benchmark": "1,819"
+    },
+    {
+        "CPU": "AMD Opteron 1212",
+        "Benchmark": "593"
+    },
+    {
+        "CPU": "AMD Opteron 1212 HE",
+        "Benchmark": "771"
+    },
+    {
+        "CPU": "AMD Opteron 1214",
+        "Benchmark": "763"
+    },
+    {
+        "CPU": "AMD Opteron 1214 HE",
+        "Benchmark": "806"
+    },
+    {
+        "CPU": "AMD Opteron 1216",
+        "Benchmark": "781"
+    },
+    {
+        "CPU": "AMD Opteron 1216 HE",
+        "Benchmark": "727"
+    },
+    {
+        "CPU": "AMD Opteron 1218",
+        "Benchmark": "910"
+    },
+    {
+        "CPU": "AMD Opteron 1218 HE",
+        "Benchmark": "979"
+    },
+    {
+        "CPU": "AMD Opteron 1220",
+        "Benchmark": "1,036"
+    },
+    {
+        "CPU": "AMD Opteron 1222",
+        "Benchmark": "1,089"
+    },
+    {
+        "CPU": "AMD Opteron 1352",
+        "Benchmark": "1,547"
+    },
+    {
+        "CPU": "AMD Opteron 1354",
+        "Benchmark": "1,635"
+    },
+    {
+        "CPU": "AMD Opteron 1356",
+        "Benchmark": "1,703"
+    },
+    {
+        "CPU": "AMD Opteron 1381",
+        "Benchmark": "1,797"
+    },
+    {
+        "CPU": "AMD Opteron 1385",
+        "Benchmark": "2,089"
+    },
+    {
+        "CPU": "AMD Opteron 1389",
+        "Benchmark": "2,079"
+    },
+    {
+        "CPU": "AMD Opteron 144",
+        "Benchmark": "316"
+    },
+    {
+        "CPU": "AMD Opteron 146",
+        "Benchmark": "346"
+    },
+    {
+        "CPU": "AMD Opteron 148",
+        "Benchmark": "392"
+    },
+    {
+        "CPU": "AMD Opteron 150",
+        "Benchmark": "393"
+    },
+    {
+        "CPU": "AMD Opteron 152",
+        "Benchmark": "428"
+    },
+    {
+        "CPU": "AMD Opteron 154",
+        "Benchmark": "457"
+    },
+    {
+        "CPU": "AMD Opteron 165",
+        "Benchmark": "531"
+    },
+    {
+        "CPU": "AMD Opteron 170",
+        "Benchmark": "648"
+    },
+    {
+        "CPU": "AMD Opteron 175",
+        "Benchmark": "682"
+    },
+    {
+        "CPU": "AMD Opteron 180",
+        "Benchmark": "746"
+    },
+    {
+        "CPU": "AMD Opteron 185",
+        "Benchmark": "695"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2216",
+        "Benchmark": "1,771"
+    },
+    {
+        "CPU": "AMD Opteron 2218",
+        "Benchmark": "1,036"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2218",
+        "Benchmark": "1,994"
+    },
+    {
+        "CPU": "AMD Opteron 2220",
+        "Benchmark": "1,106"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2220",
+        "Benchmark": "1,533"
+    },
+    {
+        "CPU": "AMD Opteron 2220 SE",
+        "Benchmark": "909"
+    },
+    {
+        "CPU": "AMD Opteron 2222",
+        "Benchmark": "1,198"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2222",
+        "Benchmark": "2,098"
+    },
+    {
+        "CPU": "AMD Opteron 2354",
+        "Benchmark": "1,509"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2354",
+        "Benchmark": "3,242"
+    },
+    {
+        "CPU": "AMD Opteron 2356",
+        "Benchmark": "1,829"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2356",
+        "Benchmark": "3,519"
+    },
+    {
+        "CPU": "AMD Opteron 2373 EE",
+        "Benchmark": "1,744"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2373 EE",
+        "Benchmark": "3,521"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2374 HE",
+        "Benchmark": "3,667"
+    },
+    {
+        "CPU": "AMD Opteron 2378",
+        "Benchmark": "1,864"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2382",
+        "Benchmark": "4,516"
+    },
+    {
+        "CPU": "AMD Opteron 2384",
+        "Benchmark": "2,074"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2387",
+        "Benchmark": "4,105"
+    },
+    {
+        "CPU": "AMD Opteron 2393 SE",
+        "Benchmark": "1,317"
+    },
+    {
+        "CPU": "AMD Opteron 2419 EE",
+        "Benchmark": "1,902"
+    },
+    {
+        "CPU": "AMD Opteron 2427",
+        "Benchmark": "1,995"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2427",
+        "Benchmark": "4,499"
+    },
+    {
+        "CPU": "AMD Opteron 2431",
+        "Benchmark": "2,894"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2431",
+        "Benchmark": "5,935"
+    },
+    {
+        "CPU": "AMD Opteron 2435",
+        "Benchmark": "3,061"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 2435",
+        "Benchmark": "5,26"
+    },
+    {
+        "CPU": "AMD Opteron 254",
+        "Benchmark": "451"
+    },
+    {
+        "CPU": "AMD Opteron 270",
+        "Benchmark": "736"
+    },
+    {
+        "CPU": "AMD Opteron 275",
+        "Benchmark": "839"
+    },
+    {
+        "CPU": "AMD Opteron 280",
+        "Benchmark": "765"
+    },
+    {
+        "CPU": "AMD Opteron 285",
+        "Benchmark": "956"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 285",
+        "Benchmark": "1,441"
+    },
+    {
+        "CPU": "AMD Opteron 290",
+        "Benchmark": "952"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 290",
+        "Benchmark": "1,43"
+    },
+    {
+        "CPU": "AMD Opteron 3250 HE",
+        "Benchmark": "2,061"
+    },
+    {
+        "CPU": "AMD Opteron 3260 HE",
+        "Benchmark": "2,283"
+    },
+    {
+        "CPU": "AMD Opteron 3280",
+        "Benchmark": "3,783"
+    },
+    {
+        "CPU": "AMD Opteron 3320 EE",
+        "Benchmark": "1,918"
+    },
+    {
+        "CPU": "AMD Opteron 3350 HE",
+        "Benchmark": "2,699"
+    },
+    {
+        "CPU": "AMD Opteron 3365",
+        "Benchmark": "4,083"
+    },
+    {
+        "CPU": "AMD Opteron 3380",
+        "Benchmark": "4,358"
+    },
+    {
+        "CPU": "AMD Opteron 4130",
+        "Benchmark": "2,342"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4130",
+        "Benchmark": "4,315"
+    },
+    {
+        "CPU": "AMD Opteron 4162 EE",
+        "Benchmark": "2,058"
+    },
+    {
+        "CPU": "AMD Opteron 4170 HE",
+        "Benchmark": "2,382"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4170 HE",
+        "Benchmark": "5,152"
+    },
+    {
+        "CPU": "AMD Opteron 4174 HE",
+        "Benchmark": "2,986"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4174 HE",
+        "Benchmark": "5,656"
+    },
+    {
+        "CPU": "AMD Opteron 4184",
+        "Benchmark": "2,872"
+    },
+    {
+        "CPU": "AMD Opteron 4226",
+        "Benchmark": "3,4"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4238",
+        "Benchmark": "7,236"
+    },
+    {
+        "CPU": "AMD Opteron 4274 HE",
+        "Benchmark": "5,776"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4274 HE",
+        "Benchmark": "6,909"
+    },
+    {
+        "CPU": "AMD Opteron 4280",
+        "Benchmark": "4,504"
+    },
+    {
+        "CPU": "AMD Opteron 4284",
+        "Benchmark": "4,665"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4284",
+        "Benchmark": "8,56"
+    },
+    {
+        "CPU": "AMD Opteron 4332 HE",
+        "Benchmark": "3,911"
+    },
+    {
+        "CPU": "AMD Opteron 4334",
+        "Benchmark": "3,949"
+    },
+    {
+        "CPU": "AMD Opteron 4365 EE",
+        "Benchmark": "3,582"
+    },
+    {
+        "CPU": "AMD Opteron 4376 HE",
+        "Benchmark": "4,318"
+    },
+    {
+        "CPU": "AMD Opteron 4386",
+        "Benchmark": "3,273"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 4386",
+        "Benchmark": "9,253"
+    },
+    {
+        "CPU": "AMD Opteron 6128",
+        "Benchmark": "2,826"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6128",
+        "Benchmark": "6,141"
+    },
+    {
+        "CPU": "AMD Opteron 6128 HE",
+        "Benchmark": "2,932"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6128 HE",
+        "Benchmark": "6,339"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6134",
+        "Benchmark": "6,053"
+    },
+    {
+        "CPU": "AMD Opteron 6136",
+        "Benchmark": "3,381"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6136",
+        "Benchmark": "7,964"
+    },
+    {
+        "CPU": "AMD Opteron 6164 HE",
+        "Benchmark": "3,478"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6168",
+        "Benchmark": "15,745"
+    },
+    {
+        "CPU": "AMD Opteron 6172",
+        "Benchmark": "2,615"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6172",
+        "Benchmark": "16,032"
+    },
+    {
+        "CPU": "AMD Opteron 6174",
+        "Benchmark": "3,697"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6174",
+        "Benchmark": "12,607"
+    },
+    {
+        "CPU": "AMD Opteron 6176 SE",
+        "Benchmark": "3,564"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6176 SE",
+        "Benchmark": "7,818"
+    },
+    {
+        "CPU": "AMD Opteron 6212",
+        "Benchmark": "3,973"
+    },
+    {
+        "CPU": "AMD Opteron 6220",
+        "Benchmark": "4,753"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6220",
+        "Benchmark": "7,951"
+    },
+    {
+        "CPU": "AMD Opteron 6234",
+        "Benchmark": "4,072"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6234",
+        "Benchmark": "8,644"
+    },
+    {
+        "CPU": "AMD Opteron 6238",
+        "Benchmark": "5,625"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6238",
+        "Benchmark": "8,206"
+    },
+    {
+        "CPU": "AMD Opteron 6272",
+        "Benchmark": "5,24"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6272",
+        "Benchmark": "9,239"
+    },
+    {
+        "CPU": "AMD Opteron 6274",
+        "Benchmark": "5,643"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6274",
+        "Benchmark": "10,313"
+    },
+    {
+        "CPU": "AMD Opteron 6276",
+        "Benchmark": "6,348"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6276",
+        "Benchmark": "12,514"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6276",
+        "Benchmark": "9,168"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6278",
+        "Benchmark": "13,733"
+    },
+    {
+        "CPU": "AMD Opteron 6281",
+        "Benchmark": "7,279"
+    },
+    {
+        "CPU": "AMD Opteron 6282 SE",
+        "Benchmark": "6,385"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6282 SE",
+        "Benchmark": "12,083"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6282 SE",
+        "Benchmark": "7,13"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6284 SE",
+        "Benchmark": "10,619"
+    },
+    {
+        "CPU": "AMD Opteron 6287 SE",
+        "Benchmark": "6,925"
+    },
+    {
+        "CPU": "AMD Opteron 6328",
+        "Benchmark": "5,306"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6328",
+        "Benchmark": "10,076"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6328",
+        "Benchmark": "9,508"
+    },
+    {
+        "CPU": "AMD Opteron 6344",
+        "Benchmark": "6,069"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6344",
+        "Benchmark": "9,023"
+    },
+    {
+        "CPU": "AMD Opteron 6348",
+        "Benchmark": "7,85"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6348",
+        "Benchmark": "13,47"
+    },
+    {
+        "CPU": "AMD Opteron 6366 HE",
+        "Benchmark": "5,613"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6366 HE",
+        "Benchmark": "10,265"
+    },
+    {
+        "CPU": "AMD Opteron 6376",
+        "Benchmark": "5,572"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6376",
+        "Benchmark": "21,745"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6376",
+        "Benchmark": "12,601"
+    },
+    {
+        "CPU": "AMD Opteron 6378",
+        "Benchmark": "5,889"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6378",
+        "Benchmark": "13,403"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6378",
+        "Benchmark": "13,236"
+    },
+    {
+        "CPU": "AMD Opteron 6380",
+        "Benchmark": "6,687"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 6380",
+        "Benchmark": "14,445"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6380",
+        "Benchmark": "11,807"
+    },
+    {
+        "CPU": "AMD Opteron 6386 SE",
+        "Benchmark": "8,291"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 6386 SE",
+        "Benchmark": "12,761"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 8356",
+        "Benchmark": "5,397"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 8378",
+        "Benchmark": "7,726"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 8431",
+        "Benchmark": "5,716"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 8435",
+        "Benchmark": "11,843"
+    },
+    {
+        "CPU": "AMD Opteron 8439 SE",
+        "Benchmark": "2,479"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Opteron 8439 SE",
+        "Benchmark": "6,34"
+    },
+    {
+        "CPU": "[Quad CPU] AMD Opteron 885",
+        "Benchmark": "2,696"
+    },
+    {
+        "CPU": "AMD Opteron X2170 APU",
+        "Benchmark": "1,911"
+    },
+    {
+        "CPU": "AMD Opteron X3216 APU",
+        "Benchmark": "1,512"
+    },
+    {
+        "CPU": "AMD Opteron X3418 APU",
+        "Benchmark": "3,043"
+    },
+    {
+        "CPU": "AMD Opteron X3421 APU",
+        "Benchmark": "3,299"
+    },
+    {
+        "CPU": "AMD Phenom 8250 Triple-Core",
+        "Benchmark": "1,114"
+    },
+    {
+        "CPU": "AMD Phenom 8250e Triple-Core",
+        "Benchmark": "1,084"
+    },
+    {
+        "CPU": "AMD Phenom 8400 Triple-Core",
+        "Benchmark": "1,164"
+    },
+    {
+        "CPU": "AMD Phenom 8450 Triple-Core",
+        "Benchmark": "1,221"
+    },
+    {
+        "CPU": "AMD Phenom 8450e Triple-Core",
+        "Benchmark": "1,206"
+    },
+    {
+        "CPU": "AMD Phenom 8600 Triple-Core",
+        "Benchmark": "1,267"
+    },
+    {
+        "CPU": "AMD Phenom 8600B Triple-Core",
+        "Benchmark": "1,464"
+    },
+    {
+        "CPU": "AMD Phenom 8650 Triple-Core",
+        "Benchmark": "1,218"
+    },
+    {
+        "CPU": "AMD Phenom 8750 Triple-Core",
+        "Benchmark": "1,445"
+    },
+    {
+        "CPU": "AMD Phenom 8750B Triple-Core",
+        "Benchmark": "1,188"
+    },
+    {
+        "CPU": "AMD Phenom 8850 Triple-Core",
+        "Benchmark": "1,142"
+    },
+    {
+        "CPU": "AMD Phenom 8850B Triple-Core",
+        "Benchmark": "1,281"
+    },
+    {
+        "CPU": "AMD Phenom 9100e Quad-Core",
+        "Benchmark": "1,353"
+    },
+    {
+        "CPU": "AMD Phenom 9150e Quad-Core",
+        "Benchmark": "1,427"
+    },
+    {
+        "CPU": "AMD Phenom 9350e Quad-Core",
+        "Benchmark": "1,659"
+    },
+    {
+        "CPU": "AMD Phenom 9450e Quad-Core",
+        "Benchmark": "1,455"
+    },
+    {
+        "CPU": "AMD Phenom 9500 Quad-Core",
+        "Benchmark": "1,564"
+    },
+    {
+        "CPU": "AMD Phenom 9550 Quad-Core",
+        "Benchmark": "1,664"
+    },
+    {
+        "CPU": "AMD Phenom 9600 Quad-Core",
+        "Benchmark": "1,607"
+    },
+    {
+        "CPU": "AMD Phenom 9600B Quad-Core",
+        "Benchmark": "1,842"
+    },
+    {
+        "CPU": "AMD Phenom 9650 Quad-Core",
+        "Benchmark": "1,749"
+    },
+    {
+        "CPU": "AMD Phenom 9750 Quad-Core",
+        "Benchmark": "1,843"
+    },
+    {
+        "CPU": "AMD Phenom 9750B Quad-Core",
+        "Benchmark": "1,52"
+    },
+    {
+        "CPU": "AMD Phenom 9850 Quad-Core",
+        "Benchmark": "1,712"
+    },
+    {
+        "CPU": "AMD Phenom 9850B Quad-Core",
+        "Benchmark": "1,946"
+    },
+    {
+        "CPU": "AMD Phenom 9950 Quad-Core",
+        "Benchmark": "1,884"
+    },
+    {
+        "CPU": "AMD Phenom FX-5000 Quad-Core",
+        "Benchmark": "1,599"
+    },
+    {
+        "CPU": "AMD Phenom FX-5200 Quad-Core",
+        "Benchmark": "1,699"
+    },
+    {
+        "CPU": "AMD Phenom II N620 Dual-Core",
+        "Benchmark": "992"
+    },
+    {
+        "CPU": "AMD Phenom II N640 Dual-Core",
+        "Benchmark": "1,135"
+    },
+    {
+        "CPU": "AMD Phenom II N660 Dual-Core",
+        "Benchmark": "1,083"
+    },
+    {
+        "CPU": "AMD Phenom II N830 3+1",
+        "Benchmark": "1,768"
+    },
+    {
+        "CPU": "AMD Phenom II N830 Triple-Core",
+        "Benchmark": "1,241"
+    },
+    {
+        "CPU": "AMD Phenom II N850 Triple-Core",
+        "Benchmark": "1,318"
+    },
+    {
+        "CPU": "AMD Phenom II N870 Triple-Core",
+        "Benchmark": "1,324"
+    },
+    {
+        "CPU": "AMD Phenom II N930 Quad-Core",
+        "Benchmark": "1,584"
+    },
+    {
+        "CPU": "AMD Phenom II N950 Quad-Core",
+        "Benchmark": "1,587"
+    },
+    {
+        "CPU": "AMD Phenom II N970 Quad-Core",
+        "Benchmark": "1,711"
+    },
+    {
+        "CPU": "AMD Phenom II P650 Dual-Core",
+        "Benchmark": "933"
+    },
+    {
+        "CPU": "AMD Phenom II P820 Triple-Core",
+        "Benchmark": "1,068"
+    },
+    {
+        "CPU": "AMD Phenom II P840 Triple-Core",
+        "Benchmark": "1,079"
+    },
+    {
+        "CPU": "AMD Phenom II P860 Triple-Core",
+        "Benchmark": "1,25"
+    },
+    {
+        "CPU": "AMD Phenom II P920 Quad-Core",
+        "Benchmark": "1,006"
+    },
+    {
+        "CPU": "AMD Phenom II P940 Quad-Core",
+        "Benchmark": "1,319"
+    },
+    {
+        "CPU": "AMD Phenom II P960 Quad-Core",
+        "Benchmark": "1,417"
+    },
+    {
+        "CPU": "AMD Phenom II X2 511",
+        "Benchmark": "1,265"
+    },
+    {
+        "CPU": "AMD Phenom II X2 521",
+        "Benchmark": "1,374"
+    },
+    {
+        "CPU": "AMD Phenom II X2 545",
+        "Benchmark": "1,222"
+    },
+    {
+        "CPU": "AMD Phenom II X2 550",
+        "Benchmark": "1,14"
+    },
+    {
+        "CPU": "AMD Phenom II X2 555",
+        "Benchmark": "1,308"
+    },
+    {
+        "CPU": "AMD Phenom II X2 560",
+        "Benchmark": "1,381"
+    },
+    {
+        "CPU": "AMD Phenom II X2 565",
+        "Benchmark": "1,442"
+    },
+    {
+        "CPU": "AMD Phenom II X2 570",
+        "Benchmark": "1,437"
+    },
+    {
+        "CPU": "AMD Phenom II X2 B53",
+        "Benchmark": "1,137"
+    },
+    {
+        "CPU": "AMD Phenom II X2 B55",
+        "Benchmark": "1,204"
+    },
+    {
+        "CPU": "AMD Phenom II X2 B57",
+        "Benchmark": "1,26"
+    },
+    {
+        "CPU": "AMD Phenom II X2 B59",
+        "Benchmark": "1,396"
+    },
+    {
+        "CPU": "AMD Phenom II X3 700e",
+        "Benchmark": "1,451"
+    },
+    {
+        "CPU": "AMD Phenom II X3 705e",
+        "Benchmark": "1,222"
+    },
+    {
+        "CPU": "AMD Phenom II X3 710",
+        "Benchmark": "1,571"
+    },
+    {
+        "CPU": "AMD Phenom II X3 720",
+        "Benchmark": "1,6"
+    },
+    {
+        "CPU": "AMD Phenom II X3 740",
+        "Benchmark": "1,424"
+    },
+    {
+        "CPU": "AMD Phenom II X3 B73",
+        "Benchmark": "1,671"
+    },
+    {
+        "CPU": "AMD Phenom II X3 B75",
+        "Benchmark": "1,764"
+    },
+    {
+        "CPU": "AMD Phenom II X3 B77",
+        "Benchmark": "1,844"
+    },
+    {
+        "CPU": "AMD Phenom II X4 805",
+        "Benchmark": "2,001"
+    },
+    {
+        "CPU": "AMD Phenom II X4 810",
+        "Benchmark": "2,008"
+    },
+    {
+        "CPU": "AMD Phenom II X4 820",
+        "Benchmark": "2,095"
+    },
+    {
+        "CPU": "AMD Phenom II X4 830",
+        "Benchmark": "2,072"
+    },
+    {
+        "CPU": "AMD Phenom II X4 840",
+        "Benchmark": "2,435"
+    },
+    {
+        "CPU": "AMD Phenom II X4 840T",
+        "Benchmark": "2,36"
+    },
+    {
+        "CPU": "AMD Phenom II X4 850",
+        "Benchmark": "2,455"
+    },
+    {
+        "CPU": "AMD Phenom II X4 900e",
+        "Benchmark": "1,727"
+    },
+    {
+        "CPU": "AMD Phenom II X4 905e",
+        "Benchmark": "2,014"
+    },
+    {
+        "CPU": "AMD Phenom II X4 910",
+        "Benchmark": "1,776"
+    },
+    {
+        "CPU": "AMD Phenom II X4 910e",
+        "Benchmark": "2,116"
+    },
+    {
+        "CPU": "AMD Phenom II X4 920",
+        "Benchmark": "2,181"
+    },
+    {
+        "CPU": "AMD Phenom II X4 925",
+        "Benchmark": "2,277"
+    },
+    {
+        "CPU": "AMD Phenom II X4 940",
+        "Benchmark": "2,351"
+    },
+    {
+        "CPU": "AMD Phenom II X4 945",
+        "Benchmark": "2,413"
+    },
+    {
+        "CPU": "AMD Phenom II X4 955",
+        "Benchmark": "2,536"
+    },
+    {
+        "CPU": "AMD Phenom II X4 960T",
+        "Benchmark": "2,375"
+    },
+    {
+        "CPU": "AMD Phenom II X4 965",
+        "Benchmark": "2,661"
+    },
+    {
+        "CPU": "AMD Phenom II X4 970",
+        "Benchmark": "2,713"
+    },
+    {
+        "CPU": "AMD Phenom II X4 973",
+        "Benchmark": "2,204"
+    },
+    {
+        "CPU": "AMD Phenom II X4 975",
+        "Benchmark": "2,61"
+    },
+    {
+        "CPU": "AMD Phenom II X4 977",
+        "Benchmark": "2,377"
+    },
+    {
+        "CPU": "AMD Phenom II X4 980",
+        "Benchmark": "2,839"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B05e",
+        "Benchmark": "1,906"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B15e",
+        "Benchmark": "1,825"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B25",
+        "Benchmark": "2,108"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B35",
+        "Benchmark": "2,319"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B40",
+        "Benchmark": "2,238"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B45",
+        "Benchmark": "2,28"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B50",
+        "Benchmark": "2,448"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B55",
+        "Benchmark": "2,584"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B60",
+        "Benchmark": "2,627"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B65",
+        "Benchmark": "2,69"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B70",
+        "Benchmark": "2,303"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B93",
+        "Benchmark": "2,159"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B95",
+        "Benchmark": "2,427"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B97",
+        "Benchmark": "2,535"
+    },
+    {
+        "CPU": "AMD Phenom II X4 B99",
+        "Benchmark": "2,536"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1035T",
+        "Benchmark": "3,014"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1045T",
+        "Benchmark": "3,236"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1055T",
+        "Benchmark": "3,352"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1065T",
+        "Benchmark": "3,398"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1075T",
+        "Benchmark": "3,474"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1090T",
+        "Benchmark": "3,801"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1100T",
+        "Benchmark": "3,912"
+    },
+    {
+        "CPU": "AMD Phenom II X6 1405T",
+        "Benchmark": "3,371"
+    },
+    {
+        "CPU": "AMD Phenom II X620 Dual-Core",
+        "Benchmark": "1,262"
+    },
+    {
+        "CPU": "AMD Phenom II X640 Dual-Core",
+        "Benchmark": "1,165"
+    },
+    {
+        "CPU": "AMD Phenom II X920 Quad-Core",
+        "Benchmark": "1,669"
+    },
+    {
+        "CPU": "AMD Phenom II X940 Quad-Core",
+        "Benchmark": "1,797"
+    },
+    {
+        "CPU": "AMD Phenom X2 Dual-Core GE-5060",
+        "Benchmark": "1,566"
+    },
+    {
+        "CPU": "AMD Phenom X2 Dual-Core GE-6060",
+        "Benchmark": "1,722"
+    },
+    {
+        "CPU": "AMD Phenom X2 Dual-Core GE-7060",
+        "Benchmark": "1,01"
+    },
+    {
+        "CPU": "AMD Phenom X2 Dual-Core GP-7730",
+        "Benchmark": "884"
+    },
+    {
+        "CPU": "AMD Phenom X3 8550",
+        "Benchmark": "1,151"
+    },
+    {
+        "CPU": "AMD Phenom X4 Quad-Core GP-9500",
+        "Benchmark": "1,297"
+    },
+    {
+        "CPU": "AMD Phenom X4 Quad-Core GP-9530",
+        "Benchmark": "1,228"
+    },
+    {
+        "CPU": "AMD Phenom X4 Quad-Core GP-9600",
+        "Benchmark": "1,649"
+    },
+    {
+        "CPU": "AMD Phenom X4 Quad-Core GP-9730",
+        "Benchmark": "1,784"
+    },
+    {
+        "CPU": "AMD Phenom X4 Quad-Core GS-6560",
+        "Benchmark": "1,063"
+    },
+    {
+        "CPU": "AMD PRO A10-8700B",
+        "Benchmark": "2,203"
+    },
+    {
+        "CPU": "AMD PRO A10-8730B",
+        "Benchmark": "2,306"
+    },
+    {
+        "CPU": "AMD PRO A10-8750B",
+        "Benchmark": "2,95"
+    },
+    {
+        "CPU": "AMD PRO A10-8770",
+        "Benchmark": "3,574"
+    },
+    {
+        "CPU": "AMD PRO A10-8770E",
+        "Benchmark": "3,013"
+    },
+    {
+        "CPU": "AMD PRO A10-8850B",
+        "Benchmark": "3,752"
+    },
+    {
+        "CPU": "AMD PRO A10-9700",
+        "Benchmark": "3,574"
+    },
+    {
+        "CPU": "AMD PRO A10-9700B",
+        "Benchmark": "2,545"
+    },
+    {
+        "CPU": "AMD PRO A10-9700E",
+        "Benchmark": "3,028"
+    },
+    {
+        "CPU": "AMD PRO A12-8800B",
+        "Benchmark": "2,673"
+    },
+    {
+        "CPU": "AMD PRO A12-8830B",
+        "Benchmark": "2,628"
+    },
+    {
+        "CPU": "AMD PRO A12-8870",
+        "Benchmark": "3,821"
+    },
+    {
+        "CPU": "AMD PRO A12-8870E",
+        "Benchmark": "3,021"
+    },
+    {
+        "CPU": "AMD PRO A12-9800",
+        "Benchmark": "3,755"
+    },
+    {
+        "CPU": "AMD PRO A12-9800B",
+        "Benchmark": "2,71"
+    },
+    {
+        "CPU": "AMD PRO A12-9800E",
+        "Benchmark": "3,113"
+    },
+    {
+        "CPU": "AMD PRO A4-3350B APU",
+        "Benchmark": "1,79"
+    },
+    {
+        "CPU": "AMD PRO A4-4350B",
+        "Benchmark": "1,077"
+    },
+    {
+        "CPU": "AMD PRO A4-8350B",
+        "Benchmark": "1,69"
+    },
+    {
+        "CPU": "AMD PRO A6-7350B",
+        "Benchmark": "1,319"
+    },
+    {
+        "CPU": "AMD PRO A6-8500B",
+        "Benchmark": "1,601"
+    },
+    {
+        "CPU": "AMD PRO A6-8530B",
+        "Benchmark": "1,158"
+    },
+    {
+        "CPU": "AMD PRO A6-8550B",
+        "Benchmark": "1,882"
+    },
+    {
+        "CPU": "AMD PRO A6-8570",
+        "Benchmark": "1,91"
+    },
+    {
+        "CPU": "AMD PRO A6-8570E",
+        "Benchmark": "1,652"
+    },
+    {
+        "CPU": "AMD PRO A6-9500",
+        "Benchmark": "1,784"
+    },
+    {
+        "CPU": "AMD PRO A6-9500B",
+        "Benchmark": "1,357"
+    },
+    {
+        "CPU": "AMD PRO A6-9500E",
+        "Benchmark": "1,689"
+    },
+    {
+        "CPU": "AMD PRO A8-8600B",
+        "Benchmark": "2,226"
+    },
+    {
+        "CPU": "AMD PRO A8-8650B",
+        "Benchmark": "3,204"
+    },
+    {
+        "CPU": "AMD PRO A8-8670E",
+        "Benchmark": "3,102"
+    },
+    {
+        "CPU": "AMD PRO A8-9600",
+        "Benchmark": "3,31"
+    },
+    {
+        "CPU": "AMD PRO A8-9600B",
+        "Benchmark": "2,203"
+    },
+    {
+        "CPU": "AMD QC-4000",
+        "Benchmark": "1,155"
+    },
+    {
+        "CPU": "AMD R-260H APU",
+        "Benchmark": "954"
+    },
+    {
+        "CPU": "AMD R-272F APU",
+        "Benchmark": "1,215"
+    },
+    {
+        "CPU": "AMD R-460L APU",
+        "Benchmark": "1,538"
+    },
+    {
+        "CPU": "AMD R-464L APU",
+        "Benchmark": "1,773"
+    },
+    {
+        "CPU": "AMD RX-225FB",
+        "Benchmark": "892"
+    },
+    {
+        "CPU": "AMD RX-425BB",
+        "Benchmark": "2,637"
+    },
+    {
+        "CPU": "AMD RX-427BB",
+        "Benchmark": "2,747"
+    },
+    {
+        "CPU": "AMD Ryzen 3 1200",
+        "Benchmark": "6,263"
+    },
+    {
+        "CPU": "AMD Ryzen 3 1300X",
+        "Benchmark": "6,944"
+    },
+    {
+        "CPU": "AMD Ryzen 3 210",
+        "Benchmark": "13,211"
+    },
+    {
+        "CPU": "AMD Ryzen 3 2200G",
+        "Benchmark": "6,747"
+    },
+    {
+        "CPU": "AMD Ryzen 3 2200GE",
+        "Benchmark": "5,875"
+    },
+    {
+        "CPU": "AMD Ryzen 3 2200U",
+        "Benchmark": "3,668"
+    },
+    {
+        "CPU": "AMD Ryzen 3 2300U",
+        "Benchmark": "5,506"
+    },
+    {
+        "CPU": "AMD Ryzen 3 2300X",
+        "Benchmark": "7,598"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3100",
+        "Benchmark": "11,563"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3200G",
+        "Benchmark": "7,046"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3200GE",
+        "Benchmark": "7,289"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3200U",
+        "Benchmark": "3,749"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3250C",
+        "Benchmark": "3,153"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3250U",
+        "Benchmark": "3,748"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3300U",
+        "Benchmark": "5,649"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3300X",
+        "Benchmark": "12,596"
+    },
+    {
+        "CPU": "AMD Ryzen 3 3350U",
+        "Benchmark": "5,779"
+    },
+    {
+        "CPU": "AMD Ryzen 3 4100",
+        "Benchmark": "11,052"
+    },
+    {
+        "CPU": "AMD Ryzen 3 4300G",
+        "Benchmark": "9,867"
+    },
+    {
+        "CPU": "AMD Ryzen 3 4300GE",
+        "Benchmark": "11,25"
+    },
+    {
+        "CPU": "AMD Ryzen 3 4300U",
+        "Benchmark": "7,368"
+    },
+    {
+        "CPU": "AMD Ryzen 3 5300G",
+        "Benchmark": "13,044"
+    },
+    {
+        "CPU": "AMD Ryzen 3 5300GE",
+        "Benchmark": "12,856"
+    },
+    {
+        "CPU": "AMD Ryzen 3 5300U",
+        "Benchmark": "9,612"
+    },
+    {
+        "CPU": "AMD Ryzen 3 5400U",
+        "Benchmark": "11,006"
+    },
+    {
+        "CPU": "AMD Ryzen 3 5425U",
+        "Benchmark": "11,185"
+    },
+    {
+        "CPU": "AMD Ryzen 3 7320C",
+        "Benchmark": "8,265"
+    },
+    {
+        "CPU": "AMD Ryzen 3 7320U",
+        "Benchmark": "8,677"
+    },
+    {
+        "CPU": "AMD Ryzen 3 7330U",
+        "Benchmark": "10,889"
+    },
+    {
+        "CPU": "AMD Ryzen 3 7335U",
+        "Benchmark": "12,54"
+    },
+    {
+        "CPU": "AMD Ryzen 3 7440U",
+        "Benchmark": "12,991"
+    },
+    {
+        "CPU": "AMD Ryzen 3 8300G",
+        "Benchmark": "14,374"
+    },
+    {
+        "CPU": "AMD Ryzen 3 8300GE",
+        "Benchmark": "13,846"
+    },
+    {
+        "CPU": "AMD Ryzen 3 8440U",
+        "Benchmark": "12,805"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 1200",
+        "Benchmark": "5,808"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 1300",
+        "Benchmark": "7,234"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 2100GE",
+        "Benchmark": "4,07"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 2200G",
+        "Benchmark": "6,623"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 2200GE",
+        "Benchmark": "6,423"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 2300U",
+        "Benchmark": "5,648"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 3200G",
+        "Benchmark": "6,457"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 3200GE",
+        "Benchmark": "6,864"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 3300U",
+        "Benchmark": "5,951"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 4200G",
+        "Benchmark": "10,831"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 4200GE",
+        "Benchmark": "10,93"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 4350G",
+        "Benchmark": "10,931"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 4350GE",
+        "Benchmark": "10,926"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 4355GE",
+        "Benchmark": "10,559"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 4450U",
+        "Benchmark": "9,709"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 5350G",
+        "Benchmark": "13,793"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 5350GE",
+        "Benchmark": "12,637"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 5355GE",
+        "Benchmark": "12,761"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 5450U",
+        "Benchmark": "11,044"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 5475U",
+        "Benchmark": "11,381"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 7330U",
+        "Benchmark": "12,474"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 7335U",
+        "Benchmark": "12,325"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 8300G",
+        "Benchmark": "14,539"
+    },
+    {
+        "CPU": "AMD Ryzen 3 PRO 8300GE",
+        "Benchmark": "14,719"
+    },
+    {
+        "CPU": "AMD Ryzen 5 1400",
+        "Benchmark": "7,735"
+    },
+    {
+        "CPU": "AMD Ryzen 5 1500X",
+        "Benchmark": "9,089"
+    },
+    {
+        "CPU": "AMD Ryzen 5 1600",
+        "Benchmark": "12,275"
+    },
+    {
+        "CPU": "AMD Ryzen 5 1600X",
+        "Benchmark": "13,035"
+    },
+    {
+        "CPU": "AMD Ryzen 5 220",
+        "Benchmark": "19,068"
+    },
+    {
+        "CPU": "AMD Ryzen 5 230",
+        "Benchmark": "19,681"
+    },
+    {
+        "CPU": "AMD Ryzen 5 240",
+        "Benchmark": "21,572"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2400G",
+        "Benchmark": "8,738"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2400GE",
+        "Benchmark": "7,289"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2500U",
+        "Benchmark": "6,513"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2500X",
+        "Benchmark": "9,455"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2600",
+        "Benchmark": "13,166"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2600E",
+        "Benchmark": "11,771"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2600H",
+        "Benchmark": "8,002"
+    },
+    {
+        "CPU": "AMD Ryzen 5 2600X",
+        "Benchmark": "13,893"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3350G",
+        "Benchmark": "8,97"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3350GE",
+        "Benchmark": "9,276"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3400G",
+        "Benchmark": "9,218"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3400GE",
+        "Benchmark": "8,848"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3450U",
+        "Benchmark": "6,699"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3500",
+        "Benchmark": "12,791"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3500C",
+        "Benchmark": "5,602"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3500U",
+        "Benchmark": "6,866"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3500X",
+        "Benchmark": "13,16"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3550H",
+        "Benchmark": "7,749"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3550U",
+        "Benchmark": "7,681"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3580U",
+        "Benchmark": "7,079"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3600",
+        "Benchmark": "17,707"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3600X",
+        "Benchmark": "18,164"
+    },
+    {
+        "CPU": "AMD Ryzen 5 3600XT",
+        "Benchmark": "18,572"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4400G",
+        "Benchmark": "17,16"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4500",
+        "Benchmark": "16,111"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4500U",
+        "Benchmark": "10,798"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4600G",
+        "Benchmark": "16,004"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4600GE",
+        "Benchmark": "15,82"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4600H",
+        "Benchmark": "14,282"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4600HS",
+        "Benchmark": "14,297"
+    },
+    {
+        "CPU": "AMD Ryzen 5 4600U",
+        "Benchmark": "13,407"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5500",
+        "Benchmark": "19,345"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5500GT",
+        "Benchmark": "19,502"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5500H",
+        "Benchmark": "11,436"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5500U",
+        "Benchmark": "12,866"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5560U",
+        "Benchmark": "15,237"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600",
+        "Benchmark": "21,557"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600G",
+        "Benchmark": "19,786"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600GE",
+        "Benchmark": "18,359"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600GT",
+        "Benchmark": "20,328"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600H",
+        "Benchmark": "16,751"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600T",
+        "Benchmark": "22,038"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600U",
+        "Benchmark": "15,237"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600X",
+        "Benchmark": "21,862"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600X3D",
+        "Benchmark": "21,858"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5600XT",
+        "Benchmark": "22,187"
+    },
+    {
+        "CPU": "AMD Ryzen 5 5625U",
+        "Benchmark": "14,838"
+    },
+    {
+        "CPU": "AMD Ryzen 5 6600H",
+        "Benchmark": "18,682"
+    },
+    {
+        "CPU": "AMD Ryzen 5 6600HS Creator Edition",
+        "Benchmark": "18,109"
+    },
+    {
+        "CPU": "AMD Ryzen 5 6600U",
+        "Benchmark": "16,606"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7235HS",
+        "Benchmark": "12,297"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7400F",
+        "Benchmark": "25,696"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7430U",
+        "Benchmark": "16,936"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7500F",
+        "Benchmark": "26,838"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7520U",
+        "Benchmark": "9,137"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7530U",
+        "Benchmark": "15,547"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7533HS",
+        "Benchmark": "14,246"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7535HS",
+        "Benchmark": "18,006"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7535U",
+        "Benchmark": "17,138"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7540U",
+        "Benchmark": "18,624"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7600",
+        "Benchmark": "27,057"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7600X",
+        "Benchmark": "28,419"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7600X3D",
+        "Benchmark": "25,623"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7640HS",
+        "Benchmark": "23,03"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7640U",
+        "Benchmark": "21,124"
+    },
+    {
+        "CPU": "AMD Ryzen 5 7645HX",
+        "Benchmark": "26,476"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8400F",
+        "Benchmark": "24,581"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8500G",
+        "Benchmark": "21,631"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8500GE",
+        "Benchmark": "20,993"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8540U",
+        "Benchmark": "18,426"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8600G",
+        "Benchmark": "25,373"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8640HS",
+        "Benchmark": "19,976"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8640U",
+        "Benchmark": "20,253"
+    },
+    {
+        "CPU": "AMD Ryzen 5 8645HS",
+        "Benchmark": "22,648"
+    },
+    {
+        "CPU": "AMD Ryzen 5 9600",
+        "Benchmark": "29,422"
+    },
+    {
+        "CPU": "AMD Ryzen 5 9600X",
+        "Benchmark": "29,982"
+    },
+    {
+        "CPU": "AMD Ryzen 5 Microsoft Surface Edition",
+        "Benchmark": "7,243"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 1500",
+        "Benchmark": "9,142"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 1600",
+        "Benchmark": "11,823"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 230",
+        "Benchmark": "20,87"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 2400G",
+        "Benchmark": "8,563"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 2400GE",
+        "Benchmark": "7,756"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 2500U",
+        "Benchmark": "6,627"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 2600",
+        "Benchmark": "13,436"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 3350G",
+        "Benchmark": "9,198"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 3350GE",
+        "Benchmark": "9,643"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 3400G",
+        "Benchmark": "9,105"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 3400GE",
+        "Benchmark": "7,718"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 3500U",
+        "Benchmark": "7"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 3600",
+        "Benchmark": "17,201"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4400G",
+        "Benchmark": "16,365"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4400GE",
+        "Benchmark": "14,795"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4500U",
+        "Benchmark": "12,117"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4650G",
+        "Benchmark": "16,123"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4650GE",
+        "Benchmark": "15,374"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4650U",
+        "Benchmark": "12,315"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4655G",
+        "Benchmark": "16,347"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 4655GE",
+        "Benchmark": "14,436"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5645",
+        "Benchmark": "21,904"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5650G",
+        "Benchmark": "20,657"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5650GE",
+        "Benchmark": "18,281"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5650U",
+        "Benchmark": "14,613"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5655G",
+        "Benchmark": "20,548"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5655GE",
+        "Benchmark": "18,241"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 5675U",
+        "Benchmark": "14,418"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 6650H",
+        "Benchmark": "17,749"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 6650U",
+        "Benchmark": "16,466"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 7530U",
+        "Benchmark": "14,34"
+    },
+    {
+        "CPU": "AMD Ryzen 5 Pro 7535U",
+        "Benchmark": "16,86"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 7540U",
+        "Benchmark": "17,828"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 7545U",
+        "Benchmark": "19,626"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 7640HS",
+        "Benchmark": "22,638"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 7640U",
+        "Benchmark": "21,287"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 7645",
+        "Benchmark": "22,446"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8500G",
+        "Benchmark": "22,001"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8500GE",
+        "Benchmark": "21,817"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8540U",
+        "Benchmark": "18,226"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8600G",
+        "Benchmark": "24,821"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8600GE",
+        "Benchmark": "23,938"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8640HS",
+        "Benchmark": "21,268"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8640U",
+        "Benchmark": "23,509"
+    },
+    {
+        "CPU": "AMD Ryzen 5 PRO 8645HS",
+        "Benchmark": "23,227"
+    },
+    {
+        "CPU": "AMD Ryzen 7 1700",
+        "Benchmark": "14,796"
+    },
+    {
+        "CPU": "AMD Ryzen 7 1700X",
+        "Benchmark": "15,659"
+    },
+    {
+        "CPU": "AMD Ryzen 7 1800X",
+        "Benchmark": "16,326"
+    },
+    {
+        "CPU": "AMD Ryzen 7 250",
+        "Benchmark": "23,552"
+    },
+    {
+        "CPU": "AMD Ryzen 7 260",
+        "Benchmark": "32"
+    },
+    {
+        "CPU": "AMD Ryzen 7 2700",
+        "Benchmark": "15,67"
+    },
+    {
+        "CPU": "AMD Ryzen 7 2700E",
+        "Benchmark": "14,657"
+    },
+    {
+        "CPU": "AMD Ryzen 7 2700U",
+        "Benchmark": "6,828"
+    },
+    {
+        "CPU": "AMD Ryzen 7 2700X",
+        "Benchmark": "17,486"
+    },
+    {
+        "CPU": "AMD Ryzen 7 2800H",
+        "Benchmark": "8,144"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3700C",
+        "Benchmark": "6,682"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3700U",
+        "Benchmark": "7,091"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3700X",
+        "Benchmark": "22,476"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3750H",
+        "Benchmark": "8,047"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3780U",
+        "Benchmark": "6,958"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3800X",
+        "Benchmark": "23,059"
+    },
+    {
+        "CPU": "AMD Ryzen 7 3800XT",
+        "Benchmark": "23,552"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4700G",
+        "Benchmark": "20,142"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4700GE",
+        "Benchmark": "19,674"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4700U",
+        "Benchmark": "13,231"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4800H",
+        "Benchmark": "18,278"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4800HS",
+        "Benchmark": "18,128"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4800U",
+        "Benchmark": "16,637"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4850U Mobile",
+        "Benchmark": "17,11"
+    },
+    {
+        "CPU": "AMD Ryzen 7 4980U Microsoft Surface Edition",
+        "Benchmark": "17,469"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5700",
+        "Benchmark": "24,275"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5700G",
+        "Benchmark": "24,443"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5700GE",
+        "Benchmark": "22,028"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5700U",
+        "Benchmark": "15,671"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5700X",
+        "Benchmark": "26,634"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5700X3D",
+        "Benchmark": "26,321"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800",
+        "Benchmark": "25,813"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800H",
+        "Benchmark": "20,855"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800HS",
+        "Benchmark": "19,737"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800HS Creator Edition",
+        "Benchmark": "21,166"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800U",
+        "Benchmark": "18,249"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800X",
+        "Benchmark": "27,76"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800X3D",
+        "Benchmark": "28,304"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5800XT",
+        "Benchmark": "28,036"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5825C",
+        "Benchmark": "14,561"
+    },
+    {
+        "CPU": "AMD Ryzen 7 5825U",
+        "Benchmark": "18,215"
+    },
+    {
+        "CPU": "AMD Ryzen 7 6800H",
+        "Benchmark": "23,136"
+    },
+    {
+        "CPU": "AMD Ryzen 7 6800HS",
+        "Benchmark": "22,773"
+    },
+    {
+        "CPU": "AMD Ryzen 7 6800HS Creator Edition",
+        "Benchmark": "21,562"
+    },
+    {
+        "CPU": "AMD Ryzen 7 6800U",
+        "Benchmark": "20,29"
+    },
+    {
+        "CPU": "AMD Ryzen 7 6810U",
+        "Benchmark": "22,741"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7435H",
+        "Benchmark": "24,482"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7435HS",
+        "Benchmark": "23,439"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7700",
+        "Benchmark": "34,458"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7700X",
+        "Benchmark": "35,821"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7730U",
+        "Benchmark": "18,16"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7735H",
+        "Benchmark": "23,807"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7735HS",
+        "Benchmark": "23,287"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7735U",
+        "Benchmark": "20,892"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7736U",
+        "Benchmark": "21,725"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7745HX",
+        "Benchmark": "32,624"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7800X3D",
+        "Benchmark": "34,237"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7840H",
+        "Benchmark": "27,951"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7840HS",
+        "Benchmark": "28,752"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7840HX",
+        "Benchmark": "42,491"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7840S",
+        "Benchmark": "23,637"
+    },
+    {
+        "CPU": "AMD Ryzen 7 7840U",
+        "Benchmark": "24,892"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8700F",
+        "Benchmark": "31,357"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8700G",
+        "Benchmark": "31,706"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8745H",
+        "Benchmark": "30,011"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8745HS",
+        "Benchmark": "29,199"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8840HS",
+        "Benchmark": "24,822"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8840U",
+        "Benchmark": "23,42"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8845H",
+        "Benchmark": "27,009"
+    },
+    {
+        "CPU": "AMD Ryzen 7 8845HS",
+        "Benchmark": "28,538"
+    },
+    {
+        "CPU": "AMD Ryzen 7 9700X",
+        "Benchmark": "37,196"
+    },
+    {
+        "CPU": "AMD Ryzen 7 9800X3D",
+        "Benchmark": "40,012"
+    },
+    {
+        "CPU": "AMD Ryzen 7 Extreme Edition",
+        "Benchmark": "16,224"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 1700",
+        "Benchmark": "14,696"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 1700X",
+        "Benchmark": "15,625"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 250",
+        "Benchmark": "22,971"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 2700",
+        "Benchmark": "15,36"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 2700U",
+        "Benchmark": "6,994"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 2700X",
+        "Benchmark": "16,949"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 3700",
+        "Benchmark": "22,83"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 3700U",
+        "Benchmark": "7,34"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 4700G",
+        "Benchmark": "19,439"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 4750G",
+        "Benchmark": "20,322"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 4750GE",
+        "Benchmark": "18,472"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 4750U",
+        "Benchmark": "14,973"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5750G",
+        "Benchmark": "24,186"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5750GE",
+        "Benchmark": "21,554"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5755GE",
+        "Benchmark": "20,894"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5800H",
+        "Benchmark": "19,313"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5845",
+        "Benchmark": "26,043"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5850U",
+        "Benchmark": "17,199"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 5875U",
+        "Benchmark": "16,501"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 6850H",
+        "Benchmark": "23,395"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 6850HS",
+        "Benchmark": "22,33"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 6850U",
+        "Benchmark": "20,778"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 6860Z",
+        "Benchmark": "20,509"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 7730U",
+        "Benchmark": "18,367"
+    },
+    {
+        "CPU": "AMD Ryzen 7 Pro 7735U",
+        "Benchmark": "19,108"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 7745",
+        "Benchmark": "33,662"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 7840HS",
+        "Benchmark": "26,824"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 7840U",
+        "Benchmark": "24,613"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 8700G",
+        "Benchmark": "31,046"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 8700GE",
+        "Benchmark": "28,192"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 8840HS",
+        "Benchmark": "27,056"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 8840U",
+        "Benchmark": "23,824"
+    },
+    {
+        "CPU": "AMD Ryzen 7 PRO 8845HS",
+        "Benchmark": "29,234"
+    },
+    {
+        "CPU": "AMD Ryzen 9 3900",
+        "Benchmark": "30,654"
+    },
+    {
+        "CPU": "AMD Ryzen 9 3900X",
+        "Benchmark": "32,561"
+    },
+    {
+        "CPU": "AMD Ryzen 9 3900XT",
+        "Benchmark": "32,591"
+    },
+    {
+        "CPU": "AMD Ryzen 9 3950X",
+        "Benchmark": "38,617"
+    },
+    {
+        "CPU": "AMD Ryzen 9 4900H",
+        "Benchmark": "19,034"
+    },
+    {
+        "CPU": "AMD Ryzen 9 4900HS",
+        "Benchmark": "18,88"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900",
+        "Benchmark": "33,992"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900H",
+        "Benchmark": "20,557"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900HS",
+        "Benchmark": "21,393"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900HS Creator Edition",
+        "Benchmark": "20,691"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900HX",
+        "Benchmark": "22,372"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900X",
+        "Benchmark": "39,029"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5900XT",
+        "Benchmark": "44,008"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5950X",
+        "Benchmark": "45,456"
+    },
+    {
+        "CPU": "[5-Way CPU] AMD Ryzen 9 5950X",
+        "Benchmark": "13,22"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5980HS",
+        "Benchmark": "20,443"
+    },
+    {
+        "CPU": "AMD Ryzen 9 5980HX",
+        "Benchmark": "23,459"
+    },
+    {
+        "CPU": "AMD Ryzen 9 6900HS",
+        "Benchmark": "23,237"
+    },
+    {
+        "CPU": "AMD Ryzen 9 6900HS Creator Edition",
+        "Benchmark": "21,489"
+    },
+    {
+        "CPU": "AMD Ryzen 9 6900HX",
+        "Benchmark": "24,409"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7845HX",
+        "Benchmark": "45,235"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7900",
+        "Benchmark": "48,455"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7900X",
+        "Benchmark": "51,448"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7900X3D",
+        "Benchmark": "50,334"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7940H",
+        "Benchmark": "28,6"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7940HS",
+        "Benchmark": "30,124"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7940HX",
+        "Benchmark": "54,369"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7945HX",
+        "Benchmark": "54,691"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7945HX3D",
+        "Benchmark": "57,807"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7950X",
+        "Benchmark": "62,524"
+    },
+    {
+        "CPU": "AMD Ryzen 9 7950X3D",
+        "Benchmark": "62,433"
+    },
+    {
+        "CPU": "AMD Ryzen 9 8940HX",
+        "Benchmark": "55,027"
+    },
+    {
+        "CPU": "AMD Ryzen 9 8945H",
+        "Benchmark": "30,176"
+    },
+    {
+        "CPU": "AMD Ryzen 9 8945HS",
+        "Benchmark": "29,83"
+    },
+    {
+        "CPU": "AMD Ryzen 9 8945HX",
+        "Benchmark": "55,262"
+    },
+    {
+        "CPU": "AMD Ryzen 9 9900X",
+        "Benchmark": "54,721"
+    },
+    {
+        "CPU": "AMD Ryzen 9 9900X3D",
+        "Benchmark": "56,52"
+    },
+    {
+        "CPU": "AMD Ryzen 9 9950X",
+        "Benchmark": "66,112"
+    },
+    {
+        "CPU": "AMD Ryzen 9 9950X3D",
+        "Benchmark": "70,396"
+    },
+    {
+        "CPU": "AMD Ryzen 9 9955HX",
+        "Benchmark": "59,47"
+    },
+    {
+        "CPU": "AMD Ryzen 9 9955HX3D",
+        "Benchmark": "60,253"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 3900",
+        "Benchmark": "31,346"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 5945",
+        "Benchmark": "34,549"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 6950H",
+        "Benchmark": "23,737"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 6950HS",
+        "Benchmark": "22,778"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 7940HS",
+        "Benchmark": "28,059"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 7945",
+        "Benchmark": "46,256"
+    },
+    {
+        "CPU": "AMD Ryzen 9 PRO 8945HS",
+        "Benchmark": "29,261"
+    },
+    {
+        "CPU": "AMD Ryzen AI 5 340",
+        "Benchmark": "20,377"
+    },
+    {
+        "CPU": "AMD Ryzen AI 5 PRO 340",
+        "Benchmark": "19,105"
+    },
+    {
+        "CPU": "AMD Ryzen AI 7 350",
+        "Benchmark": "24,515"
+    },
+    {
+        "CPU": "AMD Ryzen AI 7 H 350",
+        "Benchmark": "28,847"
+    },
+    {
+        "CPU": "AMD Ryzen AI 7 PRO 350",
+        "Benchmark": "24,301"
+    },
+    {
+        "CPU": "AMD Ryzen AI 7 PRO 360",
+        "Benchmark": "21,189"
+    },
+    {
+        "CPU": "AMD Ryzen AI 9 365",
+        "Benchmark": "29,263"
+    },
+    {
+        "CPU": "AMD Ryzen AI 9 HX 370",
+        "Benchmark": "35,142"
+    },
+    {
+        "CPU": "AMD Ryzen AI 9 HX 375",
+        "Benchmark": "32,22"
+    },
+    {
+        "CPU": "AMD Ryzen AI 9 HX PRO 370",
+        "Benchmark": "30,832"
+    },
+    {
+        "CPU": "AMD Ryzen AI 9 HX PRO 375",
+        "Benchmark": "33,238"
+    },
+    {
+        "CPU": "AMD Ryzen AI Max 385",
+        "Benchmark": "18,441"
+    },
+    {
+        "CPU": "AMD Ryzen AI Max 390",
+        "Benchmark": "45,95"
+    },
+    {
+        "CPU": "AMD Ryzen AI Max Pro 385",
+        "Benchmark": "32,05"
+    },
+    {
+        "CPU": "AMD Ryzen AI Max Pro 390",
+        "Benchmark": "43,847"
+    },
+    {
+        "CPU": "AMD Ryzen AI Max+ 395",
+        "Benchmark": "51,903"
+    },
+    {
+        "CPU": "AMD Ryzen AI Max+ Pro 395",
+        "Benchmark": "50,707"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R1305G",
+        "Benchmark": "3,073"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R1505G",
+        "Benchmark": "3,791"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R1600",
+        "Benchmark": "3,276"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R1606G",
+        "Benchmark": "4,153"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R2312",
+        "Benchmark": "3,919"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R2314",
+        "Benchmark": "5,757"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R2514",
+        "Benchmark": "7,102"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded R2544",
+        "Benchmark": "8,486"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1202B",
+        "Benchmark": "3,512"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1404I",
+        "Benchmark": "6,007"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1500B",
+        "Benchmark": "4,566"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1605B",
+        "Benchmark": "6,715"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1756B",
+        "Benchmark": "8,046"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1780B",
+        "Benchmark": "6,219"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1807B",
+        "Benchmark": "8,182"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V1807F",
+        "Benchmark": "7,775"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V2516",
+        "Benchmark": "13,329"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V2546",
+        "Benchmark": "9,656"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V2718",
+        "Benchmark": "15,761"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V2748",
+        "Benchmark": "18,434"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V3C14",
+        "Benchmark": "11,882"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V3C18I",
+        "Benchmark": "13,856"
+    },
+    {
+        "CPU": "AMD Ryzen Embedded V3C48",
+        "Benchmark": "20,203"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 1900X",
+        "Benchmark": "16,806"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 1920",
+        "Benchmark": "22,066"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 1920X",
+        "Benchmark": "23,113"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 1950X",
+        "Benchmark": "27,618"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 2920X",
+        "Benchmark": "25,235"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 2950X",
+        "Benchmark": "29,509"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 2970WX",
+        "Benchmark": "31,026"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 2990WX",
+        "Benchmark": "32,091"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 2990X",
+        "Benchmark": "25,874"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 3960X",
+        "Benchmark": "54,773"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 3970X",
+        "Benchmark": "63,138"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 3990X",
+        "Benchmark": "80,297"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 7960X",
+        "Benchmark": "83,681"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 7970X",
+        "Benchmark": "98,544"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper 7980X",
+        "Benchmark": "136,185"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 3945WX",
+        "Benchmark": "33,501"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 3955WX",
+        "Benchmark": "40,16"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Ryzen Threadripper PRO 3955WX",
+        "Benchmark": "63,885"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 3975WX",
+        "Benchmark": "62,374"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Ryzen Threadripper PRO 3975WX",
+        "Benchmark": "98,811"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 3995WX",
+        "Benchmark": "83,563"
+    },
+    {
+        "CPU": "[Dual CPU] AMD Ryzen Threadripper PRO 3995WX",
+        "Benchmark": "113,693"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 5945WX",
+        "Benchmark": "40,322"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 5955WX",
+        "Benchmark": "49,215"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 5965WX",
+        "Benchmark": "66,521"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 5975WX",
+        "Benchmark": "75,606"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 5995WX",
+        "Benchmark": "95,201"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 7945WX",
+        "Benchmark": "49,532"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 7955WX",
+        "Benchmark": "59,913"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 7965WX",
+        "Benchmark": "81,923"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 7975WX",
+        "Benchmark": "96,022"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 7985WX",
+        "Benchmark": "134,341"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 7995WX",
+        "Benchmark": "145,42"
+    },
+    {
+        "CPU": "AMD Ryzen Threadripper PRO 9995WX",
+        "Benchmark": "70,438"
+    },
+    {
+        "CPU": "AMD Ryzen Z1",
+        "Benchmark": "18,411"
+    },
+    {
+        "CPU": "AMD Ryzen Z1 Extreme",
+        "Benchmark": "25,004"
+    },
+    {
+        "CPU": "AMD Ryzen Z2 Go",
+        "Benchmark": "12,253"
+    },
+    {
+        "CPU": "AMD Sempron 130",
+        "Benchmark": "511"
+    },
+    {
+        "CPU": "AMD Sempron 140",
+        "Benchmark": "498"
+    },
+    {
+        "CPU": "AMD Sempron 145",
+        "Benchmark": "532"
+    },
+    {
+        "CPU": "AMD Sempron 150",
+        "Benchmark": "597"
+    },
+    {
+        "CPU": "AMD Sempron 200U",
+        "Benchmark": "125"
+    },
+    {
+        "CPU": "AMD Sempron 210U",
+        "Benchmark": "267"
+    },
+    {
+        "CPU": "AMD Sempron 2200+",
+        "Benchmark": "184"
+    },
+    {
+        "CPU": "AMD Sempron 2300+",
+        "Benchmark": "207"
+    },
+    {
+        "CPU": "AMD Sempron 240",
+        "Benchmark": "1,278"
+    },
+    {
+        "CPU": "AMD Sempron 2400+",
+        "Benchmark": "205"
+    },
+    {
+        "CPU": "AMD Sempron 2500+",
+        "Benchmark": "207"
+    },
+    {
+        "CPU": "AMD Sempron 2600+",
+        "Benchmark": "253"
+    },
+    {
+        "CPU": "AMD Sempron 2650 APU",
+        "Benchmark": "551"
+    },
+    {
+        "CPU": "AMD Sempron 2800+",
+        "Benchmark": "243"
+    },
+    {
+        "CPU": "AMD Sempron 3000+",
+        "Benchmark": "299"
+    },
+    {
+        "CPU": "AMD Sempron 3100+",
+        "Benchmark": "298"
+    },
+    {
+        "CPU": "AMD Sempron 3200+",
+        "Benchmark": "251"
+    },
+    {
+        "CPU": "AMD Sempron 3300+",
+        "Benchmark": "315"
+    },
+    {
+        "CPU": "AMD Sempron 3400+",
+        "Benchmark": "292"
+    },
+    {
+        "CPU": "AMD Sempron 3500+",
+        "Benchmark": "232"
+    },
+    {
+        "CPU": "AMD Sempron 3600+",
+        "Benchmark": "364"
+    },
+    {
+        "CPU": "AMD Sempron 3800+",
+        "Benchmark": "360"
+    },
+    {
+        "CPU": "AMD Sempron 3850 APU",
+        "Benchmark": "1,174"
+    },
+    {
+        "CPU": "AMD Sempron Dual Core 2100",
+        "Benchmark": "506"
+    },
+    {
+        "CPU": "AMD Sempron Dual Core 2200",
+        "Benchmark": "563"
+    },
+    {
+        "CPU": "AMD Sempron Dual Core 2300",
+        "Benchmark": "555"
+    },
+    {
+        "CPU": "AMD Sempron LE-1100",
+        "Benchmark": "315"
+    },
+    {
+        "CPU": "AMD Sempron LE-1150",
+        "Benchmark": "251"
+    },
+    {
+        "CPU": "AMD Sempron LE-1200",
+        "Benchmark": "349"
+    },
+    {
+        "CPU": "AMD Sempron LE-1250",
+        "Benchmark": "301"
+    },
+    {
+        "CPU": "AMD Sempron LE-1300",
+        "Benchmark": "417"
+    },
+    {
+        "CPU": "AMD Sempron M100",
+        "Benchmark": "332"
+    },
+    {
+        "CPU": "AMD Sempron M120",
+        "Benchmark": "281"
+    },
+    {
+        "CPU": "AMD Sempron SI-40",
+        "Benchmark": "288"
+    },
+    {
+        "CPU": "AMD Sempron SI-42",
+        "Benchmark": "245"
+    },
+    {
+        "CPU": "AMD Sempron X2 180",
+        "Benchmark": "826"
+    },
+    {
+        "CPU": "AMD Sempron X2 190",
+        "Benchmark": "879"
+    },
+    {
+        "CPU": "AMD Sempron X2 198 Dual-Core",
+        "Benchmark": "930"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile MK-36",
+        "Benchmark": "334"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile MK-38",
+        "Benchmark": "362"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-28",
+        "Benchmark": "254"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-30",
+        "Benchmark": "277"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-32",
+        "Benchmark": "285"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-34",
+        "Benchmark": "319"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-37",
+        "Benchmark": "334"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-40",
+        "Benchmark": "336"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-42",
+        "Benchmark": "400"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile ML-44",
+        "Benchmark": "384"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile MT-30",
+        "Benchmark": "246"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile MT-32",
+        "Benchmark": "286"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile MT-34",
+        "Benchmark": "279"
+    },
+    {
+        "CPU": "AMD Turion 64 Mobile MT-37",
+        "Benchmark": "274"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-50",
+        "Benchmark": "474"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-52",
+        "Benchmark": "534"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-56",
+        "Benchmark": "514"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-58",
+        "Benchmark": "483"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-60",
+        "Benchmark": "635"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-62",
+        "Benchmark": "649"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-64",
+        "Benchmark": "675"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-66",
+        "Benchmark": "716"
+    },
+    {
+        "CPU": "AMD Turion 64 X2 Mobile TL-68",
+        "Benchmark": "866"
+    },
+    {
+        "CPU": "AMD Turion Dual-Core RM-70",
+        "Benchmark": "561"
+    },
+    {
+        "CPU": "AMD Turion Dual-Core RM-72",
+        "Benchmark": "649"
+    },
+    {
+        "CPU": "AMD Turion Dual-Core RM-74",
+        "Benchmark": "588"
+    },
+    {
+        "CPU": "AMD Turion Dual-Core RM-75",
+        "Benchmark": "659"
+    },
+    {
+        "CPU": "AMD Turion II Dual-Core Mobile M500",
+        "Benchmark": "756"
+    },
+    {
+        "CPU": "AMD Turion II Dual-Core Mobile M520",
+        "Benchmark": "855"
+    },
+    {
+        "CPU": "AMD Turion II Dual-Core Mobile M540",
+        "Benchmark": "912"
+    },
+    {
+        "CPU": "AMD Turion II N530 Dual-Core",
+        "Benchmark": "855"
+    },
+    {
+        "CPU": "AMD Turion II N550 Dual-Core",
+        "Benchmark": "877"
+    },
+    {
+        "CPU": "AMD Turion II Neo K625 Dual-Core",
+        "Benchmark": "618"
+    },
+    {
+        "CPU": "AMD Turion II Neo K685 Dual-Core",
+        "Benchmark": "684"
+    },
+    {
+        "CPU": "AMD Turion II Neo N40L Dual-Core",
+        "Benchmark": "617"
+    },
+    {
+        "CPU": "AMD Turion II Neo N54L Dual-Core",
+        "Benchmark": "853"
+    },
+    {
+        "CPU": "AMD Turion II P520 Dual-Core",
+        "Benchmark": "844"
+    },
+    {
+        "CPU": "AMD Turion II P540 Dual-Core",
+        "Benchmark": "919"
+    },
+    {
+        "CPU": "AMD Turion II P560 Dual-Core",
+        "Benchmark": "913"
+    },
+    {
+        "CPU": "AMD Turion II Ultra Dual-Core Mobile M600",
+        "Benchmark": "955"
+    },
+    {
+        "CPU": "AMD Turion II Ultra Dual-Core Mobile M620",
+        "Benchmark": "814"
+    },
+    {
+        "CPU": "AMD Turion II Ultra Dual-Core Mobile M640",
+        "Benchmark": "1,034"
+    },
+    {
+        "CPU": "AMD Turion II Ultra Dual-Core Mobile M660",
+        "Benchmark": "1,011"
+    },
+    {
+        "CPU": "AMD Turion Neo X2 Dual Core L625",
+        "Benchmark": "432"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual Core L510",
+        "Benchmark": "603"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual Core Mobile RM-70",
+        "Benchmark": "497"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual Core Mobile RM-76",
+        "Benchmark": "691"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual-Core Mobile RM-70",
+        "Benchmark": "612"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual-Core Mobile RM-72",
+        "Benchmark": "653"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual-Core Mobile RM-74",
+        "Benchmark": "655"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual-Core Mobile RM-75",
+        "Benchmark": "727"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual-Core Mobile RM-76",
+        "Benchmark": "799"
+    },
+    {
+        "CPU": "AMD Turion X2 Dual-Core Mobile RM-77",
+        "Benchmark": "562"
+    },
+    {
+        "CPU": "AMD Turion X2 Ultra Dual-Core Mobile ZM-80",
+        "Benchmark": "506"
+    },
+    {
+        "CPU": "AMD Turion X2 Ultra Dual-Core Mobile ZM-82",
+        "Benchmark": "645"
+    },
+    {
+        "CPU": "AMD Turion X2 Ultra Dual-Core Mobile ZM-84",
+        "Benchmark": "802"
+    },
+    {
+        "CPU": "AMD Turion X2 Ultra Dual-Core Mobile ZM-85",
+        "Benchmark": "828"
+    },
+    {
+        "CPU": "AMD Turion X2 Ultra Dual-Core Mobile ZM-86",
+        "Benchmark": "695"
+    },
+    {
+        "CPU": "AMD Turion X2 Ultra Dual-Core Mobile ZM-87",
+        "Benchmark": "741"
+    },
+    {
+        "CPU": "AMD TurionX2 Dual Core Mobile RM-70",
+        "Benchmark": "536"
+    },
+    {
+        "CPU": "AMD TurionX2 Dual Core Mobile RM-72",
+        "Benchmark": "471"
+    },
+    {
+        "CPU": "AMD TurionX2 Ultra DualCore Mobile ZM-85",
+        "Benchmark": "841"
+    },
+    {
+        "CPU": "AMD TurionX2 Ultra DualCore Mobile ZM-87",
+        "Benchmark": "599"
+    },
+    {
+        "CPU": "AMD V105",
+        "Benchmark": "184"
+    },
+    {
+        "CPU": "AMD V120",
+        "Benchmark": "385"
+    },
+    {
+        "CPU": "AMD V140",
+        "Benchmark": "422"
+    },
+    {
+        "CPU": "AMD V160",
+        "Benchmark": "337"
+    },
+    {
+        "CPU": "AMD Z-01",
+        "Benchmark": "305"
+    },
+    {
+        "CPU": "AMD Z-60 APU",
+        "Benchmark": "262"
+    },
+    {
+        "CPU": "Amlogic",
+        "Benchmark": "650"
+    },
+    {
+        "CPU": "Amlogic AMLA311D2",
+        "Benchmark": "3,522"
+    },
+    {
+        "CPU": "Amlogic AMLS905D3",
+        "Benchmark": "815"
+    },
+    {
+        "CPU": "Amlogic AMLS905X2",
+        "Benchmark": "754"
+    },
+    {
+        "CPU": "Amlogic AMLS905X4",
+        "Benchmark": "500"
+    },
+    {
+        "CPU": "Amlogic AMLS905X5",
+        "Benchmark": "1,793"
+    },
+    {
+        "CPU": "Amlogic AMLT982",
+        "Benchmark": "972"
+    },
+    {
+        "CPU": "Ampere ARM - 192 Core 3200 MHz",
+        "Benchmark": "57,444"
+    },
+    {
+        "CPU": "ap201",
+        "Benchmark": "565"
+    },
+    {
+        "CPU": "Apple A11 Bionic",
+        "Benchmark": "4,43"
+    },
+    {
+        "CPU": "Apple A12 Bionic",
+        "Benchmark": "5,021"
+    },
+    {
+        "CPU": "Apple A12X Bionic",
+        "Benchmark": "11,08"
+    },
+    {
+        "CPU": "Apple A12Z Bionic",
+        "Benchmark": "9,365"
+    },
+    {
+        "CPU": "Apple A13 Bionic",
+        "Benchmark": "5,745"
+    },
+    {
+        "CPU": "Apple A14 Bionic",
+        "Benchmark": "8,557"
+    },
+    {
+        "CPU": "Apple A15 Bionic",
+        "Benchmark": "9,897"
+    },
+    {
+        "CPU": "Apple A16",
+        "Benchmark": "9,929"
+    },
+    {
+        "CPU": "Apple A16 Bionic",
+        "Benchmark": "10,994"
+    },
+    {
+        "CPU": "Apple A17 Pro",
+        "Benchmark": "12,235"
+    },
+    {
+        "CPU": "Apple A18",
+        "Benchmark": "12,433"
+    },
+    {
+        "CPU": "Apple A18 Pro",
+        "Benchmark": "12,911"
+    },
+    {
+        "CPU": "Apple A8",
+        "Benchmark": "1,525"
+    },
+    {
+        "CPU": "Apple A8X",
+        "Benchmark": "2,38"
+    },
+    {
+        "CPU": "Apple A9",
+        "Benchmark": "2,069"
+    },
+    {
+        "CPU": "Apple A9X",
+        "Benchmark": "2,518"
+    },
+    {
+        "CPU": "Apple M1 8 Core 3200 MHz",
+        "Benchmark": "14,145"
+    },
+    {
+        "CPU": "Apple M1 Max 10 Core 3200 MHz",
+        "Benchmark": "22,143"
+    },
+    {
+        "CPU": "Apple M1 Pro 10 Core 3200 MHz",
+        "Benchmark": "21,9"
+    },
+    {
+        "CPU": "Apple M1 Pro 8 Core 3200 MHz",
+        "Benchmark": "17,201"
+    },
+    {
+        "CPU": "Apple M1 Ultra 20 Core",
+        "Benchmark": "41,368"
+    },
+    {
+        "CPU": "Apple M2 8 Core 3500 MHz",
+        "Benchmark": "15,649"
+    },
+    {
+        "CPU": "Apple M2 Max 12 Core 3680 MHz",
+        "Benchmark": "26,767"
+    },
+    {
+        "CPU": "Apple M2 Pro 10 Core 3480 MHz",
+        "Benchmark": "21,855"
+    },
+    {
+        "CPU": "Apple M2 Pro 12 Core 3480 MHz",
+        "Benchmark": "26,649"
+    },
+    {
+        "CPU": "Apple M2 Ultra 24 Core",
+        "Benchmark": "50,685"
+    },
+    {
+        "CPU": "Apple M3 8 Core",
+        "Benchmark": "19,191"
+    },
+    {
+        "CPU": "Apple M3 Max 14 Core",
+        "Benchmark": "36,63"
+    },
+    {
+        "CPU": "Apple M3 Max 16 Core",
+        "Benchmark": "41,228"
+    },
+    {
+        "CPU": "Apple M3 Pro 11 Core",
+        "Benchmark": "24,869"
+    },
+    {
+        "CPU": "Apple M3 Pro 12 Core",
+        "Benchmark": "24,242"
+    },
+    {
+        "CPU": "Apple M3 Ultra 28 Core",
+        "Benchmark": "68,717"
+    },
+    {
+        "CPU": "Apple M3 Ultra 32 Core",
+        "Benchmark": "74,063"
+    },
+    {
+        "CPU": "Apple M4 10 Core",
+        "Benchmark": "24,008"
+    },
+    {
+        "CPU": "Apple M4 8 Core",
+        "Benchmark": "20,795"
+    },
+    {
+        "CPU": "Apple M4 9 Core",
+        "Benchmark": "22,262"
+    },
+    {
+        "CPU": "Apple M4 Max 14 Core",
+        "Benchmark": "38,529"
+    },
+    {
+        "CPU": "Apple M4 Max 16 Core",
+        "Benchmark": "43,759"
+    },
+    {
+        "CPU": "Apple M4 Pro 12 Core",
+        "Benchmark": "33,05"
+    },
+    {
+        "CPU": "Apple M4 Pro 14 Core",
+        "Benchmark": "38,241"
+    },
+    {
+        "CPU": "ARM - 32 Core 2911 MHz",
+        "Benchmark": "8,132"
+    },
+    {
+        "CPU": "ARM - 32 Core 3300 MHz",
+        "Benchmark": "8,684"
+    },
+    {
+        "CPU": "ARM - 4 Core 2016 MHz",
+        "Benchmark": "3,653"
+    },
+    {
+        "CPU": "ARM - 8 Core 1766 MHz",
+        "Benchmark": "4,08"
+    },
+    {
+        "CPU": "ARM - 8 Core 1800 MHz",
+        "Benchmark": "3,206"
+    },
+    {
+        "CPU": "ARM - 8 Core 2208 MHz",
+        "Benchmark": "2,27"
+    },
+    {
+        "CPU": "ARM - 8 Core 2424 MHz",
+        "Benchmark": "8,61"
+    },
+    {
+        "CPU": "ARM Ampere-1a 192 Core 2600 MHz",
+        "Benchmark": "47,202"
+    },
+    {
+        "CPU": "ARM ARMv7 rev 1 (v7l) 4 Core 1608 MHz",
+        "Benchmark": "776"
+    },
+    {
+        "CPU": "ARM ARMv7 rev 1 (v7l) 4 Core 1800 MHz",
+        "Benchmark": "843"
+    },
+    {
+        "CPU": "ARM ARMv7 rev 3 (v7l) 4 Core 2065 MHz",
+        "Benchmark": "984"
+    },
+    {
+        "CPU": "ARM ARMv7 rev 4 (v7l) 4 Core 1200 MHz",
+        "Benchmark": "403"
+    },
+    {
+        "CPU": "ARM ARMv7 rev 4 (v7l) 4 Core 1400 MHz",
+        "Benchmark": "399"
+    },
+    {
+        "CPU": "ARM ARMv7 rev 5 (v7l) 4 Core 1200 MHz",
+        "Benchmark": "325"
+    },
+    {
+        "CPU": "[3-Way CPU] ARM ARMv8 rev 0 (v8l) 6 Core 1907 MHz",
+        "Benchmark": "3,477"
+    },
+    {
+        "CPU": "[3-Way CPU] ARM ARMv8 rev 1 (v8l) 12 Core 2201 MHz",
+        "Benchmark": "7,371"
+    },
+    {
+        "CPU": "ARM ARMv8 rev 1 (v8l) 4 Core 1510 MHz",
+        "Benchmark": "1,042"
+    },
+    {
+        "CPU": "ARM ARMv8 rev 1 (v8l) 4 Core 1984 MHz",
+        "Benchmark": "1,473"
+    },
+    {
+        "CPU": "ARM ARMv8 rev 1 (v8l) 6 Core 1510 MHz",
+        "Benchmark": "2,553"
+    },
+    {
+        "CPU": "ARM ARMv8 rev 1 (v8l) 6 Core 1984 MHz",
+        "Benchmark": "2,776"
+    },
+    {
+        "CPU": "ARM Avalanche-M2 4 Core 2424 MHz",
+        "Benchmark": "8,233"
+    },
+    {
+        "CPU": "ARM CIX P1 CD8180 7 Core 2500 MHz",
+        "Benchmark": "5,505"
+    },
+    {
+        "CPU": "ARM Cortex-A15 4 Core 1400 MHz",
+        "Benchmark": "1,141"
+    },
+    {
+        "CPU": "ARM Cortex-A15 4 Core 1500 MHz",
+        "Benchmark": "1,304"
+    },
+    {
+        "CPU": "ARM Cortex-A15 4 Core 2000 MHz",
+        "Benchmark": "923"
+    },
+    {
+        "CPU": "ARM Cortex-A15 8 Core 1400 MHz",
+        "Benchmark": "1,16"
+    },
+    {
+        "CPU": "ARM Cortex-A17 4 Core 1800 MHz",
+        "Benchmark": "781"
+    },
+    {
+        "CPU": "ARM Cortex-A35 4 Core 1200 MHz",
+        "Benchmark": "329"
+    },
+    {
+        "CPU": "ARM Cortex-A35 4 Core 1296 MHz",
+        "Benchmark": "334"
+    },
+    {
+        "CPU": "ARM Cortex-A35 4 Core 2004 MHz",
+        "Benchmark": "546"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1000 MHz",
+        "Benchmark": "215"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1008 MHz",
+        "Benchmark": "313"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1152 MHz",
+        "Benchmark": "339"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1199 MHz",
+        "Benchmark": "408"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1200 MHz",
+        "Benchmark": "274"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1296 MHz",
+        "Benchmark": "418"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1300 MHz",
+        "Benchmark": "438"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1333 MHz",
+        "Benchmark": "207"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1368 MHz",
+        "Benchmark": "385"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1392 MHz",
+        "Benchmark": "417"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1400 MHz",
+        "Benchmark": "271"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1416 MHz",
+        "Benchmark": "468"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1500 MHz",
+        "Benchmark": "340"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1512 MHz",
+        "Benchmark": "467"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1536 MHz",
+        "Benchmark": "222"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1600 MHz",
+        "Benchmark": "458"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1608 MHz",
+        "Benchmark": "462"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1704 MHz",
+        "Benchmark": "556"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1800 MHz",
+        "Benchmark": "515"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 1908 MHz",
+        "Benchmark": "638"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 2016 MHz",
+        "Benchmark": "417"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 2040 MHz",
+        "Benchmark": "593"
+    },
+    {
+        "CPU": "ARM Cortex-A53 4 Core 600 MHz",
+        "Benchmark": "220"
+    },
+    {
+        "CPU": "ARM Cortex-A53 6 Core 1896 MHz",
+        "Benchmark": "1,851"
+    },
+    {
+        "CPU": "ARM Cortex-A53 8 Core 1512 MHz",
+        "Benchmark": "739"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 1416 MHz",
+        "Benchmark": "506"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 1800 MHz",
+        "Benchmark": "632"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 1908 MHz",
+        "Benchmark": "707"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 1992 MHz",
+        "Benchmark": "681"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 2000 MHz",
+        "Benchmark": "711"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 2016 MHz",
+        "Benchmark": "755"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 2100 MHz",
+        "Benchmark": "688"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 2124 MHz",
+        "Benchmark": "742"
+    },
+    {
+        "CPU": "ARM Cortex-A55 4 Core 2208 MHz",
+        "Benchmark": "798"
+    },
+    {
+        "CPU": "ARM Cortex-A55 8 Core 1416 MHz",
+        "Benchmark": "1,113"
+    },
+    {
+        "CPU": "ARM Cortex-A55 8 Core 1800 MHz",
+        "Benchmark": "3,013"
+    },
+    {
+        "CPU": "ARM Cortex-A57 2 Core 1479 MHz",
+        "Benchmark": "318"
+    },
+    {
+        "CPU": "ARM Cortex-A57 4 Core 1479 MHz",
+        "Benchmark": "956"
+    },
+    {
+        "CPU": "ARM Cortex-A57 4 Core 1734 MHz",
+        "Benchmark": "1,17"
+    },
+    {
+        "CPU": "ARM Cortex-A57 4 Core 1912 MHz",
+        "Benchmark": "990"
+    },
+    {
+        "CPU": "ARM Cortex-A57 4 Core 2014 MHz",
+        "Benchmark": "1,229"
+    },
+    {
+        "CPU": "ARM Cortex-A57 4 Core 2091 MHz",
+        "Benchmark": "1,192"
+    },
+    {
+        "CPU": "ARM Cortex-A57 8 Core 1500 MHz",
+        "Benchmark": "1,022"
+    },
+    {
+        "CPU": "ARM Cortex-A57 8 Core 1766 MHz",
+        "Benchmark": "3,766"
+    },
+    {
+        "CPU": "ARM Cortex-A7 2 Core 1080 MHz",
+        "Benchmark": "142"
+    },
+    {
+        "CPU": "ARM Cortex-A7 2 Core 960 MHz",
+        "Benchmark": "111"
+    },
+    {
+        "CPU": "ARM Cortex-A7 2 Core 996 MHz",
+        "Benchmark": "138"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1000 MHz",
+        "Benchmark": "278"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1008 MHz",
+        "Benchmark": "269"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1200 MHz",
+        "Benchmark": "219"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1296 MHz",
+        "Benchmark": "253"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1300 MHz",
+        "Benchmark": "343"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1368 MHz",
+        "Benchmark": "354"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 1392 MHz",
+        "Benchmark": "318"
+    },
+    {
+        "CPU": "ARM Cortex-A7 4 Core 900 MHz",
+        "Benchmark": "230"
+    },
+    {
+        "CPU": "ARM Cortex-A715 4 Core 2200 MHz",
+        "Benchmark": "3,432"
+    },
+    {
+        "CPU": "ARM Cortex-A72 16 Core 2000 MHz",
+        "Benchmark": "5,11"
+    },
+    {
+        "CPU": "ARM Cortex-A72 16 Core 2200 MHz",
+        "Benchmark": "5,47"
+    },
+    {
+        "CPU": "ARM Cortex-A72 2 Core 1703 MHz",
+        "Benchmark": "1,005"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1000 MHz",
+        "Benchmark": "608"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1200 MHz",
+        "Benchmark": "174"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1416 MHz",
+        "Benchmark": "927"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1500 MHz",
+        "Benchmark": "617"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1600 MHz",
+        "Benchmark": "667"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1700 MHz",
+        "Benchmark": "541"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1750 MHz",
+        "Benchmark": "335"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1800 MHz",
+        "Benchmark": "680"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1850 MHz",
+        "Benchmark": "199"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 1900 MHz",
+        "Benchmark": "742"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2000 MHz",
+        "Benchmark": "766"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2016 MHz",
+        "Benchmark": "2,201"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2100 MHz",
+        "Benchmark": "674"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2200 MHz",
+        "Benchmark": "799"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2208 MHz",
+        "Benchmark": "2,29"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2300 MHz",
+        "Benchmark": "915"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2394 MHz",
+        "Benchmark": "1,254"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2400 MHz",
+        "Benchmark": "1,295"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 2800 MHz",
+        "Benchmark": "314"
+    },
+    {
+        "CPU": "ARM Cortex-A72 4 Core 800 MHz",
+        "Benchmark": "279"
+    },
+    {
+        "CPU": "ARM Cortex-A72 6 Core 1008 MHz",
+        "Benchmark": "734"
+    },
+    {
+        "CPU": "ARM Cortex-A72 6 Core 1416 MHz",
+        "Benchmark": "1,071"
+    },
+    {
+        "CPU": "ARM Cortex-A72 6 Core 1512 MHz",
+        "Benchmark": "1,183"
+    },
+    {
+        "CPU": "ARM Cortex-A72 8 Core 2016 MHz",
+        "Benchmark": "2,208"
+    },
+    {
+        "CPU": "ARM Cortex-A720 8 Core 2600 MHz",
+        "Benchmark": "6,141"
+    },
+    {
+        "CPU": "ARM Cortex-A73 4 Core 1800 MHz",
+        "Benchmark": "853"
+    },
+    {
+        "CPU": "ARM Cortex-A73 4 Core 1844 MHz",
+        "Benchmark": "1,368"
+    },
+    {
+        "CPU": "ARM Cortex-A73 4 Core 1900 MHz",
+        "Benchmark": "1,547"
+    },
+    {
+        "CPU": "ARM Cortex-A73 4 Core 1989 MHz",
+        "Benchmark": "1,815"
+    },
+    {
+        "CPU": "ARM Cortex-A73 4 Core 2100 MHz",
+        "Benchmark": "1,185"
+    },
+    {
+        "CPU": "ARM Cortex-A73 6 Core 1896 MHz",
+        "Benchmark": "1,242"
+    },
+    {
+        "CPU": "ARM Cortex-A73 6 Core 1992 MHz",
+        "Benchmark": "1,311"
+    },
+    {
+        "CPU": "ARM Cortex-A73 6 Core 2016 MHz",
+        "Benchmark": "1,445"
+    },
+    {
+        "CPU": "ARM Cortex-A73 8 Core 1989 MHz",
+        "Benchmark": "1,803"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 1500 MHz",
+        "Benchmark": "1,488"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 1608 MHz",
+        "Benchmark": "2,698"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 1800 MHz",
+        "Benchmark": "3,114"
+    },
+    {
+        "CPU": "[Dual CPU] ARM Cortex-A76 4 Core 1800 MHz",
+        "Benchmark": "3,108"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 2400 MHz",
+        "Benchmark": "2,166"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 2500 MHz",
+        "Benchmark": "2,342"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 2600 MHz",
+        "Benchmark": "2,323"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 2700 MHz",
+        "Benchmark": "2,383"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 2800 MHz",
+        "Benchmark": "2,469"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 2900 MHz",
+        "Benchmark": "2,596"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 3000 MHz",
+        "Benchmark": "2,578"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 3100 MHz",
+        "Benchmark": "2,734"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 3200 MHz",
+        "Benchmark": "2,579"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 3300 MHz",
+        "Benchmark": "2,493"
+    },
+    {
+        "CPU": "ARM Cortex-A76 4 Core 3400 MHz",
+        "Benchmark": "2,58"
+    },
+    {
+        "CPU": "ARM Cortex-A76 8 Core 1800 MHz",
+        "Benchmark": "2,975"
+    },
+    {
+        "CPU": "ARM Cortex-A78 4 Core 1958 MHz",
+        "Benchmark": "3,53"
+    },
+    {
+        "CPU": "ARM Cortex-A78 4 Core 2000 MHz",
+        "Benchmark": "3,016"
+    },
+    {
+        "CPU": "ARM Cortex-A78AE 10 Core 2112 MHz",
+        "Benchmark": "5,52"
+    },
+    {
+        "CPU": "ARM Cortex-A78AE 12 Core 2201 MHz",
+        "Benchmark": "7,176"
+    },
+    {
+        "CPU": "ARM Cortex-A78AE 6 Core 1510 MHz",
+        "Benchmark": "2,631"
+    },
+    {
+        "CPU": "ARM Cortex-A78AE 6 Core 1728 MHz",
+        "Benchmark": "2,869"
+    },
+    {
+        "CPU": "ARM Cortex-A78AE 8 Core 1984 MHz",
+        "Benchmark": "3,764"
+    },
+    {
+        "CPU": "ARM Cortex-A78AE 8 Core 2201 MHz",
+        "Benchmark": "3,788"
+    },
+    {
+        "CPU": "ARM Cortex-X1C 4 Core 2438 MHz",
+        "Benchmark": "6,007"
+    },
+    {
+        "CPU": "ARM D2000/8 8 Core 2300 MHz",
+        "Benchmark": "2,674"
+    },
+    {
+        "CPU": "ARM Falkor V1/Kryo 8 Core 1900 MHz",
+        "Benchmark": "1,652"
+    },
+    {
+        "CPU": "ARM Firestorm 4 Core 2064 MHz",
+        "Benchmark": "7,804"
+    },
+    {
+        "CPU": "ARM Firestorm 8 Core 2064 MHz",
+        "Benchmark": "6,775"
+    },
+    {
+        "CPU": "ARM Firestorm-M1 4 Core 2064 MHz",
+        "Benchmark": "7,771"
+    },
+    {
+        "CPU": "ARM Firestorm-M1-Pro 8 Core 2064 MHz",
+        "Benchmark": "9,872"
+    },
+    {
+        "CPU": "ARM FT-2000/4 4 Core 2200 MHz",
+        "Benchmark": "881"
+    },
+    {
+        "CPU": "ARM HUAWEI,Kunpeng 920 24 Core 2600 MHz",
+        "Benchmark": "9,496"
+    },
+    {
+        "CPU": "ARM Kryo-3XX-Gold 4 Core 1766 MHz",
+        "Benchmark": "2,222"
+    },
+    {
+        "CPU": "ARM Kryo-3XX-Gold 8 Core 1766 MHz",
+        "Benchmark": "2,372"
+    },
+    {
+        "CPU": "ARM Kryo-4XX-Gold 8 Core 1804 MHz",
+        "Benchmark": "2,531"
+    },
+    {
+        "CPU": "ARM Kryo-4XX-Silver 4 Core 1804 MHz",
+        "Benchmark": "3,425"
+    },
+    {
+        "CPU": "ARM Kunpeng-920 24 Core 2600 MHz",
+        "Benchmark": "9,841"
+    },
+    {
+        "CPU": "ARM Kunpeng-920 8 Core 2600 MHz",
+        "Benchmark": "3,91"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 128 Core 2800 MHz",
+        "Benchmark": "43,111"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 128 Core 3000 MHz",
+        "Benchmark": "39,163"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 32 Core 1700 MHz",
+        "Benchmark": "11,841"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 64 Core 0 MHz",
+        "Benchmark": "28,044"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 64 Core 2200 MHz",
+        "Benchmark": "20,25"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 64 Core 3000 MHz",
+        "Benchmark": "17,515"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 80 Core 2600 MHz",
+        "Benchmark": "18,823"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 80 Core 2800 MHz",
+        "Benchmark": "11,755"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 80 Core 3000 MHz",
+        "Benchmark": "35,123"
+    },
+    {
+        "CPU": "ARM Neoverse-N1 96 Core 2800 MHz",
+        "Benchmark": "29,89"
+    },
+    {
+        "CPU": "ARM Neoverse-N2 8 Core 2500 MHz",
+        "Benchmark": "5,544"
+    },
+    {
+        "CPU": "ARM Neoverse-V2 72 Core 3465 MHz",
+        "Benchmark": "57,369"
+    },
+    {
+        "CPU": "ARM Neoverse-V2 72 Core 3519 MHz",
+        "Benchmark": "57,24"
+    },
+    {
+        "CPU": "ARM Phytium D3000 8 Core 2500 MHz",
+        "Benchmark": "5,528"
+    },
+    {
+        "CPU": "ARM phytium FT1500a 4 Core 2000 MHz",
+        "Benchmark": "1,579"
+    },
+    {
+        "CPU": "ARM Phytium,D2000/8 8 Core 2000 MHz",
+        "Benchmark": "2,409"
+    },
+    {
+        "CPU": "ARM Phytium,D2000/8 8 Core 2300 MHz",
+        "Benchmark": "2,69"
+    },
+    {
+        "CPU": "ARM Phytium,D2000/8 E8C 8 Core 2300 MHz",
+        "Benchmark": "2,522"
+    },
+    {
+        "CPU": "ARM Phytium,FT-2000/4 8 Core 2300 MHz",
+        "Benchmark": "2,72"
+    },
+    {
+        "CPU": "ARM X-Gene 32 Core 3000 MHz",
+        "Benchmark": "8,202"
+    },
+    {
+        "CPU": "ARM X-Gene 32 Core 3300 MHz",
+        "Benchmark": "8,684"
+    },
+    {
+        "CPU": "ASUS Tinker Board 2/2S",
+        "Benchmark": "1,771"
+    },
+    {
+        "CPU": "Athlon 64 Dual Core 3800+",
+        "Benchmark": "736"
+    },
+    {
+        "CPU": "Athlon 64 Dual Core 5000+",
+        "Benchmark": "850"
+    },
+    {
+        "CPU": "Athlon 64 Dual Core 5600+",
+        "Benchmark": "875"
+    },
+    {
+        "CPU": "Athlon Dual Core 4050e",
+        "Benchmark": "670"
+    },
+    {
+        "CPU": "Athlon Dual Core 4450e",
+        "Benchmark": "681"
+    },
+    {
+        "CPU": "Athlon Dual Core 4850e",
+        "Benchmark": "769"
+    },
+    {
+        "CPU": "BCM2711",
+        "Benchmark": "852"
+    },
+    {
+        "CPU": "BCM2712",
+        "Benchmark": "3,284"
+    },
+    {
+        "CPU": "BCM2835",
+        "Benchmark": "1,239"
+    },
+    {
+        "CPU": "Broadcom BCM2712",
+        "Benchmark": "4,095"
+    },
+    {
+        "CPU": "Broadcom STB (Flattened Device Tree)",
+        "Benchmark": "659"
+    },
+    {
+        "CPU": "Celeron Dual-Core T3000 @ 1.80GHz",
+        "Benchmark": "625"
+    },
+    {
+        "CPU": "Celeron Dual-Core T3100 @ 1.90GHz",
+        "Benchmark": "610"
+    },
+    {
+        "CPU": "Celeron Dual-Core T3300 @ 2.00GHz",
+        "Benchmark": "633"
+    },
+    {
+        "CPU": "Celeron Dual-Core T3500 @ 2.10GHz",
+        "Benchmark": "758"
+    },
+    {
+        "CPU": "CentaurHauls @2000MHz",
+        "Benchmark": "6,549"
+    },
+    {
+        "CPU": "CentaurHauls @2400MHz",
+        "Benchmark": "7,784"
+    },
+    {
+        "CPU": "CentaurHauls @2500MHz",
+        "Benchmark": "8,014"
+    },
+    {
+        "CPU": "CIX P1 CD8180",
+        "Benchmark": "9,277"
+    },
+    {
+        "CPU": "Cortex-A76",
+        "Benchmark": "51"
+    },
+    {
+        "CPU": "DG1301SML87HY",
+        "Benchmark": "3,624"
+    },
+    {
+        "CPU": "DO-Regular",
+        "Benchmark": "1,07"
+    },
+    {
+        "CPU": "Dual-Core AMD Opteron 1220 SE",
+        "Benchmark": "748"
+    },
+    {
+        "CPU": "Essgoo",
+        "Benchmark": "497"
+    },
+    {
+        "CPU": "Generic DT based system",
+        "Benchmark": "632"
+    },
+    {
+        "CPU": "Giada JHS558 (Android)",
+        "Benchmark": "2,022"
+    },
+    {
+        "CPU": "Google GS201",
+        "Benchmark": "7,268"
+    },
+    {
+        "CPU": "Google R11 BtWifi Evt1.1",
+        "Benchmark": "187"
+    },
+    {
+        "CPU": "Google Tensor",
+        "Benchmark": "6,703"
+    },
+    {
+        "CPU": "Google Tensor G3",
+        "Benchmark": "8,097"
+    },
+    {
+        "CPU": "Google Tensor G4",
+        "Benchmark": "8,535"
+    },
+    {
+        "CPU": "Grandstream GXV3480 Video Phone",
+        "Benchmark": "1,078"
+    },
+    {
+        "CPU": "Hardkernel ODROID-N2Plus",
+        "Benchmark": "2,115"
+    },
+    {
+        "CPU": "Haydn based on Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "5,359"
+    },
+    {
+        "CPU": "hi6210sft",
+        "Benchmark": "796"
+    },
+    {
+        "CPU": "High Performance Datacenter v",
+        "Benchmark": "1,61"
+    },
+    {
+        "CPU": "HiSilicon Kirin",
+        "Benchmark": "6,758"
+    },
+    {
+        "CPU": "HiSilicon Kirin 659",
+        "Benchmark": "1,893"
+    },
+    {
+        "CPU": "Hisilicon Kirin 925",
+        "Benchmark": "1,053"
+    },
+    {
+        "CPU": "Hisilicon Kirin 930",
+        "Benchmark": "1,415"
+    },
+    {
+        "CPU": "Hisilicon Kirin 935",
+        "Benchmark": "1,599"
+    },
+    {
+        "CPU": "HiSilicon Kirin 950",
+        "Benchmark": "2,457"
+    },
+    {
+        "CPU": "Hisilicon Kirin 955",
+        "Benchmark": "2,936"
+    },
+    {
+        "CPU": "HiSilicon Kirin 960",
+        "Benchmark": "2,897"
+    },
+    {
+        "CPU": "HiSilicon Kirin 970",
+        "Benchmark": "2,908"
+    },
+    {
+        "CPU": "Hisilicon Kirin 990",
+        "Benchmark": "3,965"
+    },
+    {
+        "CPU": "Hisilicon Kirin710",
+        "Benchmark": "2,445"
+    },
+    {
+        "CPU": "Hisilicon Kirin810",
+        "Benchmark": "2,945"
+    },
+    {
+        "CPU": "Hisilicon Kirin820",
+        "Benchmark": "3,893"
+    },
+    {
+        "CPU": "Hisilicon Kirin9000",
+        "Benchmark": "5,083"
+    },
+    {
+        "CPU": "Hisilicon Kirin970",
+        "Benchmark": "2,681"
+    },
+    {
+        "CPU": "Hisilicon Kirin980",
+        "Benchmark": "4,385"
+    },
+    {
+        "CPU": "Hisilicon Kirin985",
+        "Benchmark": "4,162"
+    },
+    {
+        "CPU": "HP Hexa-Core 2.0GHz",
+        "Benchmark": "1,741"
+    },
+    {
+        "CPU": "Hygon C86 3185 8-core",
+        "Benchmark": "9,243"
+    },
+    {
+        "CPU": "Hygon C86 3250 8-core",
+        "Benchmark": "11,476"
+    },
+    {
+        "CPU": "Hygon C86 3330 4-core",
+        "Benchmark": "6,031"
+    },
+    {
+        "CPU": "Hygon C86 3350 8-core",
+        "Benchmark": "12,292"
+    },
+    {
+        "CPU": "Hygon C86 52xx series",
+        "Benchmark": "4,09"
+    },
+    {
+        "CPU": "Hygon C86 7255 16-core",
+        "Benchmark": "18,831"
+    },
+    {
+        "CPU": "[Dual CPU] Hygon C86 S316 16-core",
+        "Benchmark": "27,68"
+    },
+    {
+        "CPU": "Hygon C86-3G (OPN:3350)",
+        "Benchmark": "11,305"
+    },
+    {
+        "CPU": "Hygon C86-4G (OPN:3490)",
+        "Benchmark": "26,064"
+    },
+    {
+        "CPU": "Intel 2.80GHz",
+        "Benchmark": "341"
+    },
+    {
+        "CPU": "Intel 3 N350",
+        "Benchmark": "4,877"
+    },
+    {
+        "CPU": "Intel 300",
+        "Benchmark": "7,277"
+    },
+    {
+        "CPU": "Intel 300T",
+        "Benchmark": "6,227"
+    },
+    {
+        "CPU": "Intel Atom 230 @ 1.60GHz",
+        "Benchmark": "169"
+    },
+    {
+        "CPU": "Intel Atom 330 @ 1.60GHz",
+        "Benchmark": "382"
+    },
+    {
+        "CPU": "Intel Atom C1110",
+        "Benchmark": "3,17"
+    },
+    {
+        "CPU": "Intel Atom C2338 @ 1.74GHz",
+        "Benchmark": "584"
+    },
+    {
+        "CPU": "Intel Atom C2350 @ 1.74GHz",
+        "Benchmark": "520"
+    },
+    {
+        "CPU": "Intel Atom C2358 @ 1.74GHz",
+        "Benchmark": "562"
+    },
+    {
+        "CPU": "Intel Atom C2538 @ 2.40GHz",
+        "Benchmark": "934"
+    },
+    {
+        "CPU": "Intel Atom C2550 @ 2.40GHz",
+        "Benchmark": "1,422"
+    },
+    {
+        "CPU": "Intel Atom C2558 @ 2.40GHz",
+        "Benchmark": "1,424"
+    },
+    {
+        "CPU": "Intel Atom C2750 @ 2.40GHz",
+        "Benchmark": "2,787"
+    },
+    {
+        "CPU": "Intel Atom C2750 @ 2.41GHz",
+        "Benchmark": "2,174"
+    },
+    {
+        "CPU": "Intel Atom C2758 @ 2.40GHz",
+        "Benchmark": "2,317"
+    },
+    {
+        "CPU": "Intel Atom C3338 @ 1.50GHz",
+        "Benchmark": "1,028"
+    },
+    {
+        "CPU": "Intel Atom C3508 @ 1.60GHz",
+        "Benchmark": "1,796"
+    },
+    {
+        "CPU": "Intel Atom C3538 @ 2.10GHz",
+        "Benchmark": "1,91"
+    },
+    {
+        "CPU": "Intel Atom C3558 @ 2.20GHz",
+        "Benchmark": "2,431"
+    },
+    {
+        "CPU": "Intel Atom C3708 @ 1.70GHz",
+        "Benchmark": "3,75"
+    },
+    {
+        "CPU": "Intel Atom C3758 @ 2.20GHz",
+        "Benchmark": "4,614"
+    },
+    {
+        "CPU": "Intel Atom C3758R @ 2.40GHz",
+        "Benchmark": "5,1"
+    },
+    {
+        "CPU": "Intel Atom C3808 @ 2.00GHz",
+        "Benchmark": "5,671"
+    },
+    {
+        "CPU": "Intel Atom C3858 @ 2.00GHz",
+        "Benchmark": "4,707"
+    },
+    {
+        "CPU": "Intel Atom C3958 @ 2.00GHz",
+        "Benchmark": "3,929"
+    },
+    {
+        "CPU": "Intel Atom C5125",
+        "Benchmark": "8,631"
+    },
+    {
+        "CPU": "Intel Atom D2500 @ 1.86GHz",
+        "Benchmark": "241"
+    },
+    {
+        "CPU": "Intel Atom D2550 @ 1.86GHz",
+        "Benchmark": "409"
+    },
+    {
+        "CPU": "Intel Atom D2560 @ 2.00GHz",
+        "Benchmark": "433"
+    },
+    {
+        "CPU": "Intel Atom D2700 @ 2.13GHz",
+        "Benchmark": "456"
+    },
+    {
+        "CPU": "Intel Atom D2701 @ 2.13GHz",
+        "Benchmark": "511"
+    },
+    {
+        "CPU": "Intel Atom D410 @ 1.66GHz",
+        "Benchmark": "180"
+    },
+    {
+        "CPU": "Intel Atom D425 @ 1.80GHz",
+        "Benchmark": "204"
+    },
+    {
+        "CPU": "Intel Atom D510 @ 1.66GHz",
+        "Benchmark": "406"
+    },
+    {
+        "CPU": "Intel Atom D525 @ 1.80GHz",
+        "Benchmark": "393"
+    },
+    {
+        "CPU": "Intel Atom E3805 @ 1.33GHz",
+        "Benchmark": "406"
+    },
+    {
+        "CPU": "Intel Atom E3815 @ 1.46GHz",
+        "Benchmark": "193"
+    },
+    {
+        "CPU": "Intel Atom E3825 @ 1.33GHz",
+        "Benchmark": "378"
+    },
+    {
+        "CPU": "Intel Atom E3826 @ 1.46GHz",
+        "Benchmark": "304"
+    },
+    {
+        "CPU": "Intel Atom E3827 @ 1.74GHz",
+        "Benchmark": "480"
+    },
+    {
+        "CPU": "Intel Atom E3840 @ 1.91GHz",
+        "Benchmark": "704"
+    },
+    {
+        "CPU": "Intel Atom E3845 @ 1.91GHz",
+        "Benchmark": "1,069"
+    },
+    {
+        "CPU": "Intel Atom E3900 @ 1.60GHz",
+        "Benchmark": "1,953"
+    },
+    {
+        "CPU": "Intel Atom N2100 @ 1.60GHz",
+        "Benchmark": "193"
+    },
+    {
+        "CPU": "Intel Atom N2600 @ 1.60GHz",
+        "Benchmark": "316"
+    },
+    {
+        "CPU": "Intel Atom N270 @ 1.60GHz",
+        "Benchmark": "136"
+    },
+    {
+        "CPU": "Intel Atom N280 @ 1.66GHz",
+        "Benchmark": "157"
+    },
+    {
+        "CPU": "Intel Atom N2800 @ 1.86GHz",
+        "Benchmark": "444"
+    },
+    {
+        "CPU": "Intel Atom N435 @ 1.33GHz",
+        "Benchmark": "153"
+    },
+    {
+        "CPU": "Intel Atom N450 @ 1.66GHz",
+        "Benchmark": "203"
+    },
+    {
+        "CPU": "Intel Atom N455 @ 1.66GHz",
+        "Benchmark": "196"
+    },
+    {
+        "CPU": "Intel Atom N470 @ 1.83GHz",
+        "Benchmark": "224"
+    },
+    {
+        "CPU": "Intel Atom N475 @ 1.83GHz",
+        "Benchmark": "179"
+    },
+    {
+        "CPU": "Intel Atom N550 @ 1.50GHz",
+        "Benchmark": "301"
+    },
+    {
+        "CPU": "Intel Atom N570 @ 1.66GHz",
+        "Benchmark": "360"
+    },
+    {
+        "CPU": "Intel Atom P5322",
+        "Benchmark": "7,378"
+    },
+    {
+        "CPU": "Intel Atom P5342",
+        "Benchmark": "13,085"
+    },
+    {
+        "CPU": "Intel Atom P5362",
+        "Benchmark": "17,276"
+    },
+    {
+        "CPU": "Intel Atom S1260 @ 2.00GHz",
+        "Benchmark": "526"
+    },
+    {
+        "CPU": "Intel Atom T5700 @ 1.70GHz",
+        "Benchmark": "2,363"
+    },
+    {
+        "CPU": "Intel Atom x5-E3930 @ 1.30GHz",
+        "Benchmark": "928"
+    },
+    {
+        "CPU": "Intel Atom x5-E3940 @ 1.60GHz",
+        "Benchmark": "1,908"
+    },
+    {
+        "CPU": "Intel Atom x5-E8000 @ 1.04GHz",
+        "Benchmark": "962"
+    },
+    {
+        "CPU": "Intel Atom x5-Z8300 @ 1.44GHz",
+        "Benchmark": "833"
+    },
+    {
+        "CPU": "Intel Atom x5-Z8330 @ 1.44GHz",
+        "Benchmark": "803"
+    },
+    {
+        "CPU": "Intel Atom x5-Z8350 @ 1.44GHz",
+        "Benchmark": "893"
+    },
+    {
+        "CPU": "Intel Atom x5-Z8500 @ 1.44GHz",
+        "Benchmark": "1,244"
+    },
+    {
+        "CPU": "Intel Atom x5-Z8550 @ 1.44GHz",
+        "Benchmark": "1,143"
+    },
+    {
+        "CPU": "Intel Atom x6211E @ 1.20GHz",
+        "Benchmark": "1,695"
+    },
+    {
+        "CPU": "Intel Atom x6211E @ 1.30GHz",
+        "Benchmark": "1,762"
+    },
+    {
+        "CPU": "Intel Atom x6214RE @ 1.40GHz",
+        "Benchmark": "1,109"
+    },
+    {
+        "CPU": "Intel Atom x6413E @ 1.50GHz",
+        "Benchmark": "3,96"
+    },
+    {
+        "CPU": "Intel Atom x6414RE @ 1.50GHz",
+        "Benchmark": "2,128"
+    },
+    {
+        "CPU": "Intel Atom x6425E @ 2.00GHz",
+        "Benchmark": "3,671"
+    },
+    {
+        "CPU": "Intel Atom x6425RE @ 1.90GHz",
+        "Benchmark": "2,929"
+    },
+    {
+        "CPU": "Intel Atom x6427FE @ 1.90GHz",
+        "Benchmark": "3,196"
+    },
+    {
+        "CPU": "Intel Atom x7-E3950 @ 1.60GHz",
+        "Benchmark": "2,071"
+    },
+    {
+        "CPU": "Intel Atom x7-Z8700 @ 1.60GHz",
+        "Benchmark": "1,333"
+    },
+    {
+        "CPU": "Intel Atom x7-Z8750 @ 1.60GHz",
+        "Benchmark": "1,294"
+    },
+    {
+        "CPU": "Intel Atom x7211E",
+        "Benchmark": "2,553"
+    },
+    {
+        "CPU": "Intel Atom x7211RE",
+        "Benchmark": "2,137"
+    },
+    {
+        "CPU": "Intel Atom x7213RE",
+        "Benchmark": "2,286"
+    },
+    {
+        "CPU": "Intel Atom x7425E",
+        "Benchmark": "5,582"
+    },
+    {
+        "CPU": "Intel Atom x7433RE",
+        "Benchmark": "3,343"
+    },
+    {
+        "CPU": "Intel Atom x7835RE",
+        "Benchmark": "6,341"
+    },
+    {
+        "CPU": "Intel Atom Z2760 @ 1.80GHz",
+        "Benchmark": "298"
+    },
+    {
+        "CPU": "Intel Atom Z3530 @ 1.33GHz",
+        "Benchmark": "565"
+    },
+    {
+        "CPU": "Intel Atom Z3560 @ 1.00GHz",
+        "Benchmark": "749"
+    },
+    {
+        "CPU": "Intel Atom Z3560 @ 1.83GHz",
+        "Benchmark": "690"
+    },
+    {
+        "CPU": "Intel Atom Z3580 @ 1.33GHz",
+        "Benchmark": "802"
+    },
+    {
+        "CPU": "Intel Atom Z3735D @ 1.33GHz",
+        "Benchmark": "704"
+    },
+    {
+        "CPU": "Intel Atom Z3735E @ 1.33GHz",
+        "Benchmark": "557"
+    },
+    {
+        "CPU": "Intel Atom Z3735F @ 1.33GHz",
+        "Benchmark": "539"
+    },
+    {
+        "CPU": "Intel Atom Z3735G @ 1.33GHz",
+        "Benchmark": "772"
+    },
+    {
+        "CPU": "Intel Atom Z3736F @ 1.33GHz",
+        "Benchmark": "496"
+    },
+    {
+        "CPU": "Intel Atom Z3740 @ 1.33GHz",
+        "Benchmark": "621"
+    },
+    {
+        "CPU": "Intel Atom Z3740D @ 1.33GHz",
+        "Benchmark": "614"
+    },
+    {
+        "CPU": "Intel Atom Z3745 @ 1.33GHz",
+        "Benchmark": "621"
+    },
+    {
+        "CPU": "Intel Atom Z3745D @ 1.33GHz",
+        "Benchmark": "599"
+    },
+    {
+        "CPU": "Intel Atom Z3770 @ 1.46GHz",
+        "Benchmark": "728"
+    },
+    {
+        "CPU": "Intel Atom Z3770D @ 1.49GHz",
+        "Benchmark": "488"
+    },
+    {
+        "CPU": "Intel Atom Z3775 @ 1.46GHz",
+        "Benchmark": "704"
+    },
+    {
+        "CPU": "Intel Atom Z3775D @ 1.49GHz",
+        "Benchmark": "794"
+    },
+    {
+        "CPU": "Intel Atom Z3795 @ 1.60GHz",
+        "Benchmark": "1,196"
+    },
+    {
+        "CPU": "Intel Atom Z520 @ 1.33GHz",
+        "Benchmark": "122"
+    },
+    {
+        "CPU": "Intel Atom Z530 @ 1.60GHz",
+        "Benchmark": "183"
+    },
+    {
+        "CPU": "Intel Atom Z670 @ 1.50GHz",
+        "Benchmark": "158"
+    },
+    {
+        "CPU": "Intel CC150 @ 3.50GHz",
+        "Benchmark": "14,24"
+    },
+    {
+        "CPU": "Intel Celeron 1.70GHz",
+        "Benchmark": "101"
+    },
+    {
+        "CPU": "Intel Celeron 1.80GHz",
+        "Benchmark": "96"
+    },
+    {
+        "CPU": "Intel Celeron 1000M @ 1.80GHz",
+        "Benchmark": "1,066"
+    },
+    {
+        "CPU": "Intel Celeron 1000MHz",
+        "Benchmark": "139"
+    },
+    {
+        "CPU": "Intel Celeron 1005M @ 1.90GHz",
+        "Benchmark": "1,112"
+    },
+    {
+        "CPU": "Intel Celeron 1007U @ 1.50GHz",
+        "Benchmark": "847"
+    },
+    {
+        "CPU": "Intel Celeron 1017U @ 1.60GHz",
+        "Benchmark": "877"
+    },
+    {
+        "CPU": "Intel Celeron 1019Y @ 1.00GHz",
+        "Benchmark": "576"
+    },
+    {
+        "CPU": "Intel Celeron 1020E @ 2.20GHz",
+        "Benchmark": "1,406"
+    },
+    {
+        "CPU": "Intel Celeron 1020M @ 2.10GHz",
+        "Benchmark": "1,275"
+    },
+    {
+        "CPU": "Intel Celeron 1037U @ 1.80GHz",
+        "Benchmark": "1,013"
+    },
+    {
+        "CPU": "Intel Celeron 1047UE @ 1.40GHz",
+        "Benchmark": "748"
+    },
+    {
+        "CPU": "Intel Celeron 1100MHz",
+        "Benchmark": "113"
+    },
+    {
+        "CPU": "Intel Celeron 1200MHz",
+        "Benchmark": "159"
+    },
+    {
+        "CPU": "Intel Celeron 2.00GHz",
+        "Benchmark": "125"
+    },
+    {
+        "CPU": "Intel Celeron 2.13GHz",
+        "Benchmark": "166"
+    },
+    {
+        "CPU": "Intel Celeron 2.20GHz",
+        "Benchmark": "139"
+    },
+    {
+        "CPU": "Intel Celeron 2.26GHz",
+        "Benchmark": "182"
+    },
+    {
+        "CPU": "Intel Celeron 2.30GHz",
+        "Benchmark": "148"
+    },
+    {
+        "CPU": "Intel Celeron 2.40GHz",
+        "Benchmark": "143"
+    },
+    {
+        "CPU": "Intel Celeron 2.50GHz",
+        "Benchmark": "164"
+    },
+    {
+        "CPU": "Intel Celeron 2.53GHz",
+        "Benchmark": "222"
+    },
+    {
+        "CPU": "Intel Celeron 2.60GHz",
+        "Benchmark": "143"
+    },
+    {
+        "CPU": "Intel Celeron 2.66GHz",
+        "Benchmark": "131"
+    },
+    {
+        "CPU": "Intel Celeron 2.70GHz",
+        "Benchmark": "159"
+    },
+    {
+        "CPU": "Intel Celeron 2.80GHz",
+        "Benchmark": "190"
+    },
+    {
+        "CPU": "Intel Celeron 2.93GHz",
+        "Benchmark": "230"
+    },
+    {
+        "CPU": "Intel Celeron 2000E @ 2.20GHz",
+        "Benchmark": "1,607"
+    },
+    {
+        "CPU": "Intel Celeron 2002E @ 1.50GHz",
+        "Benchmark": "1,091"
+    },
+    {
+        "CPU": "Intel Celeron 215 @ 1.33GHz",
+        "Benchmark": "174"
+    },
+    {
+        "CPU": "Intel Celeron 220 @ 1.20GHz",
+        "Benchmark": "209"
+    },
+    {
+        "CPU": "Intel Celeron 2950M @ 2.00GHz",
+        "Benchmark": "1,238"
+    },
+    {
+        "CPU": "Intel Celeron 2955U @ 1.40GHz",
+        "Benchmark": "903"
+    },
+    {
+        "CPU": "Intel Celeron 2957U @ 1.40GHz",
+        "Benchmark": "851"
+    },
+    {
+        "CPU": "Intel Celeron 2961Y @ 1.10GHz",
+        "Benchmark": "684"
+    },
+    {
+        "CPU": "Intel Celeron 2970M @ 2.20GHz",
+        "Benchmark": "1,501"
+    },
+    {
+        "CPU": "Intel Celeron 2980U @ 1.60GHz",
+        "Benchmark": "1,092"
+    },
+    {
+        "CPU": "Intel Celeron 2981U @ 1.60GHz",
+        "Benchmark": "1,036"
+    },
+    {
+        "CPU": "Intel Celeron 3.06GHz",
+        "Benchmark": "307"
+    },
+    {
+        "CPU": "Intel Celeron 3.20GHz",
+        "Benchmark": "267"
+    },
+    {
+        "CPU": "Intel Celeron 3.33GHz",
+        "Benchmark": "263"
+    },
+    {
+        "CPU": "Intel Celeron 3205U @ 1.50GHz",
+        "Benchmark": "964"
+    },
+    {
+        "CPU": "Intel Celeron 3215U @ 1.70GHz",
+        "Benchmark": "1,1"
+    },
+    {
+        "CPU": "Intel Celeron 3755U @ 1.70GHz",
+        "Benchmark": "1,182"
+    },
+    {
+        "CPU": "Intel Celeron 3765U @ 1.90GHz",
+        "Benchmark": "1,252"
+    },
+    {
+        "CPU": "Intel Celeron 3855U @ 1.60GHz",
+        "Benchmark": "1,215"
+    },
+    {
+        "CPU": "Intel Celeron 3865U @ 1.80GHz",
+        "Benchmark": "1,334"
+    },
+    {
+        "CPU": "Intel Celeron 3867U @ 1.80GHz",
+        "Benchmark": "1,466"
+    },
+    {
+        "CPU": "Intel Celeron 3955U @ 2.00GHz",
+        "Benchmark": "1,478"
+    },
+    {
+        "CPU": "Intel Celeron 3965U @ 2.20GHz",
+        "Benchmark": "1,746"
+    },
+    {
+        "CPU": "Intel Celeron 3965Y @ 1.50GHz",
+        "Benchmark": "1,197"
+    },
+    {
+        "CPU": "Intel Celeron 420 @ 1.60GHz",
+        "Benchmark": "257"
+    },
+    {
+        "CPU": "Intel Celeron 4205U @ 1.80GHz",
+        "Benchmark": "1,344"
+    },
+    {
+        "CPU": "Intel Celeron 430 @ 1.80GHz",
+        "Benchmark": "288"
+    },
+    {
+        "CPU": "Intel Celeron 4305U @ 2.20GHz",
+        "Benchmark": "1,562"
+    },
+    {
+        "CPU": "Intel Celeron 4305UE @ 2.00GHz",
+        "Benchmark": "1,699"
+    },
+    {
+        "CPU": "Intel Celeron 440 @ 2.00GHz",
+        "Benchmark": "368"
+    },
+    {
+        "CPU": "Intel Celeron 450 @ 2.20GHz",
+        "Benchmark": "433"
+    },
+    {
+        "CPU": "Intel Celeron 5205U @ 1.90GHz",
+        "Benchmark": "1,438"
+    },
+    {
+        "CPU": "Intel Celeron 530 @ 1.73GHz",
+        "Benchmark": "268"
+    },
+    {
+        "CPU": "Intel Celeron 5305U @ 2.30GHz",
+        "Benchmark": "1,684"
+    },
+    {
+        "CPU": "Intel Celeron 540 @ 1.86GHz",
+        "Benchmark": "305"
+    },
+    {
+        "CPU": "Intel Celeron 550 @ 2.00GHz",
+        "Benchmark": "334"
+    },
+    {
+        "CPU": "Intel Celeron 560 @ 2.13GHz",
+        "Benchmark": "339"
+    },
+    {
+        "CPU": "Intel Celeron 570 @ 2.26GHz",
+        "Benchmark": "344"
+    },
+    {
+        "CPU": "Intel Celeron 6305 @ 1.80GHz",
+        "Benchmark": "2,087"
+    },
+    {
+        "CPU": "Intel Celeron 6305E @ 1.80GHz",
+        "Benchmark": "2,03"
+    },
+    {
+        "CPU": "Intel Celeron 6600HE @ 2.60GHz",
+        "Benchmark": "3,286"
+    },
+    {
+        "CPU": "Intel Celeron 723 @ 1.20GHz",
+        "Benchmark": "213"
+    },
+    {
+        "CPU": "Intel Celeron 7305",
+        "Benchmark": "2,5"
+    },
+    {
+        "CPU": "Intel Celeron 7305E",
+        "Benchmark": "2,255"
+    },
+    {
+        "CPU": "Intel Celeron 743 @ 1.30GHz",
+        "Benchmark": "275"
+    },
+    {
+        "CPU": "Intel Celeron 807 @ 1.50GHz",
+        "Benchmark": "392"
+    },
+    {
+        "CPU": "Intel Celeron 807UE @ 1.00GHz",
+        "Benchmark": "241"
+    },
+    {
+        "CPU": "Intel Celeron 827E @ 1.40GHz",
+        "Benchmark": "371"
+    },
+    {
+        "CPU": "Intel Celeron 847 @ 1.10GHz",
+        "Benchmark": "492"
+    },
+    {
+        "CPU": "Intel Celeron 847E @ 1.10GHz",
+        "Benchmark": "584"
+    },
+    {
+        "CPU": "Intel Celeron 857 @ 1.20GHz",
+        "Benchmark": "569"
+    },
+    {
+        "CPU": "Intel Celeron 867 @ 1.30GHz",
+        "Benchmark": "588"
+    },
+    {
+        "CPU": "Intel Celeron 877 @ 1.40GHz",
+        "Benchmark": "700"
+    },
+    {
+        "CPU": "Intel Celeron 887 @ 1.50GHz",
+        "Benchmark": "764"
+    },
+    {
+        "CPU": "Intel Celeron 900 @ 2.20GHz",
+        "Benchmark": "412"
+    },
+    {
+        "CPU": "Intel Celeron 925 @ 2.30GHz",
+        "Benchmark": "450"
+    },
+    {
+        "CPU": "Intel Celeron @ 1.30GHz",
+        "Benchmark": "572"
+    },
+    {
+        "CPU": "Intel Celeron B710 @ 1.60GHz",
+        "Benchmark": "106"
+    },
+    {
+        "CPU": "Intel Celeron B800 @ 1.50GHz",
+        "Benchmark": "666"
+    },
+    {
+        "CPU": "Intel Celeron B810 @ 1.60GHz",
+        "Benchmark": "775"
+    },
+    {
+        "CPU": "Intel Celeron B815 @ 1.60GHz",
+        "Benchmark": "742"
+    },
+    {
+        "CPU": "Intel Celeron B820 @ 1.70GHz",
+        "Benchmark": "816"
+    },
+    {
+        "CPU": "Intel Celeron B830 @ 1.80GHz",
+        "Benchmark": "869"
+    },
+    {
+        "CPU": "Intel Celeron B840 @ 1.90GHz",
+        "Benchmark": "967"
+    },
+    {
+        "CPU": "Intel Celeron D 347 @ 3.06GHz",
+        "Benchmark": "232"
+    },
+    {
+        "CPU": "Intel Celeron D 352 @ 3.20GHz",
+        "Benchmark": "274"
+    },
+    {
+        "CPU": "Intel Celeron D 356 @ 3.33GHz",
+        "Benchmark": "251"
+    },
+    {
+        "CPU": "Intel Celeron D 360 @ 3.46GHz",
+        "Benchmark": "372"
+    },
+    {
+        "CPU": "Intel Celeron D 420 @ 1.60GHz",
+        "Benchmark": "313"
+    },
+    {
+        "CPU": "Intel Celeron E1200 @ 1.60GHz",
+        "Benchmark": "516"
+    },
+    {
+        "CPU": "Intel Celeron E1400 @ 2.00GHz",
+        "Benchmark": "735"
+    },
+    {
+        "CPU": "Intel Celeron E1500 @ 2.20GHz",
+        "Benchmark": "626"
+    },
+    {
+        "CPU": "Intel Celeron E1600 @ 2.40GHz",
+        "Benchmark": "840"
+    },
+    {
+        "CPU": "Intel Celeron E3200 @ 2.40GHz",
+        "Benchmark": "900"
+    },
+    {
+        "CPU": "Intel Celeron E3300 @ 2.50GHz",
+        "Benchmark": "809"
+    },
+    {
+        "CPU": "Intel Celeron E3400 @ 2.60GHz",
+        "Benchmark": "883"
+    },
+    {
+        "CPU": "Intel Celeron E3500 @ 2.70GHz",
+        "Benchmark": "935"
+    },
+    {
+        "CPU": "Intel Celeron G1101 @ 2.27GHz",
+        "Benchmark": "1,086"
+    },
+    {
+        "CPU": "Intel Celeron G1610 @ 2.60GHz",
+        "Benchmark": "1,546"
+    },
+    {
+        "CPU": "Intel Celeron G1610T @ 2.30GHz",
+        "Benchmark": "1,327"
+    },
+    {
+        "CPU": "Intel Celeron G1620 @ 2.70GHz",
+        "Benchmark": "1,571"
+    },
+    {
+        "CPU": "Intel Celeron G1620T @ 2.40GHz",
+        "Benchmark": "1,532"
+    },
+    {
+        "CPU": "Intel Celeron G1630 @ 2.80GHz",
+        "Benchmark": "1,707"
+    },
+    {
+        "CPU": "Intel Celeron G1820 @ 2.70GHz",
+        "Benchmark": "1,698"
+    },
+    {
+        "CPU": "Intel Celeron G1820T @ 2.40GHz",
+        "Benchmark": "1,631"
+    },
+    {
+        "CPU": "Intel Celeron G1820TE @ 2.20GHz",
+        "Benchmark": "1,02"
+    },
+    {
+        "CPU": "Intel Celeron G1830 @ 2.80GHz",
+        "Benchmark": "1,56"
+    },
+    {
+        "CPU": "Intel Celeron G1840 @ 2.80GHz",
+        "Benchmark": "1,784"
+    },
+    {
+        "CPU": "Intel Celeron G1840T @ 2.50GHz",
+        "Benchmark": "1,576"
+    },
+    {
+        "CPU": "Intel Celeron G1850 @ 2.90GHz",
+        "Benchmark": "1,909"
+    },
+    {
+        "CPU": "Intel Celeron G3900 @ 2.80GHz",
+        "Benchmark": "2,136"
+    },
+    {
+        "CPU": "Intel Celeron G3900E @ 2.40GHz",
+        "Benchmark": "2,034"
+    },
+    {
+        "CPU": "Intel Celeron G3900T @ 2.60GHz",
+        "Benchmark": "1,942"
+    },
+    {
+        "CPU": "Intel Celeron G3900TE @ 2.30GHz",
+        "Benchmark": "1,85"
+    },
+    {
+        "CPU": "Intel Celeron G3920 @ 2.90GHz",
+        "Benchmark": "2,358"
+    },
+    {
+        "CPU": "Intel Celeron G3930 @ 2.90GHz",
+        "Benchmark": "2,254"
+    },
+    {
+        "CPU": "Intel Celeron G3930T @ 2.70GHz",
+        "Benchmark": "2,023"
+    },
+    {
+        "CPU": "Intel Celeron G3930TE @ 2.70GHz",
+        "Benchmark": "2,218"
+    },
+    {
+        "CPU": "Intel Celeron G3950 @ 3.00GHz",
+        "Benchmark": "2,336"
+    },
+    {
+        "CPU": "Intel Celeron G440 @ 1.60GHz",
+        "Benchmark": "420"
+    },
+    {
+        "CPU": "Intel Celeron G460 @ 1.80GHz",
+        "Benchmark": "481"
+    },
+    {
+        "CPU": "Intel Celeron G465 @ 1.90GHz",
+        "Benchmark": "547"
+    },
+    {
+        "CPU": "Intel Celeron G470 @ 2.00GHz",
+        "Benchmark": "570"
+    },
+    {
+        "CPU": "Intel Celeron G4900 @ 3.10GHz",
+        "Benchmark": "2,389"
+    },
+    {
+        "CPU": "Intel Celeron G4900T @ 2.90GHz",
+        "Benchmark": "2,252"
+    },
+    {
+        "CPU": "Intel Celeron G4920 @ 3.20GHz",
+        "Benchmark": "2,5"
+    },
+    {
+        "CPU": "Intel Celeron G4930 @ 3.20GHz",
+        "Benchmark": "2,547"
+    },
+    {
+        "CPU": "Intel Celeron G4930T @ 3.00GHz",
+        "Benchmark": "2,283"
+    },
+    {
+        "CPU": "Intel Celeron G4950 @ 3.30GHz",
+        "Benchmark": "2,714"
+    },
+    {
+        "CPU": "Intel Celeron G530 @ 2.40GHz",
+        "Benchmark": "1,132"
+    },
+    {
+        "CPU": "Intel Celeron G530T @ 2.00GHz",
+        "Benchmark": "1,056"
+    },
+    {
+        "CPU": "Intel Celeron G540 @ 2.50GHz",
+        "Benchmark": "1,155"
+    },
+    {
+        "CPU": "Intel Celeron G540T @ 2.10GHz",
+        "Benchmark": "1,137"
+    },
+    {
+        "CPU": "Intel Celeron G550 @ 2.60GHz",
+        "Benchmark": "1,259"
+    },
+    {
+        "CPU": "Intel Celeron G550T @ 2.20GHz",
+        "Benchmark": "1,074"
+    },
+    {
+        "CPU": "Intel Celeron G555 @ 2.70GHz",
+        "Benchmark": "1,388"
+    },
+    {
+        "CPU": "Intel Celeron G5900 @ 3.40GHz",
+        "Benchmark": "2,677"
+    },
+    {
+        "CPU": "Intel Celeron G5900E @ 3.20GHz",
+        "Benchmark": "1,809"
+    },
+    {
+        "CPU": "Intel Celeron G5900T @ 3.20GHz",
+        "Benchmark": "2,155"
+    },
+    {
+        "CPU": "Intel Celeron G5905 @ 3.50GHz",
+        "Benchmark": "2,777"
+    },
+    {
+        "CPU": "Intel Celeron G5905T @ 3.30GHz",
+        "Benchmark": "2,304"
+    },
+    {
+        "CPU": "Intel Celeron G5920 @ 3.50GHz",
+        "Benchmark": "2,577"
+    },
+    {
+        "CPU": "Intel Celeron G5925 @ 3.60GHz",
+        "Benchmark": "2,787"
+    },
+    {
+        "CPU": "Intel Celeron G6900",
+        "Benchmark": "4,515"
+    },
+    {
+        "CPU": "Intel Celeron G6900E",
+        "Benchmark": "4,272"
+    },
+    {
+        "CPU": "Intel Celeron G6900T",
+        "Benchmark": "3,651"
+    },
+    {
+        "CPU": "Intel Celeron G6900TE",
+        "Benchmark": "2,782"
+    },
+    {
+        "CPU": "Intel Celeron J1750 @ 2.41GHz",
+        "Benchmark": "538"
+    },
+    {
+        "CPU": "Intel Celeron J1800 @ 2.41GHz",
+        "Benchmark": "572"
+    },
+    {
+        "CPU": "Intel Celeron J1850 @ 1.99GHz",
+        "Benchmark": "942"
+    },
+    {
+        "CPU": "Intel Celeron J1900 @ 1.99GHz",
+        "Benchmark": "1,151"
+    },
+    {
+        "CPU": "Intel Celeron J3060 @ 1.60GHz",
+        "Benchmark": "683"
+    },
+    {
+        "CPU": "Intel Celeron J3160 @ 1.60GHz",
+        "Benchmark": "1,258"
+    },
+    {
+        "CPU": "Intel Celeron J3355 @ 2.00GHz",
+        "Benchmark": "1,192"
+    },
+    {
+        "CPU": "Intel Celeron J3455 @ 1.50GHz",
+        "Benchmark": "2,248"
+    },
+    {
+        "CPU": "Intel Celeron J3455E @ 1.50GHz",
+        "Benchmark": "2,193"
+    },
+    {
+        "CPU": "Intel Celeron J4005 @ 2.00GHz",
+        "Benchmark": "1,545"
+    },
+    {
+        "CPU": "Intel Celeron J4025 @ 2.00GHz",
+        "Benchmark": "1,477"
+    },
+    {
+        "CPU": "Intel Celeron J4105 @ 1.50GHz",
+        "Benchmark": "2,864"
+    },
+    {
+        "CPU": "Intel Celeron J4115 @ 1.80GHz",
+        "Benchmark": "2,688"
+    },
+    {
+        "CPU": "Intel Celeron J4125 @ 2.00GHz",
+        "Benchmark": "2,94"
+    },
+    {
+        "CPU": "Intel Celeron J6412 @ 2.00GHz",
+        "Benchmark": "3,833"
+    },
+    {
+        "CPU": "Intel Celeron J6413 @ 1.80GHz",
+        "Benchmark": "4,259"
+    },
+    {
+        "CPU": "Intel Celeron M 1.00GHz",
+        "Benchmark": "149"
+    },
+    {
+        "CPU": "Intel Celeron M 1.30GHz",
+        "Benchmark": "205"
+    },
+    {
+        "CPU": "Intel Celeron M 1.50GHz",
+        "Benchmark": "192"
+    },
+    {
+        "CPU": "Intel Celeron M 1.60GHz",
+        "Benchmark": "190"
+    },
+    {
+        "CPU": "Intel Celeron M 1.70GHz",
+        "Benchmark": "252"
+    },
+    {
+        "CPU": "Intel Celeron M 1300MHz",
+        "Benchmark": "197"
+    },
+    {
+        "CPU": "Intel Celeron M 1500MHz",
+        "Benchmark": "217"
+    },
+    {
+        "CPU": "Intel Celeron M 360 1.40GHz",
+        "Benchmark": "221"
+    },
+    {
+        "CPU": "Intel Celeron M 410 @ 1.46GHz",
+        "Benchmark": "123"
+    },
+    {
+        "CPU": "Intel Celeron M 420 @ 1.60GHz",
+        "Benchmark": "139"
+    },
+    {
+        "CPU": "Intel Celeron M 430 @ 1.73GHz",
+        "Benchmark": "169"
+    },
+    {
+        "CPU": "Intel Celeron M 440 @ 1.86GHz",
+        "Benchmark": "169"
+    },
+    {
+        "CPU": "Intel Celeron M 443 @ 1.20GHz",
+        "Benchmark": "125"
+    },
+    {
+        "CPU": "Intel Celeron M 450 @ 2.00GHz",
+        "Benchmark": "230"
+    },
+    {
+        "CPU": "Intel Celeron M 520 @ 1.60GHz",
+        "Benchmark": "239"
+    },
+    {
+        "CPU": "Intel Celeron M 530 @ 1.73GHz",
+        "Benchmark": "320"
+    },
+    {
+        "CPU": "Intel Celeron M 723 @ 1.20GHz",
+        "Benchmark": "267"
+    },
+    {
+        "CPU": "Intel Celeron M 900MHz",
+        "Benchmark": "123"
+    },
+    {
+        "CPU": "Intel Celeron N2805 @ 1.46GHz",
+        "Benchmark": "335"
+    },
+    {
+        "CPU": "Intel Celeron N2806 @ 1.60GHz",
+        "Benchmark": "486"
+    },
+    {
+        "CPU": "Intel Celeron N2807 @ 1.58GHz",
+        "Benchmark": "481"
+    },
+    {
+        "CPU": "Intel Celeron N2808 @ 1.58GHz",
+        "Benchmark": "499"
+    },
+    {
+        "CPU": "Intel Celeron N2810 @ 2.00GHz",
+        "Benchmark": "377"
+    },
+    {
+        "CPU": "Intel Celeron N2815 @ 1.86GHz",
+        "Benchmark": "495"
+    },
+    {
+        "CPU": "Intel Celeron N2820 @ 2.13GHz",
+        "Benchmark": "502"
+    },
+    {
+        "CPU": "Intel Celeron N2830 @ 2.16GHz",
+        "Benchmark": "548"
+    },
+    {
+        "CPU": "Intel Celeron N2840 @ 2.16GHz",
+        "Benchmark": "585"
+    },
+    {
+        "CPU": "Intel Celeron N2910 @ 1.60GHz",
+        "Benchmark": "787"
+    },
+    {
+        "CPU": "Intel Celeron N2920 @ 1.86GHz",
+        "Benchmark": "954"
+    },
+    {
+        "CPU": "Intel Celeron N2930 @ 1.83GHz",
+        "Benchmark": "1,028"
+    },
+    {
+        "CPU": "Intel Celeron N2940 @ 1.83GHz",
+        "Benchmark": "1,045"
+    },
+    {
+        "CPU": "Intel Celeron N3000 @ 1.04GHz",
+        "Benchmark": "646"
+    },
+    {
+        "CPU": "Intel Celeron N3010 @ 1.04GHz",
+        "Benchmark": "612"
+    },
+    {
+        "CPU": "Intel Celeron N3050 @ 1.60GHz",
+        "Benchmark": "592"
+    },
+    {
+        "CPU": "Intel Celeron N3060 @ 1.60GHz",
+        "Benchmark": "660"
+    },
+    {
+        "CPU": "Intel Celeron N3150 @ 1.60GHz",
+        "Benchmark": "1,172"
+    },
+    {
+        "CPU": "Intel Celeron N3160 @ 1.60GHz",
+        "Benchmark": "1,2"
+    },
+    {
+        "CPU": "Intel Celeron N3350 @ 1.10GHz",
+        "Benchmark": "1,11"
+    },
+    {
+        "CPU": "Intel Celeron N3450 @ 1.10GHz",
+        "Benchmark": "1,99"
+    },
+    {
+        "CPU": "Intel Celeron N4000 @ 1.10GHz",
+        "Benchmark": "1,428"
+    },
+    {
+        "CPU": "Intel Celeron N4000C @ 1.10GHz",
+        "Benchmark": "1,43"
+    },
+    {
+        "CPU": "Intel Celeron N4020 @ 1.10GHz",
+        "Benchmark": "1,546"
+    },
+    {
+        "CPU": "Intel Celeron N4020C @ 1.10GHz",
+        "Benchmark": "1,535"
+    },
+    {
+        "CPU": "Intel Celeron N4100 @ 1.10GHz",
+        "Benchmark": "2,459"
+    },
+    {
+        "CPU": "Intel Celeron N4120 @ 1.10GHz",
+        "Benchmark": "2,469"
+    },
+    {
+        "CPU": "Intel Celeron N4500 @ 1.10GHz",
+        "Benchmark": "1,88"
+    },
+    {
+        "CPU": "Intel Celeron N4505 @ 2.00GHz",
+        "Benchmark": "2,119"
+    },
+    {
+        "CPU": "Intel Celeron N5095 @ 2.00GHz",
+        "Benchmark": "4,049"
+    },
+    {
+        "CPU": "Intel Celeron N5095A @ 2.00GHz",
+        "Benchmark": "4,066"
+    },
+    {
+        "CPU": "Intel Celeron N5100 @ 1.10GHz",
+        "Benchmark": "3,284"
+    },
+    {
+        "CPU": "Intel Celeron N5105 @ 2.00GHz",
+        "Benchmark": "4,025"
+    },
+    {
+        "CPU": "Intel Celeron N6210 @ 1.20GHz",
+        "Benchmark": "1,967"
+    },
+    {
+        "CPU": "Intel Celeron N6211 @ 1.20GHz",
+        "Benchmark": "2,245"
+    },
+    {
+        "CPU": "Intel Celeron P4500 @ 1.87GHz",
+        "Benchmark": "848"
+    },
+    {
+        "CPU": "Intel Celeron P4505 @ 1.87GHz",
+        "Benchmark": "689"
+    },
+    {
+        "CPU": "Intel Celeron P4600 @ 2.00GHz",
+        "Benchmark": "877"
+    },
+    {
+        "CPU": "Intel Celeron SU2300 @ 1.20GHz",
+        "Benchmark": "462"
+    },
+    {
+        "CPU": "Intel Celeron T1600 @ 1.66GHz",
+        "Benchmark": "553"
+    },
+    {
+        "CPU": "Intel Celeron U1900 @ 1.99GHz",
+        "Benchmark": "1,028"
+    },
+    {
+        "CPU": "Intel Celeron U3400 @ 1.07GHz",
+        "Benchmark": "516"
+    },
+    {
+        "CPU": "Intel Celeron U3600 @ 1.20GHz",
+        "Benchmark": "579"
+    },
+    {
+        "CPU": "Intel Core 3 100U",
+        "Benchmark": "14,223"
+    },
+    {
+        "CPU": "Intel Core 3 201E",
+        "Benchmark": "14,817"
+    },
+    {
+        "CPU": "Intel Core 3 N350",
+        "Benchmark": "6,844"
+    },
+    {
+        "CPU": "Intel Core 3 N355",
+        "Benchmark": "10,248"
+    },
+    {
+        "CPU": "Intel Core 5 120U",
+        "Benchmark": "17,232"
+    },
+    {
+        "CPU": "Intel Core 5 210H",
+        "Benchmark": "18,701"
+    },
+    {
+        "CPU": "Intel Core 5 220H",
+        "Benchmark": "20,604"
+    },
+    {
+        "CPU": "Intel Core 5 220U",
+        "Benchmark": "13,98"
+    },
+    {
+        "CPU": "Intel Core 7 150U",
+        "Benchmark": "15,396"
+    },
+    {
+        "CPU": "Intel Core 7 240H",
+        "Benchmark": "23,025"
+    },
+    {
+        "CPU": "Intel Core 7 250H",
+        "Benchmark": "31,84"
+    },
+    {
+        "CPU": "Intel Core 860 @ 2.80GHz",
+        "Benchmark": "2,754"
+    },
+    {
+        "CPU": "Intel Core Duo L2300 @ 1.50GHz",
+        "Benchmark": "387"
+    },
+    {
+        "CPU": "Intel Core Duo L2400 @ 1.66GHz",
+        "Benchmark": "348"
+    },
+    {
+        "CPU": "Intel Core Duo L2500 @ 1.83GHz",
+        "Benchmark": "404"
+    },
+    {
+        "CPU": "Intel Core Duo T2050 @ 1.60GHz",
+        "Benchmark": "333"
+    },
+    {
+        "CPU": "Intel Core Duo T2250 @ 1.73GHz",
+        "Benchmark": "350"
+    },
+    {
+        "CPU": "Intel Core Duo T2300 @ 1.66GHz",
+        "Benchmark": "325"
+    },
+    {
+        "CPU": "Intel Core Duo T2350 @ 1.86GHz",
+        "Benchmark": "385"
+    },
+    {
+        "CPU": "Intel Core Duo T2400 @ 1.83GHz",
+        "Benchmark": "362"
+    },
+    {
+        "CPU": "Intel Core Duo T2450 @ 2.00GHz",
+        "Benchmark": "411"
+    },
+    {
+        "CPU": "Intel Core Duo T2500 @ 2.00GHz",
+        "Benchmark": "408"
+    },
+    {
+        "CPU": "Intel Core Duo T2600 @ 2.16GHz",
+        "Benchmark": "460"
+    },
+    {
+        "CPU": "Intel Core Duo T2700 @ 2.33GHz",
+        "Benchmark": "498"
+    },
+    {
+        "CPU": "Intel Core Duo U2400 @ 1.06GHz",
+        "Benchmark": "255"
+    },
+    {
+        "CPU": "Intel Core Duo U2500 @ 1.20GHz",
+        "Benchmark": "223"
+    },
+    {
+        "CPU": "Intel Core i3-1000NG4 @ 1.10GHz",
+        "Benchmark": "3,545"
+    },
+    {
+        "CPU": "Intel Core i3-1005G1 @ 1.20GHz",
+        "Benchmark": "4,863"
+    },
+    {
+        "CPU": "Intel Core i3-10100 @ 3.60GHz",
+        "Benchmark": "8,6"
+    },
+    {
+        "CPU": "Intel Core i3-10100E @ 3.20GHz",
+        "Benchmark": "7,944"
+    },
+    {
+        "CPU": "Intel Core i3-10100F @ 3.60GHz",
+        "Benchmark": "8,712"
+    },
+    {
+        "CPU": "Intel Core i3-10100T @ 3.00GHz",
+        "Benchmark": "7,327"
+    },
+    {
+        "CPU": "Intel Core i3-10100TE @ 2.30GHz",
+        "Benchmark": "6,371"
+    },
+    {
+        "CPU": "Intel Core i3-10100Y @ 1.30GHz",
+        "Benchmark": "2,876"
+    },
+    {
+        "CPU": "Intel Core i3-10105 @ 3.70GHz",
+        "Benchmark": "8,356"
+    },
+    {
+        "CPU": "Intel Core i3-10105F @ 3.70GHz",
+        "Benchmark": "8,935"
+    },
+    {
+        "CPU": "Intel Core i3-10105T @ 3.00GHz",
+        "Benchmark": "7,869"
+    },
+    {
+        "CPU": "Intel Core i3-10110U @ 2.10GHz",
+        "Benchmark": "3,866"
+    },
+    {
+        "CPU": "Intel Core i3-10110Y @ 1.00GHz",
+        "Benchmark": "3,264"
+    },
+    {
+        "CPU": "Intel Core i3-1025G1 @ 1.20GHz",
+        "Benchmark": "6,16"
+    },
+    {
+        "CPU": "Intel Core i3-10300 @ 3.70GHz",
+        "Benchmark": "9,299"
+    },
+    {
+        "CPU": "Intel Core i3-10300T @ 3.00GHz",
+        "Benchmark": "7,845"
+    },
+    {
+        "CPU": "Intel Core i3-10305 @ 3.80GHz",
+        "Benchmark": "9,329"
+    },
+    {
+        "CPU": "Intel Core i3-10305T @ 3.00GHz",
+        "Benchmark": "8,136"
+    },
+    {
+        "CPU": "Intel Core i3-10320 @ 3.80GHz",
+        "Benchmark": "10,003"
+    },
+    {
+        "CPU": "Intel Core i3-10325 @ 3.90GHz",
+        "Benchmark": "10,291"
+    },
+    {
+        "CPU": "Intel Core i3-11100B @ 3.60GHz",
+        "Benchmark": "11,357"
+    },
+    {
+        "CPU": "Intel Core i3-11100HE @ 2.40GHz",
+        "Benchmark": "11,673"
+    },
+    {
+        "CPU": "Intel Core i3-1110G4 @ 1.80GHz",
+        "Benchmark": "3,979"
+    },
+    {
+        "CPU": "Intel Core i3-1115G4 @ 3.00GHz",
+        "Benchmark": "5,933"
+    },
+    {
+        "CPU": "Intel Core i3-1115G4E @ 3.00GHz",
+        "Benchmark": "5,499"
+    },
+    {
+        "CPU": "Intel Core i3-1115GRE @ 3.00GHz",
+        "Benchmark": "4,484"
+    },
+    {
+        "CPU": "Intel Core i3-1125G4 @ 2.00GHz",
+        "Benchmark": "9,41"
+    },
+    {
+        "CPU": "Intel Core i3-12100",
+        "Benchmark": "12,382"
+    },
+    {
+        "CPU": "Intel Core i3-12100E",
+        "Benchmark": "14,31"
+    },
+    {
+        "CPU": "Intel Core i3-12100F",
+        "Benchmark": "14,032"
+    },
+    {
+        "CPU": "Intel Core i3-12100T",
+        "Benchmark": "12,537"
+    },
+    {
+        "CPU": "Intel Core i3-12100TE",
+        "Benchmark": "11,859"
+    },
+    {
+        "CPU": "Intel Core i3-1210U",
+        "Benchmark": "10,333"
+    },
+    {
+        "CPU": "Intel Core i3-1215U",
+        "Benchmark": "10,544"
+    },
+    {
+        "CPU": "Intel Core i3-1215UE",
+        "Benchmark": "8,617"
+    },
+    {
+        "CPU": "Intel Core i3-1215UL",
+        "Benchmark": "8,034"
+    },
+    {
+        "CPU": "Intel Core i3-1220P",
+        "Benchmark": "14,582"
+    },
+    {
+        "CPU": "Intel Core i3-1220PE",
+        "Benchmark": "16,146"
+    },
+    {
+        "CPU": "Intel Core i3-12300",
+        "Benchmark": "14,365"
+    },
+    {
+        "CPU": "Intel Core i3-12300HL",
+        "Benchmark": "20,321"
+    },
+    {
+        "CPU": "Intel Core i3-12300T",
+        "Benchmark": "13,209"
+    },
+    {
+        "CPU": "Intel Core i3-1305U",
+        "Benchmark": "8,665"
+    },
+    {
+        "CPU": "Intel Core i3-13100",
+        "Benchmark": "13,675"
+    },
+    {
+        "CPU": "Intel Core i3-13100E",
+        "Benchmark": "13,727"
+    },
+    {
+        "CPU": "Intel Core i3-13100F",
+        "Benchmark": "14,685"
+    },
+    {
+        "CPU": "Intel Core i3-13100T",
+        "Benchmark": "12,815"
+    },
+    {
+        "CPU": "Intel Core i3-13100TE",
+        "Benchmark": "8,057"
+    },
+    {
+        "CPU": "Intel Core i3-1315U",
+        "Benchmark": "11,563"
+    },
+    {
+        "CPU": "Intel Core i3-1315UE",
+        "Benchmark": "8,672"
+    },
+    {
+        "CPU": "Intel Core i3-14100",
+        "Benchmark": "15,304"
+    },
+    {
+        "CPU": "Intel Core i3-14100F",
+        "Benchmark": "15,367"
+    },
+    {
+        "CPU": "Intel Core i3-14100T",
+        "Benchmark": "13,517"
+    },
+    {
+        "CPU": "Intel Core i3-2100 @ 3.10GHz",
+        "Benchmark": "1,854"
+    },
+    {
+        "CPU": "Intel Core i3-2100T @ 2.50GHz",
+        "Benchmark": "1,518"
+    },
+    {
+        "CPU": "Intel Core i3-2102 @ 3.10GHz",
+        "Benchmark": "2,029"
+    },
+    {
+        "CPU": "Intel Core i3-2105 @ 3.10GHz",
+        "Benchmark": "1,837"
+    },
+    {
+        "CPU": "Intel Core i3-21050 @ 3.10GHz",
+        "Benchmark": "2,193"
+    },
+    {
+        "CPU": "Intel Core i3-2120 @ 3.30GHz",
+        "Benchmark": "1,969"
+    },
+    {
+        "CPU": "Intel Core i3-2120T @ 2.60GHz",
+        "Benchmark": "1,565"
+    },
+    {
+        "CPU": "Intel Core i3-2125 @ 3.30GHz",
+        "Benchmark": "2,09"
+    },
+    {
+        "CPU": "Intel Core i3-2130 @ 3.40GHz",
+        "Benchmark": "2,059"
+    },
+    {
+        "CPU": "Intel Core i3-2140 @ 3.50GHz",
+        "Benchmark": "2,307"
+    },
+    {
+        "CPU": "Intel Core i3-2310E @ 2.10GHz",
+        "Benchmark": "1,845"
+    },
+    {
+        "CPU": "Intel Core i3-2310M @ 2.10GHz",
+        "Benchmark": "1,217"
+    },
+    {
+        "CPU": "Intel Core i3-2312M @ 2.10GHz",
+        "Benchmark": "1,175"
+    },
+    {
+        "CPU": "Intel Core i3-2328M @ 2.20GHz",
+        "Benchmark": "1,234"
+    },
+    {
+        "CPU": "Intel Core i3-2330E @ 2.20GHz",
+        "Benchmark": "1,823"
+    },
+    {
+        "CPU": "Intel Core i3-2330M @ 2.20GHz",
+        "Benchmark": "1,251"
+    },
+    {
+        "CPU": "Intel Core i3-2332M @ 2.20GHz",
+        "Benchmark": "1,353"
+    },
+    {
+        "CPU": "Intel Core i3-2340UE @ 1.30GHz",
+        "Benchmark": "976"
+    },
+    {
+        "CPU": "Intel Core i3-2348M @ 2.30GHz",
+        "Benchmark": "1,285"
+    },
+    {
+        "CPU": "Intel Core i3-2350M @ 2.30GHz",
+        "Benchmark": "1,26"
+    },
+    {
+        "CPU": "Intel Core i3-2357M @ 1.30GHz",
+        "Benchmark": "788"
+    },
+    {
+        "CPU": "Intel Core i3-2365M @ 1.40GHz",
+        "Benchmark": "812"
+    },
+    {
+        "CPU": "Intel Core i3-2367M @ 1.40GHz",
+        "Benchmark": "849"
+    },
+    {
+        "CPU": "Intel Core i3-2370M @ 2.40GHz",
+        "Benchmark": "1,359"
+    },
+    {
+        "CPU": "Intel Core i3-2375M @ 1.50GHz",
+        "Benchmark": "904"
+    },
+    {
+        "CPU": "Intel Core i3-2377M @ 1.50GHz",
+        "Benchmark": "874"
+    },
+    {
+        "CPU": "Intel Core i3-3110M @ 2.40GHz",
+        "Benchmark": "1,65"
+    },
+    {
+        "CPU": "Intel Core i3-3120M @ 2.50GHz",
+        "Benchmark": "1,699"
+    },
+    {
+        "CPU": "Intel Core i3-3130M @ 2.60GHz",
+        "Benchmark": "1,9"
+    },
+    {
+        "CPU": "Intel Core i3-3210 @ 3.20GHz",
+        "Benchmark": "2,219"
+    },
+    {
+        "CPU": "Intel Core i3-3217U @ 1.80GHz",
+        "Benchmark": "1,227"
+    },
+    {
+        "CPU": "Intel Core i3-3217UE @ 1.60GHz",
+        "Benchmark": "1,362"
+    },
+    {
+        "CPU": "Intel Core i3-3220 @ 3.30GHz",
+        "Benchmark": "2,275"
+    },
+    {
+        "CPU": "Intel Core i3-3220T @ 2.80GHz",
+        "Benchmark": "1,947"
+    },
+    {
+        "CPU": "Intel Core i3-3225 @ 3.30GHz",
+        "Benchmark": "2,263"
+    },
+    {
+        "CPU": "Intel Core i3-3227U @ 1.90GHz",
+        "Benchmark": "1,293"
+    },
+    {
+        "CPU": "Intel Core i3-3229Y @ 1.40GHz",
+        "Benchmark": "1,008"
+    },
+    {
+        "CPU": "Intel Core i3-3240 @ 3.40GHz",
+        "Benchmark": "2,344"
+    },
+    {
+        "CPU": "Intel Core i3-3240T @ 2.90GHz",
+        "Benchmark": "2,071"
+    },
+    {
+        "CPU": "Intel Core i3-3245 @ 3.40GHz",
+        "Benchmark": "2,382"
+    },
+    {
+        "CPU": "Intel Core i3-3250 @ 3.50GHz",
+        "Benchmark": "2,459"
+    },
+    {
+        "CPU": "Intel Core i3-3250T @ 3.00GHz",
+        "Benchmark": "2,65"
+    },
+    {
+        "CPU": "Intel Core i3-330E @ 2.13GHz",
+        "Benchmark": "1,26"
+    },
+    {
+        "CPU": "Intel Core i3-330M @ 2.13GHz",
+        "Benchmark": "1,029"
+    },
+    {
+        "CPU": "Intel Core i3-330UM @ 1.20GHz",
+        "Benchmark": "543"
+    },
+    {
+        "CPU": "Intel Core i3-350M @ 2.27GHz",
+        "Benchmark": "1,085"
+    },
+    {
+        "CPU": "Intel Core i3-370M @ 2.40GHz",
+        "Benchmark": "1,167"
+    },
+    {
+        "CPU": "Intel Core i3-380M @ 2.53GHz",
+        "Benchmark": "1,208"
+    },
+    {
+        "CPU": "Intel Core i3-380UM @ 1.33GHz",
+        "Benchmark": "748"
+    },
+    {
+        "CPU": "Intel Core i3-390M @ 2.67GHz",
+        "Benchmark": "1,292"
+    },
+    {
+        "CPU": "Intel Core i3-4000M @ 2.40GHz",
+        "Benchmark": "1,791"
+    },
+    {
+        "CPU": "Intel Core i3-4005U @ 1.70GHz",
+        "Benchmark": "1,656"
+    },
+    {
+        "CPU": "Intel Core i3-4010U @ 1.70GHz",
+        "Benchmark": "1,666"
+    },
+    {
+        "CPU": "Intel Core i3-4010Y @ 1.30GHz",
+        "Benchmark": "1,358"
+    },
+    {
+        "CPU": "Intel Core i3-4012Y @ 1.50GHz",
+        "Benchmark": "1,278"
+    },
+    {
+        "CPU": "Intel Core i3-4020Y @ 1.50GHz",
+        "Benchmark": "1,47"
+    },
+    {
+        "CPU": "Intel Core i3-4025U @ 1.90GHz",
+        "Benchmark": "1,968"
+    },
+    {
+        "CPU": "Intel Core i3-4030U @ 1.90GHz",
+        "Benchmark": "1,88"
+    },
+    {
+        "CPU": "Intel Core i3-4030Y @ 1.60GHz",
+        "Benchmark": "1,654"
+    },
+    {
+        "CPU": "Intel Core i3-4100E @ 2.40GHz",
+        "Benchmark": "1,848"
+    },
+    {
+        "CPU": "Intel Core i3-4100M @ 2.50GHz",
+        "Benchmark": "2,522"
+    },
+    {
+        "CPU": "Intel Core i3-4110M @ 2.60GHz",
+        "Benchmark": "2,678"
+    },
+    {
+        "CPU": "Intel Core i3-4110U @ 1.90GHz",
+        "Benchmark": "1,86"
+    },
+    {
+        "CPU": "Intel Core i3-4120U @ 2.00GHz",
+        "Benchmark": "1,948"
+    },
+    {
+        "CPU": "Intel Core i3-4130 @ 3.40GHz",
+        "Benchmark": "3,327"
+    },
+    {
+        "CPU": "Intel Core i3-4130T @ 2.90GHz",
+        "Benchmark": "2,893"
+    },
+    {
+        "CPU": "Intel Core i3-4150 @ 3.50GHz",
+        "Benchmark": "3,4"
+    },
+    {
+        "CPU": "Intel Core i3-4150T @ 3.00GHz",
+        "Benchmark": "2,875"
+    },
+    {
+        "CPU": "Intel Core i3-4158U @ 2.00GHz",
+        "Benchmark": "1,921"
+    },
+    {
+        "CPU": "Intel Core i3-4160 @ 3.60GHz",
+        "Benchmark": "3,513"
+    },
+    {
+        "CPU": "Intel Core i3-4160T @ 3.10GHz",
+        "Benchmark": "3,114"
+    },
+    {
+        "CPU": "Intel Core i3-4170 @ 3.70GHz",
+        "Benchmark": "3,591"
+    },
+    {
+        "CPU": "Intel Core i3-4170T @ 3.20GHz",
+        "Benchmark": "3,132"
+    },
+    {
+        "CPU": "Intel Core i3-4330 @ 3.50GHz",
+        "Benchmark": "3,466"
+    },
+    {
+        "CPU": "Intel Core i3-4330T @ 3.00GHz",
+        "Benchmark": "3,111"
+    },
+    {
+        "CPU": "Intel Core i3-4330TE @ 2.40GHz",
+        "Benchmark": "2,022"
+    },
+    {
+        "CPU": "Intel Core i3-4340 @ 3.60GHz",
+        "Benchmark": "3,481"
+    },
+    {
+        "CPU": "Intel Core i3-4350 @ 3.60GHz",
+        "Benchmark": "3,609"
+    },
+    {
+        "CPU": "Intel Core i3-4350T @ 3.10GHz",
+        "Benchmark": "3,142"
+    },
+    {
+        "CPU": "Intel Core i3-4360 @ 3.70GHz",
+        "Benchmark": "3,663"
+    },
+    {
+        "CPU": "Intel Core i3-4360T @ 3.20GHz",
+        "Benchmark": "3,286"
+    },
+    {
+        "CPU": "Intel Core i3-4370 @ 3.80GHz",
+        "Benchmark": "3,869"
+    },
+    {
+        "CPU": "Intel Core i3-4370T @ 3.30GHz",
+        "Benchmark": "3,361"
+    },
+    {
+        "CPU": "Intel Core i3-4570T @ 2.90GHz",
+        "Benchmark": "3,244"
+    },
+    {
+        "CPU": "Intel Core i3-5005U @ 2.00GHz",
+        "Benchmark": "2,017"
+    },
+    {
+        "CPU": "Intel Core i3-5010U @ 2.10GHz",
+        "Benchmark": "2,184"
+    },
+    {
+        "CPU": "Intel Core i3-5015U @ 2.10GHz",
+        "Benchmark": "1,972"
+    },
+    {
+        "CPU": "Intel Core i3-5020U @ 2.20GHz",
+        "Benchmark": "2,218"
+    },
+    {
+        "CPU": "Intel Core i3-5157U @ 2.50GHz",
+        "Benchmark": "2,593"
+    },
+    {
+        "CPU": "Intel Core i3-530 @ 2.93GHz",
+        "Benchmark": "1,507"
+    },
+    {
+        "CPU": "Intel Core i3-540 @ 3.07GHz",
+        "Benchmark": "1,54"
+    },
+    {
+        "CPU": "Intel Core i3-550 @ 3.20GHz",
+        "Benchmark": "1,625"
+    },
+    {
+        "CPU": "Intel Core i3-560 @ 3.33GHz",
+        "Benchmark": "1,627"
+    },
+    {
+        "CPU": "Intel Core i3-6006U @ 2.00GHz",
+        "Benchmark": "2,274"
+    },
+    {
+        "CPU": "Intel Core i3-6098P @ 3.60GHz",
+        "Benchmark": "3,981"
+    },
+    {
+        "CPU": "Intel Core i3-6100 @ 3.70GHz",
+        "Benchmark": "4,13"
+    },
+    {
+        "CPU": "Intel Core i3-6100E @ 2.70GHz",
+        "Benchmark": "3,315"
+    },
+    {
+        "CPU": "Intel Core i3-6100H @ 2.70GHz",
+        "Benchmark": "3,073"
+    },
+    {
+        "CPU": "Intel Core i3-6100T @ 3.20GHz",
+        "Benchmark": "3,648"
+    },
+    {
+        "CPU": "Intel Core i3-6100TE @ 2.70GHz",
+        "Benchmark": "3,152"
+    },
+    {
+        "CPU": "Intel Core i3-6100U @ 2.30GHz",
+        "Benchmark": "2,639"
+    },
+    {
+        "CPU": "Intel Core i3-6102E @ 1.90GHz",
+        "Benchmark": "2,349"
+    },
+    {
+        "CPU": "Intel Core i3-6157U @ 2.40GHz",
+        "Benchmark": "2,775"
+    },
+    {
+        "CPU": "Intel Core i3-6167U @ 2.70GHz",
+        "Benchmark": "3,255"
+    },
+    {
+        "CPU": "Intel Core i3-6300 @ 3.80GHz",
+        "Benchmark": "4,341"
+    },
+    {
+        "CPU": "Intel Core i3-6300T @ 3.30GHz",
+        "Benchmark": "4,002"
+    },
+    {
+        "CPU": "Intel Core i3-6320 @ 3.90GHz",
+        "Benchmark": "4,409"
+    },
+    {
+        "CPU": "Intel Core i3-7020U @ 2.30GHz",
+        "Benchmark": "2,579"
+    },
+    {
+        "CPU": "Intel Core i3-7100 @ 3.90GHz",
+        "Benchmark": "4,323"
+    },
+    {
+        "CPU": "Intel Core i3-7100H @ 3.00GHz",
+        "Benchmark": "3,43"
+    },
+    {
+        "CPU": "Intel Core i3-7100T @ 3.40GHz",
+        "Benchmark": "3,743"
+    },
+    {
+        "CPU": "Intel Core i3-7100U @ 2.40GHz",
+        "Benchmark": "2,723"
+    },
+    {
+        "CPU": "Intel Core i3-7101E @ 3.90GHz",
+        "Benchmark": "4,43"
+    },
+    {
+        "CPU": "Intel Core i3-7101TE @ 3.40GHz",
+        "Benchmark": "3,956"
+    },
+    {
+        "CPU": "Intel Core i3-7102E @ 2.10GHz",
+        "Benchmark": "2,599"
+    },
+    {
+        "CPU": "Intel Core i3-7130U @ 2.70GHz",
+        "Benchmark": "3,032"
+    },
+    {
+        "CPU": "Intel Core i3-7167U @ 2.80GHz",
+        "Benchmark": "3,368"
+    },
+    {
+        "CPU": "Intel Core i3-7300 @ 4.00GHz",
+        "Benchmark": "4,508"
+    },
+    {
+        "CPU": "Intel Core i3-7300T @ 3.50GHz",
+        "Benchmark": "4,149"
+    },
+    {
+        "CPU": "Intel Core i3-7320 @ 4.10GHz",
+        "Benchmark": "4,829"
+    },
+    {
+        "CPU": "Intel Core i3-7350K @ 4.20GHz",
+        "Benchmark": "4,886"
+    },
+    {
+        "CPU": "Intel Core i3-8100 @ 3.60GHz",
+        "Benchmark": "6,089"
+    },
+    {
+        "CPU": "Intel Core i3-8100B @ 3.60GHz",
+        "Benchmark": "5,979"
+    },
+    {
+        "CPU": "Intel Core i3-8100H @ 3.00GHz",
+        "Benchmark": "4,31"
+    },
+    {
+        "CPU": "Intel Core i3-8100T @ 3.10GHz",
+        "Benchmark": "5,258"
+    },
+    {
+        "CPU": "Intel Core i3-8109U @ 3.00GHz",
+        "Benchmark": "4,198"
+    },
+    {
+        "CPU": "Intel Core i3-8121U @ 2.20GHz",
+        "Benchmark": "4,391"
+    },
+    {
+        "CPU": "Intel Core i3-8130U @ 2.20GHz",
+        "Benchmark": "3,537"
+    },
+    {
+        "CPU": "Intel Core i3-8140U @ 2.10GHz",
+        "Benchmark": "4,227"
+    },
+    {
+        "CPU": "Intel Core i3-8145U @ 2.10GHz",
+        "Benchmark": "3,783"
+    },
+    {
+        "CPU": "Intel Core i3-8145UE @ 2.20GHz",
+        "Benchmark": "4,153"
+    },
+    {
+        "CPU": "Intel Core i3-8300 @ 3.70GHz",
+        "Benchmark": "6,34"
+    },
+    {
+        "CPU": "Intel Core i3-8300T @ 3.20GHz",
+        "Benchmark": "5,576"
+    },
+    {
+        "CPU": "Intel Core i3-8350K @ 4.00GHz",
+        "Benchmark": "6,869"
+    },
+    {
+        "CPU": "Intel Core i3-9100 @ 3.60GHz",
+        "Benchmark": "6,606"
+    },
+    {
+        "CPU": "Intel Core i3-9100E @ 3.10GHz",
+        "Benchmark": "6,767"
+    },
+    {
+        "CPU": "Intel Core i3-9100F @ 3.60GHz",
+        "Benchmark": "6,716"
+    },
+    {
+        "CPU": "Intel Core i3-9100HL @ 1.60GHz",
+        "Benchmark": "2,745"
+    },
+    {
+        "CPU": "Intel Core i3-9100T @ 3.10GHz",
+        "Benchmark": "5,597"
+    },
+    {
+        "CPU": "Intel Core i3-9100TE @ 2.20GHz",
+        "Benchmark": "4,382"
+    },
+    {
+        "CPU": "Intel Core i3-9300 @ 3.70GHz",
+        "Benchmark": "7,193"
+    },
+    {
+        "CPU": "Intel Core i3-9300T @ 3.20GHz",
+        "Benchmark": "6,108"
+    },
+    {
+        "CPU": "Intel Core i3-9320 @ 3.70GHz",
+        "Benchmark": "7,358"
+    },
+    {
+        "CPU": "Intel Core i3-9350K @ 4.00GHz",
+        "Benchmark": "7,662"
+    },
+    {
+        "CPU": "Intel Core i3-9350KF @ 4.00GHz",
+        "Benchmark": "7,559"
+    },
+    {
+        "CPU": "Intel Core i3-N300",
+        "Benchmark": "8,553"
+    },
+    {
+        "CPU": "Intel Core i3-N305",
+        "Benchmark": "9,77"
+    },
+    {
+        "CPU": "Intel Core i5 750S @ 2.40GHz",
+        "Benchmark": "1,326"
+    },
+    {
+        "CPU": "Intel Core i5 E 520 @ 2.40GHz",
+        "Benchmark": "1,619"
+    },
+    {
+        "CPU": "Intel Core i5-10200H @ 2.40GHz",
+        "Benchmark": "7,986"
+    },
+    {
+        "CPU": "Intel Core i5-10210U @ 1.60GHz",
+        "Benchmark": "6,134"
+    },
+    {
+        "CPU": "Intel Core i5-10210Y @ 1.00GHz",
+        "Benchmark": "4,266"
+    },
+    {
+        "CPU": "Intel Core i5-10300H @ 2.50GHz",
+        "Benchmark": "8,281"
+    },
+    {
+        "CPU": "Intel Core i5-1030NG7 @ 1.10GHz",
+        "Benchmark": "5,604"
+    },
+    {
+        "CPU": "Intel Core i5-10310U @ 1.70GHz",
+        "Benchmark": "5,984"
+    },
+    {
+        "CPU": "Intel Core i5-1035G1 @ 1.00GHz",
+        "Benchmark": "7,233"
+    },
+    {
+        "CPU": "Intel Core i5-1035G4 @ 1.10GHz",
+        "Benchmark": "7,831"
+    },
+    {
+        "CPU": "Intel Core i5-1035G7 @ 1.20GHz",
+        "Benchmark": "8,149"
+    },
+    {
+        "CPU": "Intel Core i5-1038NG7 @ 2.00GHz",
+        "Benchmark": "8,837"
+    },
+    {
+        "CPU": "Intel Core i5-10400 @ 2.90GHz",
+        "Benchmark": "12,042"
+    },
+    {
+        "CPU": "Intel Core i5-10400F @ 2.90GHz",
+        "Benchmark": "12,135"
+    },
+    {
+        "CPU": "Intel Core i5-10400H @ 2.60GHz",
+        "Benchmark": "8,364"
+    },
+    {
+        "CPU": "Intel Core i5-10400T @ 2.00GHz",
+        "Benchmark": "9,732"
+    },
+    {
+        "CPU": "Intel Core i5-10500 @ 3.10GHz",
+        "Benchmark": "13,226"
+    },
+    {
+        "CPU": "Intel Core i5-10500E @ 3.10GHz",
+        "Benchmark": "11,212"
+    },
+    {
+        "CPU": "Intel Core i5-10500H @ 2.50GHz",
+        "Benchmark": "11,127"
+    },
+    {
+        "CPU": "Intel Core i5-10500T @ 2.30GHz",
+        "Benchmark": "10,165"
+    },
+    {
+        "CPU": "Intel Core i5-10500TE @ 2.30GHz",
+        "Benchmark": "9,195"
+    },
+    {
+        "CPU": "Intel Core i5-10505 @ 3.20GHz",
+        "Benchmark": "12,066"
+    },
+    {
+        "CPU": "Intel Core i5-10600 @ 3.30GHz",
+        "Benchmark": "13,666"
+    },
+    {
+        "CPU": "Intel Core i5-10600K @ 4.10GHz",
+        "Benchmark": "14,281"
+    },
+    {
+        "CPU": "Intel Core i5-10600KF @ 4.10GHz",
+        "Benchmark": "14,173"
+    },
+    {
+        "CPU": "Intel Core i5-10600T @ 2.40GHz",
+        "Benchmark": "11,397"
+    },
+    {
+        "CPU": "Intel Core i5-11260H @ 2.60GHz",
+        "Benchmark": "15,594"
+    },
+    {
+        "CPU": "Intel Core i5-11300H @ 3.10GHz",
+        "Benchmark": "10,849"
+    },
+    {
+        "CPU": "Intel Core i5-1130G7 @ 1.10GHz",
+        "Benchmark": "8,452"
+    },
+    {
+        "CPU": "Intel Core i5-11320H @ 3.20GHz",
+        "Benchmark": "10,884"
+    },
+    {
+        "CPU": "Intel Core i5-1135G7 @ 2.40GHz",
+        "Benchmark": "9,564"
+    },
+    {
+        "CPU": "Intel Core i5-11400 @ 2.60GHz",
+        "Benchmark": "16,902"
+    },
+    {
+        "CPU": "Intel Core i5-11400F @ 2.60GHz",
+        "Benchmark": "16,927"
+    },
+    {
+        "CPU": "Intel Core i5-11400H @ 2.70GHz",
+        "Benchmark": "15,393"
+    },
+    {
+        "CPU": "Intel Core i5-11400T @ 1.30GHz",
+        "Benchmark": "13,135"
+    },
+    {
+        "CPU": "Intel Core i5-1140G7 @ 1.10GHz",
+        "Benchmark": "8,767"
+    },
+    {
+        "CPU": "Intel Core i5-1145G7 @ 2.60GHz",
+        "Benchmark": "9,512"
+    },
+    {
+        "CPU": "Intel Core i5-1145G7E @ 2.60GHz",
+        "Benchmark": "8,774"
+    },
+    {
+        "CPU": "Intel Core i5-1145GRE @ 2.60GHz",
+        "Benchmark": "8,221"
+    },
+    {
+        "CPU": "Intel Core i5-11500 @ 2.70GHz",
+        "Benchmark": "17,194"
+    },
+    {
+        "CPU": "Intel Core i5-11500B @ 3.30GHz",
+        "Benchmark": "17,358"
+    },
+    {
+        "CPU": "Intel Core i5-11500H @ 2.90GHz",
+        "Benchmark": "15,813"
+    },
+    {
+        "CPU": "Intel Core i5-11500T @ 1.50GHz",
+        "Benchmark": "12,45"
+    },
+    {
+        "CPU": "Intel Core i5-1155G7 @ 2.50GHz",
+        "Benchmark": "9,816"
+    },
+    {
+        "CPU": "Intel Core i5-11600 @ 2.80GHz",
+        "Benchmark": "17,935"
+    },
+    {
+        "CPU": "Intel Core i5-11600K @ 3.90GHz",
+        "Benchmark": "19,541"
+    },
+    {
+        "CPU": "Intel Core i5-11600KF @ 3.90GHz",
+        "Benchmark": "19,539"
+    },
+    {
+        "CPU": "Intel Core i5-11600T @ 1.70GHz",
+        "Benchmark": "14,396"
+    },
+    {
+        "CPU": "Intel Core i5-1230U",
+        "Benchmark": "10,809"
+    },
+    {
+        "CPU": "Intel Core i5-1235U",
+        "Benchmark": "12,986"
+    },
+    {
+        "CPU": "Intel Core i5-12400",
+        "Benchmark": "19,1"
+    },
+    {
+        "CPU": "Intel Core i5-12400F",
+        "Benchmark": "19,477"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Core i5-12400F",
+        "Benchmark": "19,68"
+    },
+    {
+        "CPU": "Intel Core i5-12400T",
+        "Benchmark": "15,854"
+    },
+    {
+        "CPU": "Intel Core i5-1240P",
+        "Benchmark": "16,674"
+    },
+    {
+        "CPU": "Intel Core i5-1240U",
+        "Benchmark": "12,999"
+    },
+    {
+        "CPU": "Intel Core i5-12450H",
+        "Benchmark": "16,403"
+    },
+    {
+        "CPU": "Intel Core i5-12450HX",
+        "Benchmark": "18,341"
+    },
+    {
+        "CPU": "Intel Core i5-1245U",
+        "Benchmark": "13,258"
+    },
+    {
+        "CPU": "Intel Core i5-1245UE",
+        "Benchmark": "9,437"
+    },
+    {
+        "CPU": "Intel Core i5-12490F",
+        "Benchmark": "20,192"
+    },
+    {
+        "CPU": "Intel Core i5-12500",
+        "Benchmark": "19,753"
+    },
+    {
+        "CPU": "Intel Core i5-12500E",
+        "Benchmark": "20,049"
+    },
+    {
+        "CPU": "Intel Core i5-12500H",
+        "Benchmark": "20,651"
+    },
+    {
+        "CPU": "Intel Core i5-12500T",
+        "Benchmark": "16,429"
+    },
+    {
+        "CPU": "Intel Core i5-12500TE",
+        "Benchmark": "14,533"
+    },
+    {
+        "CPU": "Intel Core i5-1250P",
+        "Benchmark": "19,851"
+    },
+    {
+        "CPU": "Intel Core i5-1250PE",
+        "Benchmark": "18,365"
+    },
+    {
+        "CPU": "Intel Core i5-12600",
+        "Benchmark": "21,437"
+    },
+    {
+        "CPU": "Intel Core i5-12600H",
+        "Benchmark": "20,991"
+    },
+    {
+        "CPU": "Intel Core i5-12600HE",
+        "Benchmark": "22,827"
+    },
+    {
+        "CPU": "Intel Core i5-12600HL",
+        "Benchmark": "23,615"
+    },
+    {
+        "CPU": "Intel Core i5-12600HX",
+        "Benchmark": "24,205"
+    },
+    {
+        "CPU": "Intel Core i5-12600K",
+        "Benchmark": "27,632"
+    },
+    {
+        "CPU": "Intel Core i5-12600KF",
+        "Benchmark": "27,843"
+    },
+    {
+        "CPU": "Intel Core i5-12600T",
+        "Benchmark": "17,51"
+    },
+    {
+        "CPU": "Intel Core i5-1334U",
+        "Benchmark": "13,31"
+    },
+    {
+        "CPU": "Intel Core i5-1335U",
+        "Benchmark": "14,373"
+    },
+    {
+        "CPU": "Intel Core i5-1335UE",
+        "Benchmark": "10,863"
+    },
+    {
+        "CPU": "Intel Core i5-13400",
+        "Benchmark": "23,679"
+    },
+    {
+        "CPU": "Intel Core i5-13400E",
+        "Benchmark": "27"
+    },
+    {
+        "CPU": "Intel Core i5-13400F",
+        "Benchmark": "25,079"
+    },
+    {
+        "CPU": "Intel Core i5-13400T",
+        "Benchmark": "20,316"
+    },
+    {
+        "CPU": "Intel Core i5-1340P",
+        "Benchmark": "18,784"
+    },
+    {
+        "CPU": "Intel Core i5-1340PE",
+        "Benchmark": "17,476"
+    },
+    {
+        "CPU": "Intel Core i5-13420H",
+        "Benchmark": "17,604"
+    },
+    {
+        "CPU": "Intel Core i5-13450HX",
+        "Benchmark": "25,269"
+    },
+    {
+        "CPU": "Intel Core i5-1345U",
+        "Benchmark": "14,581"
+    },
+    {
+        "CPU": "Intel Core i5-1345UE",
+        "Benchmark": "10,312"
+    },
+    {
+        "CPU": "Intel Core i5-1345URE",
+        "Benchmark": "11,565"
+    },
+    {
+        "CPU": "Intel Core i5-13490F",
+        "Benchmark": "26,432"
+    },
+    {
+        "CPU": "Intel Core i5-13500",
+        "Benchmark": "31,42"
+    },
+    {
+        "CPU": "Intel Core i5-13500E",
+        "Benchmark": "28,092"
+    },
+    {
+        "CPU": "Intel Core i5-13500H",
+        "Benchmark": "21,871"
+    },
+    {
+        "CPU": "Intel Core i5-13500HX",
+        "Benchmark": "28,829"
+    },
+    {
+        "CPU": "Intel Core i5-13500T",
+        "Benchmark": "22,704"
+    },
+    {
+        "CPU": "Intel Core i5-13500TE",
+        "Benchmark": "21,242"
+    },
+    {
+        "CPU": "Intel Core i5-1350P",
+        "Benchmark": "19,045"
+    },
+    {
+        "CPU": "Intel Core i5-13600",
+        "Benchmark": "31,662"
+    },
+    {
+        "CPU": "Intel Core i5-13600H",
+        "Benchmark": "23,436"
+    },
+    {
+        "CPU": "Intel Core i5-13600HE",
+        "Benchmark": "23,483"
+    },
+    {
+        "CPU": "Intel Core i5-13600HX",
+        "Benchmark": "28,078"
+    },
+    {
+        "CPU": "Intel Core i5-13600K",
+        "Benchmark": "37,688"
+    },
+    {
+        "CPU": "Intel Core i5-13600KF",
+        "Benchmark": "37,528"
+    },
+    {
+        "CPU": "Intel Core i5-13600T",
+        "Benchmark": "26,952"
+    },
+    {
+        "CPU": "Intel Core i5-14400",
+        "Benchmark": "25,346"
+    },
+    {
+        "CPU": "Intel Core i5-14400F",
+        "Benchmark": "25,741"
+    },
+    {
+        "CPU": "Intel Core i5-14400T",
+        "Benchmark": "22,173"
+    },
+    {
+        "CPU": "Intel Core i5-14450HX",
+        "Benchmark": "25,387"
+    },
+    {
+        "CPU": "Intel Core i5-14490F",
+        "Benchmark": "28,662"
+    },
+    {
+        "CPU": "Intel Core i5-14500",
+        "Benchmark": "31,392"
+    },
+    {
+        "CPU": "Intel Core i5-14500HX",
+        "Benchmark": "29,144"
+    },
+    {
+        "CPU": "Intel Core i5-14500T",
+        "Benchmark": "23,106"
+    },
+    {
+        "CPU": "Intel Core i5-14600",
+        "Benchmark": "33,203"
+    },
+    {
+        "CPU": "Intel Core i5-14600K",
+        "Benchmark": "38,69"
+    },
+    {
+        "CPU": "Intel Core i5-14600KF",
+        "Benchmark": "38,857"
+    },
+    {
+        "CPU": "Intel Core i5-14600T",
+        "Benchmark": "27,129"
+    },
+    {
+        "CPU": "Intel Core i5-2300 @ 2.80GHz",
+        "Benchmark": "3,464"
+    },
+    {
+        "CPU": "Intel Core i5-2310 @ 2.90GHz",
+        "Benchmark": "3,661"
+    },
+    {
+        "CPU": "Intel Core i5-2320 @ 3.00GHz",
+        "Benchmark": "3,689"
+    },
+    {
+        "CPU": "Intel Core i5-2380P @ 3.10GHz",
+        "Benchmark": "3,636"
+    },
+    {
+        "CPU": "Intel Core i5-2390T @ 2.70GHz",
+        "Benchmark": "2,506"
+    },
+    {
+        "CPU": "Intel Core i5-2400 @ 3.10GHz",
+        "Benchmark": "3,87"
+    },
+    {
+        "CPU": "Intel Core i5-2400S @ 2.50GHz",
+        "Benchmark": "3,172"
+    },
+    {
+        "CPU": "Intel Core i5-24050S @ 2.50GHz",
+        "Benchmark": "3,061"
+    },
+    {
+        "CPU": "Intel Core i5-2405S @ 2.50GHz",
+        "Benchmark": "3,224"
+    },
+    {
+        "CPU": "Intel Core i5-2410M @ 2.30GHz",
+        "Benchmark": "1,947"
+    },
+    {
+        "CPU": "Intel Core i5-2415M @ 2.30GHz",
+        "Benchmark": "1,908"
+    },
+    {
+        "CPU": "Intel Core i5-2430M @ 2.40GHz",
+        "Benchmark": "2,002"
+    },
+    {
+        "CPU": "Intel Core i5-2435M @ 2.40GHz",
+        "Benchmark": "2,031"
+    },
+    {
+        "CPU": "Intel Core i5-2450M @ 2.50GHz",
+        "Benchmark": "2,089"
+    },
+    {
+        "CPU": "Intel Core i5-2450P @ 3.20GHz",
+        "Benchmark": "4,273"
+    },
+    {
+        "CPU": "Intel Core i5-2467M @ 1.60GHz",
+        "Benchmark": "1,414"
+    },
+    {
+        "CPU": "Intel Core i5-2500 @ 3.30GHz",
+        "Benchmark": "4,116"
+    },
+    {
+        "CPU": "Intel Core i5-2500K @ 3.30GHz",
+        "Benchmark": "4,128"
+    },
+    {
+        "CPU": "Intel Core i5-2500S @ 2.70GHz",
+        "Benchmark": "3,389"
+    },
+    {
+        "CPU": "Intel Core i5-2500T @ 2.30GHz",
+        "Benchmark": "2,929"
+    },
+    {
+        "CPU": "Intel Core i5-2510E @ 2.50GHz",
+        "Benchmark": "1,889"
+    },
+    {
+        "CPU": "Intel Core i5-2515E @ 2.50GHz",
+        "Benchmark": "1,882"
+    },
+    {
+        "CPU": "Intel Core i5-2520M @ 2.50GHz",
+        "Benchmark": "2,248"
+    },
+    {
+        "CPU": "Intel Core i5-2537M @ 1.40GHz",
+        "Benchmark": "1,191"
+    },
+    {
+        "CPU": "Intel Core i5-2540M @ 2.60GHz",
+        "Benchmark": "2,353"
+    },
+    {
+        "CPU": "Intel Core i5-2550K @ 3.40GHz",
+        "Benchmark": "4,197"
+    },
+    {
+        "CPU": "Intel Core i5-2557M @ 1.70GHz",
+        "Benchmark": "1,625"
+    },
+    {
+        "CPU": "Intel Core i5-2560M @ 2.70GHz",
+        "Benchmark": "2,397"
+    },
+    {
+        "CPU": "Intel Core i5-3170K @ 3.20GHz",
+        "Benchmark": "8,882"
+    },
+    {
+        "CPU": "Intel Core i5-3210M @ 2.50GHz",
+        "Benchmark": "2,469"
+    },
+    {
+        "CPU": "Intel Core i5-3230M @ 2.60GHz",
+        "Benchmark": "2,564"
+    },
+    {
+        "CPU": "Intel Core i5-3317U @ 1.70GHz",
+        "Benchmark": "2,018"
+    },
+    {
+        "CPU": "Intel Core i5-3320M @ 2.60GHz",
+        "Benchmark": "2,662"
+    },
+    {
+        "CPU": "Intel Core i5-3330 @ 3.00GHz",
+        "Benchmark": "4,102"
+    },
+    {
+        "CPU": "Intel Core i5-3330S @ 2.70GHz",
+        "Benchmark": "3,899"
+    },
+    {
+        "CPU": "Intel Core i5-3335S @ 2.70GHz",
+        "Benchmark": "3,783"
+    },
+    {
+        "CPU": "Intel Core i5-3337U @ 1.80GHz",
+        "Benchmark": "2,101"
+    },
+    {
+        "CPU": "Intel Core i5-3339Y @ 1.50GHz",
+        "Benchmark": "1,589"
+    },
+    {
+        "CPU": "Intel Core i5-3340 @ 3.10GHz",
+        "Benchmark": "4,235"
+    },
+    {
+        "CPU": "Intel Core i5-3340M @ 2.70GHz",
+        "Benchmark": "2,699"
+    },
+    {
+        "CPU": "Intel Core i5-3340S @ 2.80GHz",
+        "Benchmark": "3,95"
+    },
+    {
+        "CPU": "Intel Core i5-3350P @ 3.10GHz",
+        "Benchmark": "4,3"
+    },
+    {
+        "CPU": "Intel Core i5-3360M @ 2.80GHz",
+        "Benchmark": "2,876"
+    },
+    {
+        "CPU": "Intel Core i5-3380M @ 2.90GHz",
+        "Benchmark": "2,923"
+    },
+    {
+        "CPU": "Intel Core i5-3427U @ 1.80GHz",
+        "Benchmark": "2,238"
+    },
+    {
+        "CPU": "Intel Core i5-3437U @ 1.90GHz",
+        "Benchmark": "2,193"
+    },
+    {
+        "CPU": "Intel Core i5-3439Y @ 1.50GHz",
+        "Benchmark": "1,907"
+    },
+    {
+        "CPU": "Intel Core i5-3450 @ 3.10GHz",
+        "Benchmark": "4,517"
+    },
+    {
+        "CPU": "Intel Core i5-3450S @ 2.80GHz",
+        "Benchmark": "4,348"
+    },
+    {
+        "CPU": "Intel Core i5-3470 @ 3.20GHz",
+        "Benchmark": "4,67"
+    },
+    {
+        "CPU": "Intel Core i5-3470S @ 2.90GHz",
+        "Benchmark": "4,398"
+    },
+    {
+        "CPU": "Intel Core i5-3470T @ 2.90GHz",
+        "Benchmark": "3,005"
+    },
+    {
+        "CPU": "Intel Core i5-3475S @ 2.90GHz",
+        "Benchmark": "4,298"
+    },
+    {
+        "CPU": "Intel Core i5-3550 @ 3.30GHz",
+        "Benchmark": "4,793"
+    },
+    {
+        "CPU": "Intel Core i5-3550S @ 3.00GHz",
+        "Benchmark": "4,401"
+    },
+    {
+        "CPU": "Intel Core i5-3570 @ 3.40GHz",
+        "Benchmark": "4,942"
+    },
+    {
+        "CPU": "Intel Core i5-3570K @ 3.40GHz",
+        "Benchmark": "4,964"
+    },
+    {
+        "CPU": "Intel Core i5-3570S @ 3.10GHz",
+        "Benchmark": "4,674"
+    },
+    {
+        "CPU": "Intel Core i5-3570T @ 2.30GHz",
+        "Benchmark": "3,962"
+    },
+    {
+        "CPU": "Intel Core i5-3610ME @ 2.70GHz",
+        "Benchmark": "2,666"
+    },
+    {
+        "CPU": "Intel Core i5-4200H @ 2.80GHz",
+        "Benchmark": "3,016"
+    },
+    {
+        "CPU": "Intel Core i5-4200M @ 2.50GHz",
+        "Benchmark": "2,807"
+    },
+    {
+        "CPU": "Intel Core i5-4200U @ 1.60GHz",
+        "Benchmark": "2,183"
+    },
+    {
+        "CPU": "Intel Core i5-4200Y @ 1.40GHz",
+        "Benchmark": "1,558"
+    },
+    {
+        "CPU": "Intel Core i5-4202Y @ 1.60GHz",
+        "Benchmark": "1,518"
+    },
+    {
+        "CPU": "Intel Core i5-4210H @ 2.90GHz",
+        "Benchmark": "3,074"
+    },
+    {
+        "CPU": "Intel Core i5-4210M @ 2.60GHz",
+        "Benchmark": "2,884"
+    },
+    {
+        "CPU": "Intel Core i5-4210U @ 1.70GHz",
+        "Benchmark": "2,314"
+    },
+    {
+        "CPU": "Intel Core i5-4210Y @ 1.50GHz",
+        "Benchmark": "1,535"
+    },
+    {
+        "CPU": "Intel Core i5-4220Y @ 1.60GHz",
+        "Benchmark": "1,652"
+    },
+    {
+        "CPU": "Intel Core i5-4230U @ 1.90GHz",
+        "Benchmark": "1,853"
+    },
+    {
+        "CPU": "Intel Core i5-4250U @ 1.30GHz",
+        "Benchmark": "2,148"
+    },
+    {
+        "CPU": "Intel Core i5-4258U @ 2.40GHz",
+        "Benchmark": "2,621"
+    },
+    {
+        "CPU": "Intel Core i5-4260U @ 1.40GHz",
+        "Benchmark": "2,307"
+    },
+    {
+        "CPU": "Intel Core i5-4278U @ 2.60GHz",
+        "Benchmark": "2,828"
+    },
+    {
+        "CPU": "Intel Core i5-4288U @ 2.60GHz",
+        "Benchmark": "2,685"
+    },
+    {
+        "CPU": "Intel Core i5-4300M @ 2.60GHz",
+        "Benchmark": "2,974"
+    },
+    {
+        "CPU": "Intel Core i5-4300U @ 1.90GHz",
+        "Benchmark": "2,495"
+    },
+    {
+        "CPU": "Intel Core i5-4300Y @ 1.60GHz",
+        "Benchmark": "1,492"
+    },
+    {
+        "CPU": "Intel Core i5-4302Y @ 1.60GHz",
+        "Benchmark": "1,58"
+    },
+    {
+        "CPU": "Intel Core i5-4308U @ 2.80GHz",
+        "Benchmark": "2,975"
+    },
+    {
+        "CPU": "Intel Core i5-430M @ 2.27GHz",
+        "Benchmark": "1,209"
+    },
+    {
+        "CPU": "Intel Core i5-430UM @ 1.20GHz",
+        "Benchmark": "627"
+    },
+    {
+        "CPU": "Intel Core i5-4310M @ 2.70GHz",
+        "Benchmark": "3,069"
+    },
+    {
+        "CPU": "Intel Core i5-4310U @ 2.00GHz",
+        "Benchmark": "2,532"
+    },
+    {
+        "CPU": "Intel Core i5-4330M @ 2.80GHz",
+        "Benchmark": "3,19"
+    },
+    {
+        "CPU": "Intel Core i5-4340M @ 2.90GHz",
+        "Benchmark": "3,352"
+    },
+    {
+        "CPU": "Intel Core i5-4350U @ 1.40GHz",
+        "Benchmark": "2,425"
+    },
+    {
+        "CPU": "Intel Core i5-4400E @ 2.70GHz",
+        "Benchmark": "3,251"
+    },
+    {
+        "CPU": "Intel Core i5-4402E @ 1.60GHz",
+        "Benchmark": "2,681"
+    },
+    {
+        "CPU": "Intel Core i5-4422E @ 1.80GHz",
+        "Benchmark": "1,907"
+    },
+    {
+        "CPU": "Intel Core i5-4430 @ 3.00GHz",
+        "Benchmark": "4,658"
+    },
+    {
+        "CPU": "Intel Core i5-4430S @ 2.70GHz",
+        "Benchmark": "4,361"
+    },
+    {
+        "CPU": "Intel Core i5-4440 @ 3.10GHz",
+        "Benchmark": "4,788"
+    },
+    {
+        "CPU": "Intel Core i5-4440S @ 2.80GHz",
+        "Benchmark": "4,331"
+    },
+    {
+        "CPU": "Intel Core i5-4460 @ 3.20GHz",
+        "Benchmark": "4,908"
+    },
+    {
+        "CPU": "Intel Core i5-4460S @ 2.90GHz",
+        "Benchmark": "4,629"
+    },
+    {
+        "CPU": "Intel Core i5-4460T @ 1.90GHz",
+        "Benchmark": "3,643"
+    },
+    {
+        "CPU": "Intel Core i5-4470 @ 3.30GHz",
+        "Benchmark": "4,491"
+    },
+    {
+        "CPU": "Intel Core i5-4470S @ 3.00GHz",
+        "Benchmark": "4,742"
+    },
+    {
+        "CPU": "Intel Core i5-450M @ 2.40GHz",
+        "Benchmark": "1,255"
+    },
+    {
+        "CPU": "Intel Core i5-4570 @ 3.20GHz",
+        "Benchmark": "5,238"
+    },
+    {
+        "CPU": "Intel Core i5-4570R @ 2.70GHz",
+        "Benchmark": "4,578"
+    },
+    {
+        "CPU": "Intel Core i5-4570S @ 2.90GHz",
+        "Benchmark": "5,017"
+    },
+    {
+        "CPU": "Intel Core i5-4570T @ 2.90GHz",
+        "Benchmark": "3,233"
+    },
+    {
+        "CPU": "Intel Core i5-4570TE @ 2.70GHz",
+        "Benchmark": "3,083"
+    },
+    {
+        "CPU": "Intel Core i5-4590 @ 3.30GHz",
+        "Benchmark": "5,374"
+    },
+    {
+        "CPU": "Intel Core i5-4590S @ 3.00GHz",
+        "Benchmark": "5,136"
+    },
+    {
+        "CPU": "Intel Core i5-4590T @ 2.00GHz",
+        "Benchmark": "4,067"
+    },
+    {
+        "CPU": "Intel Core i5-460M @ 2.53GHz",
+        "Benchmark": "1,312"
+    },
+    {
+        "CPU": "Intel Core i5-4670 @ 3.40GHz",
+        "Benchmark": "5,5"
+    },
+    {
+        "CPU": "Intel Core i5-4670K @ 3.40GHz",
+        "Benchmark": "5,577"
+    },
+    {
+        "CPU": "Intel Core i5-4670K CPT @ 3.40GHz",
+        "Benchmark": "5,034"
+    },
+    {
+        "CPU": "Intel Core i5-4670R @ 3.00GHz",
+        "Benchmark": "5,233"
+    },
+    {
+        "CPU": "Intel Core i5-4670S @ 3.10GHz",
+        "Benchmark": "5,247"
+    },
+    {
+        "CPU": "Intel Core i5-4670T @ 2.30GHz",
+        "Benchmark": "4,456"
+    },
+    {
+        "CPU": "Intel Core i5-4690 @ 3.50GHz",
+        "Benchmark": "5,575"
+    },
+    {
+        "CPU": "Intel Core i5-4690K @ 3.50GHz",
+        "Benchmark": "5,705"
+    },
+    {
+        "CPU": "Intel Core i5-4690S @ 3.20GHz",
+        "Benchmark": "5,469"
+    },
+    {
+        "CPU": "Intel Core i5-4690T @ 2.50GHz",
+        "Benchmark": "4,587"
+    },
+    {
+        "CPU": "Intel Core i5-470UM @ 1.33GHz",
+        "Benchmark": "782"
+    },
+    {
+        "CPU": "Intel Core i5-480M @ 2.67GHz",
+        "Benchmark": "1,324"
+    },
+    {
+        "CPU": "Intel Core i5-5200U @ 2.20GHz",
+        "Benchmark": "2,505"
+    },
+    {
+        "CPU": "Intel Core i5-520M @ 2.40GHz",
+        "Benchmark": "1,728"
+    },
+    {
+        "CPU": "Intel Core i5-520UM @ 1.07GHz",
+        "Benchmark": "908"
+    },
+    {
+        "CPU": "Intel Core i5-5250U @ 1.60GHz",
+        "Benchmark": "2,448"
+    },
+    {
+        "CPU": "Intel Core i5-5257U @ 2.70GHz",
+        "Benchmark": "2,827"
+    },
+    {
+        "CPU": "Intel Core i5-5287U @ 2.90GHz",
+        "Benchmark": "3,078"
+    },
+    {
+        "CPU": "Intel Core i5-5300U @ 2.30GHz",
+        "Benchmark": "2,713"
+    },
+    {
+        "CPU": "Intel Core i5-5350U @ 1.80GHz",
+        "Benchmark": "2,583"
+    },
+    {
+        "CPU": "Intel Core i5-540M @ 2.53GHz",
+        "Benchmark": "1,795"
+    },
+    {
+        "CPU": "Intel Core i5-540UM @ 1.20GHz",
+        "Benchmark": "1,002"
+    },
+    {
+        "CPU": "Intel Core i5-5575R @ 2.80GHz",
+        "Benchmark": "5,098"
+    },
+    {
+        "CPU": "Intel Core i5-560M @ 2.67GHz",
+        "Benchmark": "1,91"
+    },
+    {
+        "CPU": "Intel Core i5-560UM @ 1.33GHz",
+        "Benchmark": "1,015"
+    },
+    {
+        "CPU": "Intel Core i5-5675C @ 3.10GHz",
+        "Benchmark": "5,689"
+    },
+    {
+        "CPU": "Intel Core i5-5675R @ 3.10GHz",
+        "Benchmark": "5,567"
+    },
+    {
+        "CPU": "Intel Core i5-580M @ 2.67GHz",
+        "Benchmark": "1,952"
+    },
+    {
+        "CPU": "Intel Core i5-6198DU @ 2.30GHz",
+        "Benchmark": "3,091"
+    },
+    {
+        "CPU": "Intel Core i5-6200U @ 2.30GHz",
+        "Benchmark": "2,994"
+    },
+    {
+        "CPU": "Intel Core i5-6260U @ 1.80GHz",
+        "Benchmark": "3,193"
+    },
+    {
+        "CPU": "Intel Core i5-6267U @ 2.90GHz",
+        "Benchmark": "3,369"
+    },
+    {
+        "CPU": "Intel Core i5-6287U @ 3.10GHz",
+        "Benchmark": "3,801"
+    },
+    {
+        "CPU": "Intel Core i5-6300HQ @ 2.30GHz",
+        "Benchmark": "4,688"
+    },
+    {
+        "CPU": "Intel Core i5-6300U @ 2.40GHz",
+        "Benchmark": "3,214"
+    },
+    {
+        "CPU": "Intel Core i5-6350HQ @ 2.30GHz",
+        "Benchmark": "4,255"
+    },
+    {
+        "CPU": "Intel Core i5-6360U @ 2.00GHz",
+        "Benchmark": "3,09"
+    },
+    {
+        "CPU": "Intel Core i5-6400 @ 2.70GHz",
+        "Benchmark": "5,173"
+    },
+    {
+        "CPU": "Intel Core i5-6400T @ 2.20GHz",
+        "Benchmark": "4,267"
+    },
+    {
+        "CPU": "Intel Core i5-6402P @ 2.80GHz",
+        "Benchmark": "5,355"
+    },
+    {
+        "CPU": "Intel Core i5-6440EQ @ 2.70GHz",
+        "Benchmark": "5,389"
+    },
+    {
+        "CPU": "Intel Core i5-6440HQ @ 2.60GHz",
+        "Benchmark": "5,023"
+    },
+    {
+        "CPU": "Intel Core i5-6442EQ @ 1.90GHz",
+        "Benchmark": "4,483"
+    },
+    {
+        "CPU": "Intel Core i5-650 @ 3.20GHz",
+        "Benchmark": "2,254"
+    },
+    {
+        "CPU": "Intel Core i5-6500 @ 3.20GHz",
+        "Benchmark": "5,613"
+    },
+    {
+        "CPU": "Intel Core i5-6500T @ 2.50GHz",
+        "Benchmark": "4,756"
+    },
+    {
+        "CPU": "Intel Core i5-6500TE @ 2.30GHz",
+        "Benchmark": "4,746"
+    },
+    {
+        "CPU": "Intel Core i5-655K @ 3.20GHz",
+        "Benchmark": "2,017"
+    },
+    {
+        "CPU": "Intel Core i5-660 @ 3.33GHz",
+        "Benchmark": "2,42"
+    },
+    {
+        "CPU": "Intel Core i5-6600 @ 3.30GHz",
+        "Benchmark": "6,056"
+    },
+    {
+        "CPU": "Intel Core i5-6600K @ 3.50GHz",
+        "Benchmark": "6,305"
+    },
+    {
+        "CPU": "Intel Core i5-6600T @ 2.70GHz",
+        "Benchmark": "5,577"
+    },
+    {
+        "CPU": "Intel Core i5-661 @ 3.33GHz",
+        "Benchmark": "2,482"
+    },
+    {
+        "CPU": "Intel Core i5-670 @ 3.47GHz",
+        "Benchmark": "2,533"
+    },
+    {
+        "CPU": "Intel Core i5-680 @ 3.60GHz",
+        "Benchmark": "2,658"
+    },
+    {
+        "CPU": "Intel Core i5-7200U @ 2.50GHz",
+        "Benchmark": "3,37"
+    },
+    {
+        "CPU": "Intel Core i5-7260U @ 2.20GHz",
+        "Benchmark": "3,973"
+    },
+    {
+        "CPU": "Intel Core i5-7267U @ 3.10GHz",
+        "Benchmark": "3,608"
+    },
+    {
+        "CPU": "Intel Core i5-7287U @ 3.30GHz",
+        "Benchmark": "3,743"
+    },
+    {
+        "CPU": "Intel Core i5-7300HQ @ 2.50GHz",
+        "Benchmark": "5,081"
+    },
+    {
+        "CPU": "Intel Core i5-7300U @ 2.60GHz",
+        "Benchmark": "3,639"
+    },
+    {
+        "CPU": "Intel Core i5-7360U @ 2.30GHz",
+        "Benchmark": "3,827"
+    },
+    {
+        "CPU": "Intel Core i5-7400 @ 3.00GHz",
+        "Benchmark": "5,475"
+    },
+    {
+        "CPU": "Intel Core i5-7400T @ 2.40GHz",
+        "Benchmark": "4,722"
+    },
+    {
+        "CPU": "Intel Core i5-7440EQ @ 2.90GHz",
+        "Benchmark": "5,711"
+    },
+    {
+        "CPU": "Intel Core i5-7440HQ @ 2.80GHz",
+        "Benchmark": "5,489"
+    },
+    {
+        "CPU": "Intel Core i5-7442EQ @ 2.10GHz",
+        "Benchmark": "4,834"
+    },
+    {
+        "CPU": "Intel Core i5-750 @ 2.67GHz",
+        "Benchmark": "2,535"
+    },
+    {
+        "CPU": "Intel Core i5-7500 @ 3.40GHz",
+        "Benchmark": "6,027"
+    },
+    {
+        "CPU": "Intel Core i5-7500T @ 2.70GHz",
+        "Benchmark": "5,2"
+    },
+    {
+        "CPU": "Intel Core i5-760 @ 2.80GHz",
+        "Benchmark": "2,655"
+    },
+    {
+        "CPU": "Intel Core i5-7600 @ 3.50GHz",
+        "Benchmark": "6,552"
+    },
+    {
+        "CPU": "Intel Core i5-7600K @ 3.80GHz",
+        "Benchmark": "6,805"
+    },
+    {
+        "CPU": "Intel Core i5-7600T @ 2.80GHz",
+        "Benchmark": "5,875"
+    },
+    {
+        "CPU": "Intel Core i5-760S @ 2.53GHz",
+        "Benchmark": "5,44"
+    },
+    {
+        "CPU": "Intel Core i5-7640X @ 4.00GHz",
+        "Benchmark": "7,021"
+    },
+    {
+        "CPU": "Intel Core i5-7Y54 @ 1.20GHz",
+        "Benchmark": "2,619"
+    },
+    {
+        "CPU": "Intel Core i5-7Y57 @ 1.20GHz",
+        "Benchmark": "2,588"
+    },
+    {
+        "CPU": "Intel Core i5-8200Y @ 1.30GHz",
+        "Benchmark": "2,243"
+    },
+    {
+        "CPU": "Intel Core i5-8210Y @ 1.60GHz",
+        "Benchmark": "2,738"
+    },
+    {
+        "CPU": "Intel Core i5-8250U @ 1.60GHz",
+        "Benchmark": "5,819"
+    },
+    {
+        "CPU": "Intel Core i5-8257U @ 1.40GHz",
+        "Benchmark": "7,438"
+    },
+    {
+        "CPU": "Intel Core i5-8259U @ 2.30GHz",
+        "Benchmark": "7,842"
+    },
+    {
+        "CPU": "Intel Core i5-8260U @ 1.60GHz",
+        "Benchmark": "7,398"
+    },
+    {
+        "CPU": "Intel Core i5-8265U @ 1.60GHz",
+        "Benchmark": "5,86"
+    },
+    {
+        "CPU": "Intel Core i5-8265UC @ 1.60GHz",
+        "Benchmark": "5,187"
+    },
+    {
+        "CPU": "Intel Core i5-8269U @ 2.60GHz",
+        "Benchmark": "7,111"
+    },
+    {
+        "CPU": "Intel Core i5-8279U @ 2.40GHz",
+        "Benchmark": "7,497"
+    },
+    {
+        "CPU": "Intel Core i5-8300H @ 2.30GHz",
+        "Benchmark": "7,39"
+    },
+    {
+        "CPU": "Intel Core i5-8305G @ 2.80GHz",
+        "Benchmark": "6,951"
+    },
+    {
+        "CPU": "Intel Core i5-8350U @ 1.70GHz",
+        "Benchmark": "6,142"
+    },
+    {
+        "CPU": "Intel Core i5-8365U @ 1.60GHz",
+        "Benchmark": "5,993"
+    },
+    {
+        "CPU": "Intel Core i5-8365UE @ 1.60GHz",
+        "Benchmark": "5,694"
+    },
+    {
+        "CPU": "Intel Core i5-8400 @ 2.80GHz",
+        "Benchmark": "9,226"
+    },
+    {
+        "CPU": "Intel Core i5-8400H @ 2.50GHz",
+        "Benchmark": "7,636"
+    },
+    {
+        "CPU": "Intel Core i5-8400T @ 1.70GHz",
+        "Benchmark": "7,443"
+    },
+    {
+        "CPU": "Intel Core i5-8500 @ 3.00GHz",
+        "Benchmark": "9,533"
+    },
+    {
+        "CPU": "Intel Core i5-8500B @ 3.00GHz",
+        "Benchmark": "8,913"
+    },
+    {
+        "CPU": "Intel Core i5-8500T @ 2.10GHz",
+        "Benchmark": "7,722"
+    },
+    {
+        "CPU": "Intel Core i5-8600 @ 3.10GHz",
+        "Benchmark": "9,951"
+    },
+    {
+        "CPU": "Intel Core i5-8600K @ 3.60GHz",
+        "Benchmark": "10,134"
+    },
+    {
+        "CPU": "Intel Core i5-8600T @ 2.30GHz",
+        "Benchmark": "9,26"
+    },
+    {
+        "CPU": "Intel Core i5-9300H @ 2.40GHz",
+        "Benchmark": "7,481"
+    },
+    {
+        "CPU": "Intel Core i5-9300HF @ 2.40GHz",
+        "Benchmark": "7,329"
+    },
+    {
+        "CPU": "Intel Core i5-9400 @ 2.90GHz",
+        "Benchmark": "9,386"
+    },
+    {
+        "CPU": "Intel Core i5-9400F @ 2.90GHz",
+        "Benchmark": "9,457"
+    },
+    {
+        "CPU": "Intel Core i5-9400H @ 2.50GHz",
+        "Benchmark": "7,937"
+    },
+    {
+        "CPU": "Intel Core i5-9400T @ 1.80GHz",
+        "Benchmark": "8,261"
+    },
+    {
+        "CPU": "Intel Core i5-9500 @ 3.00GHz",
+        "Benchmark": "9,874"
+    },
+    {
+        "CPU": "Intel Core i5-9500E @ 3.00GHz",
+        "Benchmark": "7,598"
+    },
+    {
+        "CPU": "Intel Core i5-9500F @ 3.00GHz",
+        "Benchmark": "9,962"
+    },
+    {
+        "CPU": "Intel Core i5-9500T @ 2.20GHz",
+        "Benchmark": "8,093"
+    },
+    {
+        "CPU": "Intel Core i5-9500TE @ 2.20GHz",
+        "Benchmark": "9,791"
+    },
+    {
+        "CPU": "Intel Core i5-9600 @ 3.10GHz",
+        "Benchmark": "10,278"
+    },
+    {
+        "CPU": "Intel Core i5-9600K @ 3.70GHz",
+        "Benchmark": "10,641"
+    },
+    {
+        "CPU": "Intel Core i5-9600KF @ 3.70GHz",
+        "Benchmark": "10,667"
+    },
+    {
+        "CPU": "Intel Core i5-9600T @ 2.30GHz",
+        "Benchmark": "9,643"
+    },
+    {
+        "CPU": "Intel Core i5-L16G7 @ 1.40GHz",
+        "Benchmark": "3,335"
+    },
+    {
+        "CPU": "Intel Core i7-10510U @ 1.80GHz",
+        "Benchmark": "6,49"
+    },
+    {
+        "CPU": "Intel Core i7-10510Y @ 1.20GHz",
+        "Benchmark": "3,56"
+    },
+    {
+        "CPU": "Intel Core i7-1060NG7 @ 1.20GHz",
+        "Benchmark": "6,549"
+    },
+    {
+        "CPU": "Intel Core i7-10610U @ 1.80GHz",
+        "Benchmark": "6,615"
+    },
+    {
+        "CPU": "Intel Core i7-1065G7 @ 1.30GHz",
+        "Benchmark": "8,206"
+    },
+    {
+        "CPU": "Intel Core i7-1068NG7 @ 2.30GHz",
+        "Benchmark": "9,315"
+    },
+    {
+        "CPU": "Intel Core i7-10700 @ 2.90GHz",
+        "Benchmark": "16,214"
+    },
+    {
+        "CPU": "Intel Core i7-10700E @ 2.90GHz",
+        "Benchmark": "16,131"
+    },
+    {
+        "CPU": "Intel Core i7-10700F @ 2.90GHz",
+        "Benchmark": "16,279"
+    },
+    {
+        "CPU": "Intel Core i7-10700K @ 3.80GHz",
+        "Benchmark": "18,64"
+    },
+    {
+        "CPU": "Intel Core i7-10700KF @ 3.80GHz",
+        "Benchmark": "18,461"
+    },
+    {
+        "CPU": "Intel Core i7-10700T @ 2.00GHz",
+        "Benchmark": "12,848"
+    },
+    {
+        "CPU": "Intel Core i7-10700TE @ 2.00GHz",
+        "Benchmark": "13,505"
+    },
+    {
+        "CPU": "Intel Core i7-10710U @ 1.10GHz",
+        "Benchmark": "9,332"
+    },
+    {
+        "CPU": "Intel Core i7-10750H @ 2.60GHz",
+        "Benchmark": "11,661"
+    },
+    {
+        "CPU": "Intel Core i7-10810U @ 1.10GHz",
+        "Benchmark": "8,156"
+    },
+    {
+        "CPU": "Intel Core i7-10850H @ 2.70GHz",
+        "Benchmark": "11,696"
+    },
+    {
+        "CPU": "Intel Core i7-10870H @ 2.20GHz",
+        "Benchmark": "14,218"
+    },
+    {
+        "CPU": "Intel Core i7-10875H @ 2.30GHz",
+        "Benchmark": "14,677"
+    },
+    {
+        "CPU": "Intel Core i7-11370H @ 3.30GHz",
+        "Benchmark": "11,643"
+    },
+    {
+        "CPU": "Intel Core i7-11375H @ 3.30GHz",
+        "Benchmark": "11,711"
+    },
+    {
+        "CPU": "Intel Core i7-11390H @ 3.40GHz",
+        "Benchmark": "9,838"
+    },
+    {
+        "CPU": "Intel Core i7-11600H @ 2.90GHz",
+        "Benchmark": "16,162"
+    },
+    {
+        "CPU": "Intel Core i7-1160G7 @ 1.20GHz",
+        "Benchmark": "9,099"
+    },
+    {
+        "CPU": "Intel Core i7-1165G7 @ 2.80GHz",
+        "Benchmark": "10,01"
+    },
+    {
+        "CPU": "Intel Core i7-11700 @ 2.50GHz",
+        "Benchmark": "20,696"
+    },
+    {
+        "CPU": "Intel Core i7-11700B @ 3.20GHz",
+        "Benchmark": "22,184"
+    },
+    {
+        "CPU": "Intel Core i7-11700F @ 2.50GHz",
+        "Benchmark": "20,768"
+    },
+    {
+        "CPU": "Intel Core i7-11700K @ 3.60GHz",
+        "Benchmark": "24,428"
+    },
+    {
+        "CPU": "Intel Core i7-11700KF @ 3.60GHz",
+        "Benchmark": "23,824"
+    },
+    {
+        "CPU": "Intel Core i7-11700T @ 1.40GHz",
+        "Benchmark": "15,495"
+    },
+    {
+        "CPU": "Intel Core i7-11800H @ 2.30GHz",
+        "Benchmark": "20,083"
+    },
+    {
+        "CPU": "Intel Core i7-1180G7 @ 1.30GHz",
+        "Benchmark": "7,844"
+    },
+    {
+        "CPU": "Intel Core i7-11850H @ 2.50GHz",
+        "Benchmark": "20,142"
+    },
+    {
+        "CPU": "Intel Core i7-11850HE @ 2.60GHz",
+        "Benchmark": "21,365"
+    },
+    {
+        "CPU": "Intel Core i7-1185G7 @ 3.00GHz",
+        "Benchmark": "10,174"
+    },
+    {
+        "CPU": "Intel Core i7-1185G7E @ 2.80GHz",
+        "Benchmark": "9,911"
+    },
+    {
+        "CPU": "Intel Core i7-1185GRE @ 2.80GHz",
+        "Benchmark": "8,046"
+    },
+    {
+        "CPU": "Intel Core i7-1195G7 @ 2.90GHz",
+        "Benchmark": "10,552"
+    },
+    {
+        "CPU": "Intel Core i7-1250U",
+        "Benchmark": "11,391"
+    },
+    {
+        "CPU": "Intel Core i7-1255U",
+        "Benchmark": "13,281"
+    },
+    {
+        "CPU": "Intel Core i7-1260P",
+        "Benchmark": "16,813"
+    },
+    {
+        "CPU": "Intel Core i7-1260U",
+        "Benchmark": "13,957"
+    },
+    {
+        "CPU": "Intel Core i7-12650H",
+        "Benchmark": "22,064"
+    },
+    {
+        "CPU": "Intel Core i7-12650HX",
+        "Benchmark": "21,774"
+    },
+    {
+        "CPU": "Intel Core i7-1265U",
+        "Benchmark": "13,43"
+    },
+    {
+        "CPU": "Intel Core i7-1265UE",
+        "Benchmark": "9,462"
+    },
+    {
+        "CPU": "Intel Core i7-12700",
+        "Benchmark": "30,437"
+    },
+    {
+        "CPU": "Intel Core i7-12700E",
+        "Benchmark": "27,857"
+    },
+    {
+        "CPU": "Intel Core i7-12700F",
+        "Benchmark": "30,471"
+    },
+    {
+        "CPU": "Intel Core i7-12700H",
+        "Benchmark": "25,767"
+    },
+    {
+        "CPU": "Intel Core i7-12700K",
+        "Benchmark": "34,463"
+    },
+    {
+        "CPU": "Intel Core i7-12700KF",
+        "Benchmark": "34,121"
+    },
+    {
+        "CPU": "Intel Core i7-12700T",
+        "Benchmark": "21,254"
+    },
+    {
+        "CPU": "Intel Core i7-12700TE",
+        "Benchmark": "19,507"
+    },
+    {
+        "CPU": "Intel Core i7-1270P",
+        "Benchmark": "16,996"
+    },
+    {
+        "CPU": "Intel Core i7-1270PE",
+        "Benchmark": "17,96"
+    },
+    {
+        "CPU": "Intel Core i7-12800H",
+        "Benchmark": "24,495"
+    },
+    {
+        "CPU": "Intel Core i7-12800HE",
+        "Benchmark": "26,753"
+    },
+    {
+        "CPU": "Intel Core i7-12800HX",
+        "Benchmark": "31,889"
+    },
+    {
+        "CPU": "Intel Core i7-1280P",
+        "Benchmark": "20,313"
+    },
+    {
+        "CPU": "Intel Core i7-12850HX",
+        "Benchmark": "30,823"
+    },
+    {
+        "CPU": "Intel Core i7-1355U",
+        "Benchmark": "14,36"
+    },
+    {
+        "CPU": "Intel Core i7-1360P",
+        "Benchmark": "18,768"
+    },
+    {
+        "CPU": "Intel Core i7-13620H",
+        "Benchmark": "24,267"
+    },
+    {
+        "CPU": "Intel Core i7-13650HX",
+        "Benchmark": "30,814"
+    },
+    {
+        "CPU": "Intel Core i7-1365U",
+        "Benchmark": "14,216"
+    },
+    {
+        "CPU": "Intel Core i7-1365UE",
+        "Benchmark": "10,019"
+    },
+    {
+        "CPU": "Intel Core i7-1365URE",
+        "Benchmark": "10,545"
+    },
+    {
+        "CPU": "Intel Core i7-13700",
+        "Benchmark": "36,546"
+    },
+    {
+        "CPU": "Intel Core i7-13700E",
+        "Benchmark": "34,577"
+    },
+    {
+        "CPU": "Intel Core i7-13700F",
+        "Benchmark": "38,534"
+    },
+    {
+        "CPU": "Intel Core i7-13700H",
+        "Benchmark": "26,451"
+    },
+    {
+        "CPU": "Intel Core i7-13700HX",
+        "Benchmark": "32,847"
+    },
+    {
+        "CPU": "Intel Core i7-13700K",
+        "Benchmark": "46"
+    },
+    {
+        "CPU": "Intel Core i7-13700KF",
+        "Benchmark": "46,297"
+    },
+    {
+        "CPU": "Intel Core i7-13700T",
+        "Benchmark": "27,967"
+    },
+    {
+        "CPU": "Intel Core i7-13700TE",
+        "Benchmark": "22,754"
+    },
+    {
+        "CPU": "Intel Core i7-13705H",
+        "Benchmark": "24,052"
+    },
+    {
+        "CPU": "Intel Core i7-1370P",
+        "Benchmark": "20,317"
+    },
+    {
+        "CPU": "Intel Core i7-1370PE",
+        "Benchmark": "21,92"
+    },
+    {
+        "CPU": "Intel Core i7-1370PRE",
+        "Benchmark": "18,42"
+    },
+    {
+        "CPU": "Intel Core i7-13790F",
+        "Benchmark": "46,309"
+    },
+    {
+        "CPU": "Intel Core i7-13800H",
+        "Benchmark": "26,692"
+    },
+    {
+        "CPU": "Intel Core i7-13800HRE",
+        "Benchmark": "13,4"
+    },
+    {
+        "CPU": "Intel Core i7-13850HX",
+        "Benchmark": "37,155"
+    },
+    {
+        "CPU": "Intel Core i7-14650HX",
+        "Benchmark": "35,133"
+    },
+    {
+        "CPU": "Intel Core i7-14700",
+        "Benchmark": "41,723"
+    },
+    {
+        "CPU": "Intel Core i7-14700F",
+        "Benchmark": "41,907"
+    },
+    {
+        "CPU": "Intel Core i7-14700HX",
+        "Benchmark": "37,053"
+    },
+    {
+        "CPU": "Intel Core i7-14700K",
+        "Benchmark": "52,628"
+    },
+    {
+        "CPU": "Intel Core i7-14700KF",
+        "Benchmark": "53,079"
+    },
+    {
+        "CPU": "Intel Core i7-14700T",
+        "Benchmark": "30,372"
+    },
+    {
+        "CPU": "Intel Core i7-14701E",
+        "Benchmark": "25,95"
+    },
+    {
+        "CPU": "Intel Core i7-2600 @ 3.40GHz",
+        "Benchmark": "5,349"
+    },
+    {
+        "CPU": "Intel Core i7-2600K @ 3.40GHz",
+        "Benchmark": "5,483"
+    },
+    {
+        "CPU": "Intel Core i7-2600S @ 2.80GHz",
+        "Benchmark": "4,625"
+    },
+    {
+        "CPU": "Intel Core i7-2610UE @ 1.50GHz",
+        "Benchmark": "1,527"
+    },
+    {
+        "CPU": "Intel Core i7-2617M @ 1.50GHz",
+        "Benchmark": "1,687"
+    },
+    {
+        "CPU": "Intel Core i7-2620M @ 2.70GHz",
+        "Benchmark": "2,425"
+    },
+    {
+        "CPU": "Intel Core i7-2630QM @ 2.00GHz",
+        "Benchmark": "3,563"
+    },
+    {
+        "CPU": "Intel Core i7-2630UM @ 1.60GHz",
+        "Benchmark": "400"
+    },
+    {
+        "CPU": "Intel Core i7-2635QM @ 2.00GHz",
+        "Benchmark": "3,521"
+    },
+    {
+        "CPU": "Intel Core i7-2637M @ 1.70GHz",
+        "Benchmark": "1,896"
+    },
+    {
+        "CPU": "Intel Core i7-2640M @ 2.80GHz",
+        "Benchmark": "2,459"
+    },
+    {
+        "CPU": "Intel Core i7-2655LE @ 2.20GHz",
+        "Benchmark": "1,999"
+    },
+    {
+        "CPU": "Intel Core i7-2670QM @ 2.20GHz",
+        "Benchmark": "3,744"
+    },
+    {
+        "CPU": "Intel Core i7-2675QM @ 2.20GHz",
+        "Benchmark": "3,913"
+    },
+    {
+        "CPU": "Intel Core i7-2677M @ 1.80GHz",
+        "Benchmark": "1,889"
+    },
+    {
+        "CPU": "Intel Core i7-2700K @ 3.50GHz",
+        "Benchmark": "5,735"
+    },
+    {
+        "CPU": "Intel Core i7-2710QE @ 2.10GHz",
+        "Benchmark": "3,749"
+    },
+    {
+        "CPU": "Intel Core i7-2715QE @ 2.10GHz",
+        "Benchmark": "3,221"
+    },
+    {
+        "CPU": "Intel Core i7-2720QM @ 2.20GHz",
+        "Benchmark": "4,023"
+    },
+    {
+        "CPU": "Intel Core i7-2760QM @ 2.40GHz",
+        "Benchmark": "4,385"
+    },
+    {
+        "CPU": "Intel Core i7-2820QM @ 2.30GHz",
+        "Benchmark": "4,381"
+    },
+    {
+        "CPU": "Intel Core i7-2840QM @ 2.40GHz",
+        "Benchmark": "3,842"
+    },
+    {
+        "CPU": "Intel Core i7-2860QM @ 2.50GHz",
+        "Benchmark": "4,587"
+    },
+    {
+        "CPU": "Intel Core i7-2920XM @ 2.50GHz",
+        "Benchmark": "4,313"
+    },
+    {
+        "CPU": "Intel Core i7-2960XM @ 2.70GHz",
+        "Benchmark": "4,698"
+    },
+    {
+        "CPU": "Intel Core i7-3517U @ 1.90GHz",
+        "Benchmark": "2,121"
+    },
+    {
+        "CPU": "Intel Core i7-3517UE @ 1.70GHz",
+        "Benchmark": "2,384"
+    },
+    {
+        "CPU": "Intel Core i7-3520M @ 2.90GHz",
+        "Benchmark": "2,845"
+    },
+    {
+        "CPU": "Intel Core i7-3537U @ 2.00GHz",
+        "Benchmark": "2,356"
+    },
+    {
+        "CPU": "Intel Core i7-3540M @ 3.00GHz",
+        "Benchmark": "2,978"
+    },
+    {
+        "CPU": "Intel Core i7-3555LE @ 2.50GHz",
+        "Benchmark": "2,238"
+    },
+    {
+        "CPU": "Intel Core i7-3610QE @ 2.30GHz",
+        "Benchmark": "5,234"
+    },
+    {
+        "CPU": "Intel Core i7-3610QM @ 2.30GHz",
+        "Benchmark": "5,109"
+    },
+    {
+        "CPU": "Intel Core i7-3612QE @ 2.10GHz",
+        "Benchmark": "4,929"
+    },
+    {
+        "CPU": "Intel Core i7-3612QM @ 2.10GHz",
+        "Benchmark": "4,645"
+    },
+    {
+        "CPU": "Intel Core i7-3615QE @ 2.30GHz",
+        "Benchmark": "5,61"
+    },
+    {
+        "CPU": "Intel Core i7-3615QM @ 2.30GHz",
+        "Benchmark": "5,167"
+    },
+    {
+        "CPU": "Intel Core i7-3630QM @ 2.40GHz",
+        "Benchmark": "5,134"
+    },
+    {
+        "CPU": "Intel Core i7-3632QM @ 2.20GHz",
+        "Benchmark": "4,746"
+    },
+    {
+        "CPU": "Intel Core i7-3635QM @ 2.40GHz",
+        "Benchmark": "4,787"
+    },
+    {
+        "CPU": "Intel Core i7-3667U @ 2.00GHz",
+        "Benchmark": "2,442"
+    },
+    {
+        "CPU": "Intel Core i7-3687U @ 2.10GHz",
+        "Benchmark": "2,655"
+    },
+    {
+        "CPU": "Intel Core i7-3689Y @ 1.50GHz",
+        "Benchmark": "1,967"
+    },
+    {
+        "CPU": "Intel Core i7-3720QM @ 2.60GHz",
+        "Benchmark": "5,61"
+    },
+    {
+        "CPU": "Intel Core i7-3740QM @ 2.70GHz",
+        "Benchmark": "5,707"
+    },
+    {
+        "CPU": "Intel Core i7-3770 @ 3.40GHz",
+        "Benchmark": "6,416"
+    },
+    {
+        "CPU": "Intel Core i7-3770K @ 3.50GHz",
+        "Benchmark": "6,478"
+    },
+    {
+        "CPU": "Intel Core i7-3770S @ 3.10GHz",
+        "Benchmark": "6,193"
+    },
+    {
+        "CPU": "Intel Core i7-3770T @ 2.50GHz",
+        "Benchmark": "5,45"
+    },
+    {
+        "CPU": "Intel Core i7-3820 @ 3.60GHz",
+        "Benchmark": "5,78"
+    },
+    {
+        "CPU": "Intel Core i7-3820QM @ 2.70GHz",
+        "Benchmark": "5,601"
+    },
+    {
+        "CPU": "Intel Core i7-3840QM @ 2.80GHz",
+        "Benchmark": "5,894"
+    },
+    {
+        "CPU": "Intel Core i7-3920XM @ 2.90GHz",
+        "Benchmark": "5,698"
+    },
+    {
+        "CPU": "Intel Core i7-3930K @ 3.20GHz",
+        "Benchmark": "8,205"
+    },
+    {
+        "CPU": "Intel Core i7-3940XM @ 3.00GHz",
+        "Benchmark": "5,912"
+    },
+    {
+        "CPU": "Intel Core i7-3960X @ 3.30GHz",
+        "Benchmark": "8,431"
+    },
+    {
+        "CPU": "Intel Core i7-3970X @ 3.50GHz",
+        "Benchmark": "8,595"
+    },
+    {
+        "CPU": "Intel Core i7-4500U @ 1.80GHz",
+        "Benchmark": "2,495"
+    },
+    {
+        "CPU": "Intel Core i7-4510U @ 2.00GHz",
+        "Benchmark": "2,626"
+    },
+    {
+        "CPU": "Intel Core i7-4550U @ 1.50GHz",
+        "Benchmark": "2,291"
+    },
+    {
+        "CPU": "Intel Core i7-4558U @ 2.80GHz",
+        "Benchmark": "2,945"
+    },
+    {
+        "CPU": "Intel Core i7-4560U @ 1.60GHz",
+        "Benchmark": "2,473"
+    },
+    {
+        "CPU": "Intel Core i7-4578U @ 3.00GHz",
+        "Benchmark": "3,098"
+    },
+    {
+        "CPU": "Intel Core i7-4600M @ 2.90GHz",
+        "Benchmark": "3,211"
+    },
+    {
+        "CPU": "Intel Core i7-4600U @ 2.10GHz",
+        "Benchmark": "2,721"
+    },
+    {
+        "CPU": "Intel Core i7-4610M @ 3.00GHz",
+        "Benchmark": "3,238"
+    },
+    {
+        "CPU": "Intel Core i7-4610Y @ 1.70GHz",
+        "Benchmark": "2,446"
+    },
+    {
+        "CPU": "Intel Core i7-4650U @ 1.70GHz",
+        "Benchmark": "2,461"
+    },
+    {
+        "CPU": "Intel Core i7-4700EQ @ 2.40GHz",
+        "Benchmark": "5,417"
+    },
+    {
+        "CPU": "Intel Core i7-4700HQ @ 2.40GHz",
+        "Benchmark": "5,618"
+    },
+    {
+        "CPU": "Intel Core i7-4700MQ @ 2.40GHz",
+        "Benchmark": "5,354"
+    },
+    {
+        "CPU": "Intel Core i7-4702HQ @ 2.20GHz",
+        "Benchmark": "5,35"
+    },
+    {
+        "CPU": "Intel Core i7-4702MQ @ 2.20GHz",
+        "Benchmark": "5,193"
+    },
+    {
+        "CPU": "Intel Core i7-4710HQ @ 2.50GHz",
+        "Benchmark": "5,531"
+    },
+    {
+        "CPU": "Intel Core i7-4710MQ @ 2.50GHz",
+        "Benchmark": "5,772"
+    },
+    {
+        "CPU": "Intel Core i7-4712HQ @ 2.30GHz",
+        "Benchmark": "5,352"
+    },
+    {
+        "CPU": "Intel Core i7-4712MQ @ 2.30GHz",
+        "Benchmark": "5,311"
+    },
+    {
+        "CPU": "Intel Core i7-4720HQ @ 2.60GHz",
+        "Benchmark": "5,724"
+    },
+    {
+        "CPU": "Intel Core i7-4722HQ @ 2.40GHz",
+        "Benchmark": "5,768"
+    },
+    {
+        "CPU": "Intel Core i7-4750HQ @ 2.00GHz",
+        "Benchmark": "5,684"
+    },
+    {
+        "CPU": "Intel Core i7-4760HQ @ 2.10GHz",
+        "Benchmark": "6,3"
+    },
+    {
+        "CPU": "Intel Core i7-4765T @ 2.00GHz",
+        "Benchmark": "5,071"
+    },
+    {
+        "CPU": "Intel Core i7-4770 @ 3.40GHz",
+        "Benchmark": "7,054"
+    },
+    {
+        "CPU": "Intel Core i7-4770HQ @ 2.20GHz",
+        "Benchmark": "6,049"
+    },
+    {
+        "CPU": "Intel Core i7-4770K @ 3.50GHz",
+        "Benchmark": "7,142"
+    },
+    {
+        "CPU": "Intel Core i7-4770R @ 3.20GHz",
+        "Benchmark": "6,561"
+    },
+    {
+        "CPU": "Intel Core i7-4770S @ 3.10GHz",
+        "Benchmark": "6,753"
+    },
+    {
+        "CPU": "Intel Core i7-4770T @ 2.50GHz",
+        "Benchmark": "5,856"
+    },
+    {
+        "CPU": "Intel Core i7-4770TE @ 2.30GHz",
+        "Benchmark": "4,983"
+    },
+    {
+        "CPU": "Intel Core i7-4771 @ 3.50GHz",
+        "Benchmark": "7,137"
+    },
+    {
+        "CPU": "Intel Core i7-4785T @ 2.20GHz",
+        "Benchmark": "5,514"
+    },
+    {
+        "CPU": "Intel Core i7-4790 @ 3.60GHz",
+        "Benchmark": "7,266"
+    },
+    {
+        "CPU": "Intel Core i7-4790K @ 4.00GHz",
+        "Benchmark": "8,061"
+    },
+    {
+        "CPU": "Intel Core i7-4790S @ 3.20GHz",
+        "Benchmark": "6,997"
+    },
+    {
+        "CPU": "Intel Core i7-4790T @ 2.70GHz",
+        "Benchmark": "6,28"
+    },
+    {
+        "CPU": "Intel Core i7-4800MQ @ 2.70GHz",
+        "Benchmark": "5,779"
+    },
+    {
+        "CPU": "Intel Core i7-4810MQ @ 2.80GHz",
+        "Benchmark": "6,068"
+    },
+    {
+        "CPU": "Intel Core i7-4820K @ 3.70GHz",
+        "Benchmark": "6,501"
+    },
+    {
+        "CPU": "Intel Core i7-4850HQ @ 2.30GHz",
+        "Benchmark": "6,128"
+    },
+    {
+        "CPU": "Intel Core i7-4860EQ @ 1.80GHz",
+        "Benchmark": "5,5"
+    },
+    {
+        "CPU": "Intel Core i7-4860HQ @ 2.40GHz",
+        "Benchmark": "6,198"
+    },
+    {
+        "CPU": "Intel Core i7-4870HQ @ 2.50GHz",
+        "Benchmark": "6,306"
+    },
+    {
+        "CPU": "Intel Core i7-4900MQ @ 2.80GHz",
+        "Benchmark": "6,148"
+    },
+    {
+        "CPU": "Intel Core i7-4910MQ @ 2.90GHz",
+        "Benchmark": "6,259"
+    },
+    {
+        "CPU": "Intel Core i7-4930K @ 3.40GHz",
+        "Benchmark": "9,399"
+    },
+    {
+        "CPU": "Intel Core i7-4930MX @ 3.00GHz",
+        "Benchmark": "6,457"
+    },
+    {
+        "CPU": "Intel Core i7-4940MX @ 3.10GHz",
+        "Benchmark": "6,847"
+    },
+    {
+        "CPU": "Intel Core i7-4960HQ @ 2.60GHz",
+        "Benchmark": "6,366"
+    },
+    {
+        "CPU": "Intel Core i7-4960X @ 3.60GHz",
+        "Benchmark": "10,01"
+    },
+    {
+        "CPU": "Intel Core i7-4980HQ @ 2.80GHz",
+        "Benchmark": "6,528"
+    },
+    {
+        "CPU": "Intel Core i7-5500U @ 2.40GHz",
+        "Benchmark": "2,798"
+    },
+    {
+        "CPU": "Intel Core i7-5550U @ 2.00GHz",
+        "Benchmark": "2,864"
+    },
+    {
+        "CPU": "Intel Core i7-5557U @ 3.10GHz",
+        "Benchmark": "3,159"
+    },
+    {
+        "CPU": "Intel Core i7-5600U @ 2.60GHz",
+        "Benchmark": "3,017"
+    },
+    {
+        "CPU": "Intel Core i7-5650U @ 2.20GHz",
+        "Benchmark": "2,998"
+    },
+    {
+        "CPU": "Intel Core i7-5675C @ 3.10GHz",
+        "Benchmark": "6,089"
+    },
+    {
+        "CPU": "Intel Core i7-5700EQ @ 2.60GHz",
+        "Benchmark": "5,803"
+    },
+    {
+        "CPU": "Intel Core i7-5700HQ @ 2.70GHz",
+        "Benchmark": "6,019"
+    },
+    {
+        "CPU": "Intel Core i7-5775C @ 3.30GHz",
+        "Benchmark": "7,753"
+    },
+    {
+        "CPU": "Intel Core i7-5775R @ 3.30GHz",
+        "Benchmark": "7,58"
+    },
+    {
+        "CPU": "Intel Core i7-5820K @ 3.30GHz",
+        "Benchmark": "9,83"
+    },
+    {
+        "CPU": "Intel Core i7-5850EQ @ 2.70GHz",
+        "Benchmark": "7,036"
+    },
+    {
+        "CPU": "Intel Core i7-5850HQ @ 2.70GHz",
+        "Benchmark": "6,866"
+    },
+    {
+        "CPU": "Intel Core i7-5930K @ 3.50GHz",
+        "Benchmark": "10,359"
+    },
+    {
+        "CPU": "Intel Core i7-5950HQ @ 2.90GHz",
+        "Benchmark": "7,7"
+    },
+    {
+        "CPU": "Intel Core i7-5960X @ 3.00GHz",
+        "Benchmark": "13,525"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Core i7-5960X @ 3.50GHz",
+        "Benchmark": "20,781"
+    },
+    {
+        "CPU": "Intel Core i7-610E @ 2.53GHz",
+        "Benchmark": "2,071"
+    },
+    {
+        "CPU": "Intel Core i7-620LM @ 2.00GHz",
+        "Benchmark": "1,406"
+    },
+    {
+        "CPU": "Intel Core i7-620M @ 2.67GHz",
+        "Benchmark": "1,975"
+    },
+    {
+        "CPU": "Intel Core i7-620UM @ 1.07GHz",
+        "Benchmark": "1,091"
+    },
+    {
+        "CPU": "Intel Core i7-640LM @ 2.13GHz",
+        "Benchmark": "1,528"
+    },
+    {
+        "CPU": "Intel Core i7-640M @ 2.80GHz",
+        "Benchmark": "2,086"
+    },
+    {
+        "CPU": "Intel Core i7-640UM @ 1.20GHz",
+        "Benchmark": "1,168"
+    },
+    {
+        "CPU": "Intel Core i7-6498DU @ 2.50GHz",
+        "Benchmark": "3,351"
+    },
+    {
+        "CPU": "Intel Core i7-6500U @ 2.50GHz",
+        "Benchmark": "3,281"
+    },
+    {
+        "CPU": "Intel Core i7-6560U @ 2.20GHz",
+        "Benchmark": "3,354"
+    },
+    {
+        "CPU": "Intel Core i7-6567U @ 3.30GHz",
+        "Benchmark": "3,699"
+    },
+    {
+        "CPU": "Intel Core i7-6600U @ 2.60GHz",
+        "Benchmark": "3,409"
+    },
+    {
+        "CPU": "Intel Core i7-660UM @ 1.33GHz",
+        "Benchmark": "1,284"
+    },
+    {
+        "CPU": "Intel Core i7-6650U @ 2.20GHz",
+        "Benchmark": "3,549"
+    },
+    {
+        "CPU": "Intel Core i7-6660U @ 2.40GHz",
+        "Benchmark": "3,628"
+    },
+    {
+        "CPU": "Intel Core i7-6700 @ 3.40GHz",
+        "Benchmark": "8,058"
+    },
+    {
+        "CPU": "Intel Core i7-6700HQ @ 2.60GHz",
+        "Benchmark": "6,525"
+    },
+    {
+        "CPU": "Intel Core i7-6700K @ 4.00GHz",
+        "Benchmark": "8,938"
+    },
+    {
+        "CPU": "Intel Core i7-6700T @ 2.80GHz",
+        "Benchmark": "7,061"
+    },
+    {
+        "CPU": "Intel Core i7-6700TE @ 2.40GHz",
+        "Benchmark": "6,185"
+    },
+    {
+        "CPU": "Intel Core i7-6770HQ @ 2.60GHz",
+        "Benchmark": "7,124"
+    },
+    {
+        "CPU": "Intel Core i7-6800K @ 3.40GHz",
+        "Benchmark": "10,73"
+    },
+    {
+        "CPU": "Intel Core i7-680UM @ 1.47GHz",
+        "Benchmark": "1,196"
+    },
+    {
+        "CPU": "Intel Core i7-6820EQ @ 2.80GHz",
+        "Benchmark": "7,025"
+    },
+    {
+        "CPU": "Intel Core i7-6820HK @ 2.70GHz",
+        "Benchmark": "7,007"
+    },
+    {
+        "CPU": "Intel Core i7-6820HQ @ 2.70GHz",
+        "Benchmark": "6,774"
+    },
+    {
+        "CPU": "Intel Core i7-6822EQ @ 2.00GHz",
+        "Benchmark": "5,55"
+    },
+    {
+        "CPU": "Intel Core i7-6850K @ 3.60GHz",
+        "Benchmark": "11,428"
+    },
+    {
+        "CPU": "Intel Core i7-6900K @ 3.20GHz",
+        "Benchmark": "14,483"
+    },
+    {
+        "CPU": "Intel Core i7-6920HQ @ 2.90GHz",
+        "Benchmark": "7,282"
+    },
+    {
+        "CPU": "Intel Core i7-6950X @ 3.00GHz",
+        "Benchmark": "17,67"
+    },
+    {
+        "CPU": "Intel Core i7-6970HQ @ 2.80GHz",
+        "Benchmark": "4,632"
+    },
+    {
+        "CPU": "Intel Core i7-720QM @ 1.60GHz",
+        "Benchmark": "1,662"
+    },
+    {
+        "CPU": "Intel Core i7-740QM @ 1.73GHz",
+        "Benchmark": "1,837"
+    },
+    {
+        "CPU": "Intel Core i7-7500U @ 2.70GHz",
+        "Benchmark": "3,64"
+    },
+    {
+        "CPU": "Intel Core i7-7560U @ 2.40GHz",
+        "Benchmark": "3,806"
+    },
+    {
+        "CPU": "Intel Core i7-7567U @ 3.50GHz",
+        "Benchmark": "4,089"
+    },
+    {
+        "CPU": "Intel Core i7-7600U @ 2.80GHz",
+        "Benchmark": "3,694"
+    },
+    {
+        "CPU": "Intel Core i7-7660U @ 2.50GHz",
+        "Benchmark": "4,054"
+    },
+    {
+        "CPU": "Intel Core i7-7700 @ 3.60GHz",
+        "Benchmark": "8,643"
+    },
+    {
+        "CPU": "Intel Core i7-7700HQ @ 2.80GHz",
+        "Benchmark": "6,888"
+    },
+    {
+        "CPU": "Intel Core i7-7700K @ 4.20GHz",
+        "Benchmark": "9,626"
+    },
+    {
+        "CPU": "Intel Core i7-7700T @ 2.90GHz",
+        "Benchmark": "7,577"
+    },
+    {
+        "CPU": "Intel Core i7-7740X @ 4.30GHz",
+        "Benchmark": "9,64"
+    },
+    {
+        "CPU": "Intel Core i7-7800X @ 3.50GHz",
+        "Benchmark": "12,978"
+    },
+    {
+        "CPU": "Intel Core i7-7820EQ @ 3.00GHz",
+        "Benchmark": "7,542"
+    },
+    {
+        "CPU": "Intel Core i7-7820HK @ 2.90GHz",
+        "Benchmark": "7,401"
+    },
+    {
+        "CPU": "Intel Core i7-7820HQ @ 2.90GHz",
+        "Benchmark": "7,163"
+    },
+    {
+        "CPU": "Intel Core i7-7820X @ 3.60GHz",
+        "Benchmark": "17,171"
+    },
+    {
+        "CPU": "Intel Core i7-7900X @ 3.30GHz",
+        "Benchmark": "21,008"
+    },
+    {
+        "CPU": "Intel Core i7-7920HQ @ 3.10GHz",
+        "Benchmark": "7,289"
+    },
+    {
+        "CPU": "Intel Core i7-7Y75 @ 1.30GHz",
+        "Benchmark": "2,554"
+    },
+    {
+        "CPU": "Intel Core i7-8086K @ 4.00GHz",
+        "Benchmark": "14,075"
+    },
+    {
+        "CPU": "Intel Core i7-820QM @ 1.73GHz",
+        "Benchmark": "1,81"
+    },
+    {
+        "CPU": "Intel Core i7-840QM @ 1.87GHz",
+        "Benchmark": "1,97"
+    },
+    {
+        "CPU": "Intel Core i7-8500Y @ 1.50GHz",
+        "Benchmark": "2,456"
+    },
+    {
+        "CPU": "Intel Core i7-8550U @ 1.80GHz",
+        "Benchmark": "5,847"
+    },
+    {
+        "CPU": "Intel Core i7-8557U @ 1.70GHz",
+        "Benchmark": "7,309"
+    },
+    {
+        "CPU": "Intel Core i7-8559U @ 2.70GHz",
+        "Benchmark": "8,297"
+    },
+    {
+        "CPU": "Intel Core i7-8565U @ 1.80GHz",
+        "Benchmark": "5,997"
+    },
+    {
+        "CPU": "Intel Core i7-8565UC @ 1.80GHz",
+        "Benchmark": "6,187"
+    },
+    {
+        "CPU": "Intel Core i7-8569U @ 2.80GHz",
+        "Benchmark": "8,169"
+    },
+    {
+        "CPU": "Intel Core i7-860 @ 2.80GHz",
+        "Benchmark": "3,022"
+    },
+    {
+        "CPU": "Intel Core i7-860S @ 2.53GHz",
+        "Benchmark": "2,324"
+    },
+    {
+        "CPU": "Intel Core i7-8650U @ 1.90GHz",
+        "Benchmark": "6,205"
+    },
+    {
+        "CPU": "Intel Core i7-8665U @ 1.90GHz",
+        "Benchmark": "6,212"
+    },
+    {
+        "CPU": "Intel Core i7-8665UE @ 1.70GHz",
+        "Benchmark": "5,013"
+    },
+    {
+        "CPU": "Intel Core i7-870 @ 2.93GHz",
+        "Benchmark": "3,155"
+    },
+    {
+        "CPU": "Intel Core i7-8700 @ 3.20GHz",
+        "Benchmark": "12,77"
+    },
+    {
+        "CPU": "Intel Core i7-8700B @ 3.20GHz",
+        "Benchmark": "11,822"
+    },
+    {
+        "CPU": "Intel Core i7-8700K @ 3.70GHz",
+        "Benchmark": "13,583"
+    },
+    {
+        "CPU": "Intel Core i7-8700T @ 2.40GHz",
+        "Benchmark": "10,177"
+    },
+    {
+        "CPU": "Intel Core i7-8705G @ 3.10GHz",
+        "Benchmark": "7,659"
+    },
+    {
+        "CPU": "Intel Core i7-8706G @ 3.10GHz",
+        "Benchmark": "7,582"
+    },
+    {
+        "CPU": "Intel Core i7-8709G @ 3.10GHz",
+        "Benchmark": "7,934"
+    },
+    {
+        "CPU": "Intel Core i7-870S @ 2.67GHz",
+        "Benchmark": "2,765"
+    },
+    {
+        "CPU": "Intel Core i7-8750H @ 2.20GHz",
+        "Benchmark": "9,838"
+    },
+    {
+        "CPU": "Intel Core i7-875K @ 2.93GHz",
+        "Benchmark": "3,142"
+    },
+    {
+        "CPU": "Intel Core i7-880 @ 3.07GHz",
+        "Benchmark": "3,436"
+    },
+    {
+        "CPU": "Intel Core i7-8809G @ 3.10GHz",
+        "Benchmark": "8,536"
+    },
+    {
+        "CPU": "Intel Core i7-8850H @ 2.60GHz",
+        "Benchmark": "10,17"
+    },
+    {
+        "CPU": "Intel Core i7-920 @ 2.67GHz",
+        "Benchmark": "2,85"
+    },
+    {
+        "CPU": "Intel Core i7-920XM @ 2.00GHz",
+        "Benchmark": "1,964"
+    },
+    {
+        "CPU": "Intel Core i7-930 @ 2.80GHz",
+        "Benchmark": "2,979"
+    },
+    {
+        "CPU": "Intel Core i7-940 @ 2.93GHz",
+        "Benchmark": "3,023"
+    },
+    {
+        "CPU": "Intel Core i7-940XM @ 2.13GHz",
+        "Benchmark": "2,315"
+    },
+    {
+        "CPU": "Intel Core i7-950 @ 3.07GHz",
+        "Benchmark": "3,241"
+    },
+    {
+        "CPU": "Intel Core i7-960 @ 3.20GHz",
+        "Benchmark": "3,368"
+    },
+    {
+        "CPU": "Intel Core i7-965 @ 3.20GHz",
+        "Benchmark": "3,424"
+    },
+    {
+        "CPU": "Intel Core i7-970 @ 3.20GHz",
+        "Benchmark": "6,531"
+    },
+    {
+        "CPU": "Intel Core i7-9700 @ 3.00GHz",
+        "Benchmark": "13,244"
+    },
+    {
+        "CPU": "Intel Core i7-9700E @ 2.60GHz",
+        "Benchmark": "12,658"
+    },
+    {
+        "CPU": "Intel Core i7-9700F @ 3.00GHz",
+        "Benchmark": "13,177"
+    },
+    {
+        "CPU": "Intel Core i7-9700K @ 3.60GHz",
+        "Benchmark": "14,421"
+    },
+    {
+        "CPU": "Intel Core i7-9700KF @ 3.60GHz",
+        "Benchmark": "14,24"
+    },
+    {
+        "CPU": "Intel Core i7-9700T @ 2.00GHz",
+        "Benchmark": "10,578"
+    },
+    {
+        "CPU": "Intel Core i7-9700TE @ 1.80GHz",
+        "Benchmark": "10,203"
+    },
+    {
+        "CPU": "Intel Core i7-975 @ 3.33GHz",
+        "Benchmark": "3,51"
+    },
+    {
+        "CPU": "Intel Core i7-9750H @ 2.60GHz",
+        "Benchmark": "10,705"
+    },
+    {
+        "CPU": "Intel Core i7-9750HF @ 2.60GHz",
+        "Benchmark": "10,49"
+    },
+    {
+        "CPU": "Intel Core i7-980 @ 3.33GHz",
+        "Benchmark": "6,867"
+    },
+    {
+        "CPU": "Intel Core i7-9800X @ 3.80GHz",
+        "Benchmark": "18,06"
+    },
+    {
+        "CPU": "Intel Core i7-980X @ 3.33GHz",
+        "Benchmark": "6,835"
+    },
+    {
+        "CPU": "Intel Core i7-985 @ 3.47GHz",
+        "Benchmark": "3,928"
+    },
+    {
+        "CPU": "Intel Core i7-9850H @ 2.60GHz",
+        "Benchmark": "10,956"
+    },
+    {
+        "CPU": "Intel Core i7-9850HE @ 2.70GHz",
+        "Benchmark": "10,163"
+    },
+    {
+        "CPU": "Intel Core i7-9850HL @ 1.90GHz",
+        "Benchmark": "7,897"
+    },
+    {
+        "CPU": "Intel Core i7-990X @ 3.47GHz",
+        "Benchmark": "7,116"
+    },
+    {
+        "CPU": "Intel Core i7-995X @ 3.60GHz",
+        "Benchmark": "7,862"
+    },
+    {
+        "CPU": "Intel Core i9-10850K @ 3.60GHz",
+        "Benchmark": "22,105"
+    },
+    {
+        "CPU": "Intel Core i9-10880H @ 2.30GHz",
+        "Benchmark": "14,25"
+    },
+    {
+        "CPU": "Intel Core i9-10885H @ 2.40GHz",
+        "Benchmark": "14,626"
+    },
+    {
+        "CPU": "Intel Core i9-10900 @ 2.80GHz",
+        "Benchmark": "19,411"
+    },
+    {
+        "CPU": "Intel Core i9-10900E @ 2.80GHz",
+        "Benchmark": "19,469"
+    },
+    {
+        "CPU": "Intel Core i9-10900F @ 2.80GHz",
+        "Benchmark": "19,796"
+    },
+    {
+        "CPU": "Intel Core i9-10900K @ 3.70GHz",
+        "Benchmark": "22,532"
+    },
+    {
+        "CPU": "Intel Core i9-10900KF @ 3.70GHz",
+        "Benchmark": "22,359"
+    },
+    {
+        "CPU": "Intel Core i9-10900T @ 1.90GHz",
+        "Benchmark": "14,718"
+    },
+    {
+        "CPU": "Intel Core i9-10900TE @ 1.80GHz",
+        "Benchmark": "14,679"
+    },
+    {
+        "CPU": "Intel Core i9-10900X @ 3.70GHz",
+        "Benchmark": "22,423"
+    },
+    {
+        "CPU": "Intel Core i9-10910 @ 3.60GHz",
+        "Benchmark": "21,456"
+    },
+    {
+        "CPU": "Intel Core i9-10920X @ 3.50GHz",
+        "Benchmark": "26,067"
+    },
+    {
+        "CPU": "Intel Core i9-10940X @ 3.30GHz",
+        "Benchmark": "27,802"
+    },
+    {
+        "CPU": "Intel Core i9-10980HK @ 2.40GHz",
+        "Benchmark": "15,239"
+    },
+    {
+        "CPU": "Intel Core i9-10980XE @ 3.00GHz",
+        "Benchmark": "32,444"
+    },
+    {
+        "CPU": "Intel Core i9-11900 @ 2.50GHz",
+        "Benchmark": "22,448"
+    },
+    {
+        "CPU": "Intel Core i9-11900F @ 2.50GHz",
+        "Benchmark": "22,214"
+    },
+    {
+        "CPU": "Intel Core i9-11900H @ 2.50GHz",
+        "Benchmark": "20,23"
+    },
+    {
+        "CPU": "Intel Core i9-11900K @ 3.50GHz",
+        "Benchmark": "25,051"
+    },
+    {
+        "CPU": "Intel Core i9-11900KB @ 3.30GHz",
+        "Benchmark": "22,856"
+    },
+    {
+        "CPU": "Intel Core i9-11900KF @ 3.50GHz",
+        "Benchmark": "24,775"
+    },
+    {
+        "CPU": "Intel Core i9-11900T @ 1.50GHz",
+        "Benchmark": "18,512"
+    },
+    {
+        "CPU": "Intel Core i9-11950H @ 2.60GHz",
+        "Benchmark": "21,009"
+    },
+    {
+        "CPU": "Intel Core i9-11980HK @ 2.60GHz",
+        "Benchmark": "22,521"
+    },
+    {
+        "CPU": "Intel Core i9-12900",
+        "Benchmark": "33,755"
+    },
+    {
+        "CPU": "Intel Core i9-12900E",
+        "Benchmark": "28,17"
+    },
+    {
+        "CPU": "Intel Core i9-12900F",
+        "Benchmark": "36,063"
+    },
+    {
+        "CPU": "Intel Core i9-12900H",
+        "Benchmark": "27,497"
+    },
+    {
+        "CPU": "Intel Core i9-12900HK",
+        "Benchmark": "25,885"
+    },
+    {
+        "CPU": "Intel Core i9-12900HX",
+        "Benchmark": "33,272"
+    },
+    {
+        "CPU": "Intel Core i9-12900K",
+        "Benchmark": "41,306"
+    },
+    {
+        "CPU": "Intel Core i9-12900KF",
+        "Benchmark": "41,039"
+    },
+    {
+        "CPU": "Intel Core i9-12900KS",
+        "Benchmark": "43,856"
+    },
+    {
+        "CPU": "Intel Core i9-12900T",
+        "Benchmark": "29,417"
+    },
+    {
+        "CPU": "Intel Core i9-12900TE",
+        "Benchmark": "22,887"
+    },
+    {
+        "CPU": "Intel Core i9-12950HX",
+        "Benchmark": "31,626"
+    },
+    {
+        "CPU": "Intel Core i9-13900",
+        "Benchmark": "45,924"
+    },
+    {
+        "CPU": "Intel Core i9-13900E",
+        "Benchmark": "40,696"
+    },
+    {
+        "CPU": "Intel Core i9-13900F",
+        "Benchmark": "50,114"
+    },
+    {
+        "CPU": "Intel Core i9-13900H",
+        "Benchmark": "27,855"
+    },
+    {
+        "CPU": "Intel Core i9-13900HK",
+        "Benchmark": "29,021"
+    },
+    {
+        "CPU": "Intel Core i9-13900HX",
+        "Benchmark": "43,217"
+    },
+    {
+        "CPU": "Intel Core i9-13900K",
+        "Benchmark": "58,675"
+    },
+    {
+        "CPU": "Intel Core i9-13900KF",
+        "Benchmark": "57,848"
+    },
+    {
+        "CPU": "Intel Core i9-13900KS",
+        "Benchmark": "60,926"
+    },
+    {
+        "CPU": "Intel Core i9-13900T",
+        "Benchmark": "42,758"
+    },
+    {
+        "CPU": "Intel Core i9-13900TE",
+        "Benchmark": "16,265"
+    },
+    {
+        "CPU": "Intel Core i9-13905H",
+        "Benchmark": "29,774"
+    },
+    {
+        "CPU": "Intel Core i9-13950HX",
+        "Benchmark": "41,868"
+    },
+    {
+        "CPU": "Intel Core i9-13980HX",
+        "Benchmark": "46,643"
+    },
+    {
+        "CPU": "Intel Core i9-14900",
+        "Benchmark": "45,581"
+    },
+    {
+        "CPU": "Intel Core i9-14900F",
+        "Benchmark": "46,662"
+    },
+    {
+        "CPU": "Intel Core i9-14900HX",
+        "Benchmark": "45,35"
+    },
+    {
+        "CPU": "Intel Core i9-14900K",
+        "Benchmark": "58,934"
+    },
+    {
+        "CPU": "Intel Core i9-14900KF",
+        "Benchmark": "58,73"
+    },
+    {
+        "CPU": "Intel Core i9-14900KS",
+        "Benchmark": "60,738"
+    },
+    {
+        "CPU": "Intel Core i9-14900T",
+        "Benchmark": "40,617"
+    },
+    {
+        "CPU": "Intel Core i9-7900X @ 3.30GHz",
+        "Benchmark": "21,036"
+    },
+    {
+        "CPU": "Intel Core i9-7920X @ 2.90GHz",
+        "Benchmark": "23,558"
+    },
+    {
+        "CPU": "Intel Core i9-7940X @ 3.10GHz",
+        "Benchmark": "25,643"
+    },
+    {
+        "CPU": "Intel Core i9-7960X @ 2.80GHz",
+        "Benchmark": "28,136"
+    },
+    {
+        "CPU": "Intel Core i9-7980XE @ 2.60GHz",
+        "Benchmark": "29,832"
+    },
+    {
+        "CPU": "Intel Core i9-8950HK @ 2.90GHz",
+        "Benchmark": "10,389"
+    },
+    {
+        "CPU": "Intel Core i9-9820X @ 3.30GHz",
+        "Benchmark": "20,44"
+    },
+    {
+        "CPU": "Intel Core i9-9880H @ 2.30GHz",
+        "Benchmark": "13,608"
+    },
+    {
+        "CPU": "Intel Core i9-9900 @ 3.10GHz",
+        "Benchmark": "16,329"
+    },
+    {
+        "CPU": "Intel Core i9-9900B @ 3.10GHz",
+        "Benchmark": "15,893"
+    },
+    {
+        "CPU": "Intel Core i9-9900K @ 3.60GHz",
+        "Benchmark": "18,172"
+    },
+    {
+        "CPU": "Intel Core i9-9900KF @ 3.60GHz",
+        "Benchmark": "18,105"
+    },
+    {
+        "CPU": "Intel Core i9-9900KS @ 4.00GHz",
+        "Benchmark": "19,458"
+    },
+    {
+        "CPU": "Intel Core i9-9900T @ 2.10GHz",
+        "Benchmark": "13,219"
+    },
+    {
+        "CPU": "Intel Core i9-9900X @ 3.50GHz",
+        "Benchmark": "21,689"
+    },
+    {
+        "CPU": "Intel Core i9-9920X @ 3.50GHz",
+        "Benchmark": "25,094"
+    },
+    {
+        "CPU": "Intel Core i9-9940X @ 3.30GHz",
+        "Benchmark": "28,117"
+    },
+    {
+        "CPU": "Intel Core i9-9960X @ 3.10GHz",
+        "Benchmark": "29,901"
+    },
+    {
+        "CPU": "Intel Core i9-9980HK @ 2.40GHz",
+        "Benchmark": "14,012"
+    },
+    {
+        "CPU": "Intel Core i9-9980XE @ 3.00GHz",
+        "Benchmark": "31,668"
+    },
+    {
+        "CPU": "Intel Core i9-9990XE @ 4.00GHz",
+        "Benchmark": "30,162"
+    },
+    {
+        "CPU": "Intel Core M-5Y10 @ 0.80GHz",
+        "Benchmark": "1,644"
+    },
+    {
+        "CPU": "Intel Core M-5Y10a @ 0.80GHz",
+        "Benchmark": "1,905"
+    },
+    {
+        "CPU": "Intel Core M-5Y10c @ 0.80GHz",
+        "Benchmark": "1,906"
+    },
+    {
+        "CPU": "Intel Core M-5Y31 @ 0.90GHz",
+        "Benchmark": "1,896"
+    },
+    {
+        "CPU": "Intel Core M-5Y51 @ 1.10GHz",
+        "Benchmark": "2,036"
+    },
+    {
+        "CPU": "Intel Core M-5Y70 @ 1.10GHz",
+        "Benchmark": "1,872"
+    },
+    {
+        "CPU": "Intel Core M-5Y71 @ 1.20GHz",
+        "Benchmark": "2,013"
+    },
+    {
+        "CPU": "Intel Core m3-6Y30 @ 0.90GHz",
+        "Benchmark": "2,178"
+    },
+    {
+        "CPU": "Intel Core m3-7Y30 @ 1.00GHz",
+        "Benchmark": "2,543"
+    },
+    {
+        "CPU": "Intel Core m3-7Y32 @ 1.10GHz",
+        "Benchmark": "2,729"
+    },
+    {
+        "CPU": "Intel Core m3-8100Y @ 1.10GHz",
+        "Benchmark": "2,771"
+    },
+    {
+        "CPU": "Intel Core m5-6Y54 @ 1.10GHz",
+        "Benchmark": "2,28"
+    },
+    {
+        "CPU": "Intel Core m5-6Y57 @ 1.10GHz",
+        "Benchmark": "2,348"
+    },
+    {
+        "CPU": "Intel Core m5-7Y54 @ 1.20GHz",
+        "Benchmark": "1,475"
+    },
+    {
+        "CPU": "Intel Core m7-6Y75 @ 1.20GHz",
+        "Benchmark": "2,362"
+    },
+    {
+        "CPU": "Intel Core Solo T1300 @ 1.66GHz",
+        "Benchmark": "210"
+    },
+    {
+        "CPU": "Intel Core Solo T1350 @ 1.86GHz",
+        "Benchmark": "194"
+    },
+    {
+        "CPU": "Intel Core Solo T1400 @ 1.83GHz",
+        "Benchmark": "253"
+    },
+    {
+        "CPU": "Intel Core Solo U1300 @ 1.06GHz",
+        "Benchmark": "127"
+    },
+    {
+        "CPU": "Intel Core Solo U1400 @ 1.20GHz",
+        "Benchmark": "130"
+    },
+    {
+        "CPU": "Intel Core Solo U1500 @ 1.33GHz",
+        "Benchmark": "164"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 125H",
+        "Benchmark": "21,15"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 125U",
+        "Benchmark": "17,565"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 134U",
+        "Benchmark": "12,667"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 135H",
+        "Benchmark": "22,46"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 135U",
+        "Benchmark": "17,478"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 225",
+        "Benchmark": "30,695"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 225F",
+        "Benchmark": "31,121"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 225H",
+        "Benchmark": "29,861"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 225T",
+        "Benchmark": "23,64"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 225U",
+        "Benchmark": "19,2"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 226V",
+        "Benchmark": "18,864"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 228V",
+        "Benchmark": "16,816"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 235",
+        "Benchmark": "40,621"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 235H",
+        "Benchmark": "26,826"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 235T",
+        "Benchmark": "34,359"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 235U",
+        "Benchmark": "17,423"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 236V",
+        "Benchmark": "19,156"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 238V",
+        "Benchmark": "18,65"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 245",
+        "Benchmark": "38,104"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 245K",
+        "Benchmark": "43,584"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 245KF",
+        "Benchmark": "43,604"
+    },
+    {
+        "CPU": "Intel Core Ultra 5 245T",
+        "Benchmark": "31,782"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 155H",
+        "Benchmark": "24,952"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 155U",
+        "Benchmark": "16,477"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 164U",
+        "Benchmark": "13,279"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 165H",
+        "Benchmark": "26,039"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 165U",
+        "Benchmark": "17,166"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 255H",
+        "Benchmark": "30,277"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 255HX",
+        "Benchmark": "54,304"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 255U",
+        "Benchmark": "19,314"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 256V",
+        "Benchmark": "20,084"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 258V",
+        "Benchmark": "19,204"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265",
+        "Benchmark": "49,184"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265F",
+        "Benchmark": "49,277"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265H",
+        "Benchmark": "33,808"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265HX",
+        "Benchmark": "46,443"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265K",
+        "Benchmark": "58,811"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265KF",
+        "Benchmark": "58,88"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265T",
+        "Benchmark": "36,535"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 265U",
+        "Benchmark": "19,162"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 266V",
+        "Benchmark": "20,41"
+    },
+    {
+        "CPU": "Intel Core Ultra 7 268V",
+        "Benchmark": "20,173"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 185H",
+        "Benchmark": "29,406"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 275HX",
+        "Benchmark": "55,887"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 285",
+        "Benchmark": "56,327"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 285H",
+        "Benchmark": "32,926"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 285HX",
+        "Benchmark": "60,438"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 285K",
+        "Benchmark": "67,817"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 285T",
+        "Benchmark": "37,308"
+    },
+    {
+        "CPU": "Intel Core Ultra 9 288V",
+        "Benchmark": "20,4"
+    },
+    {
+        "CPU": "Intel Core2 Duo E4300 @ 1.80GHz",
+        "Benchmark": "588"
+    },
+    {
+        "CPU": "Intel Core2 Duo E4400 @ 2.00GHz",
+        "Benchmark": "737"
+    },
+    {
+        "CPU": "Intel Core2 Duo E4500 @ 2.20GHz",
+        "Benchmark": "743"
+    },
+    {
+        "CPU": "Intel Core2 Duo E4600 @ 2.40GHz",
+        "Benchmark": "875"
+    },
+    {
+        "CPU": "Intel Core2 Duo E4700 @ 2.60GHz",
+        "Benchmark": "987"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6300 @ 1.86GHz",
+        "Benchmark": "652"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6320 @ 1.86GHz",
+        "Benchmark": "717"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6400 @ 2.13GHz",
+        "Benchmark": "774"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6420 @ 2.13GHz",
+        "Benchmark": "752"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6540 @ 2.33GHz",
+        "Benchmark": "808"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6550 @ 2.33GHz",
+        "Benchmark": "909"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6600 @ 2.40GHz",
+        "Benchmark": "942"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6700 @ 2.66GHz",
+        "Benchmark": "975"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6750 @ 2.66GHz",
+        "Benchmark": "1,022"
+    },
+    {
+        "CPU": "Intel Core2 Duo E6850 @ 3.00GHz",
+        "Benchmark": "1,159"
+    },
+    {
+        "CPU": "Intel Core2 Duo E7200 @ 2.53GHz",
+        "Benchmark": "991"
+    },
+    {
+        "CPU": "Intel Core2 Duo E7300 @ 2.66GHz",
+        "Benchmark": "948"
+    },
+    {
+        "CPU": "Intel Core2 Duo E7400 @ 2.80GHz",
+        "Benchmark": "1,038"
+    },
+    {
+        "CPU": "Intel Core2 Duo E7500 @ 2.93GHz",
+        "Benchmark": "1,15"
+    },
+    {
+        "CPU": "Intel Core2 Duo E7600 @ 3.06GHz",
+        "Benchmark": "1,144"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8135 @ 2.40GHz",
+        "Benchmark": "973"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8135 @ 2.66GHz",
+        "Benchmark": "1,112"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8200 @ 2.66GHz",
+        "Benchmark": "1,14"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8235 @ 2.80GHz",
+        "Benchmark": "1,02"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8290 @ 2.83GHz",
+        "Benchmark": "1,408"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8300 @ 2.83GHz",
+        "Benchmark": "1,019"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8335 @ 2.66GHz",
+        "Benchmark": "1,121"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8335 @ 2.93GHz",
+        "Benchmark": "1,06"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8400 @ 3.00GHz",
+        "Benchmark": "1,21"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8435 @ 3.06GHz",
+        "Benchmark": "1,104"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8500 @ 3.16GHz",
+        "Benchmark": "1,293"
+    },
+    {
+        "CPU": "Intel Core2 Duo E8600 @ 3.33GHz",
+        "Benchmark": "1,364"
+    },
+    {
+        "CPU": "Intel Core2 Duo L7100 @ 1.20GHz",
+        "Benchmark": "467"
+    },
+    {
+        "CPU": "Intel Core2 Duo L7300 @ 1.40GHz",
+        "Benchmark": "536"
+    },
+    {
+        "CPU": "Intel Core2 Duo L7400 @ 1.50GHz",
+        "Benchmark": "516"
+    },
+    {
+        "CPU": "Intel Core2 Duo L7500 @ 1.60GHz",
+        "Benchmark": "657"
+    },
+    {
+        "CPU": "Intel Core2 Duo L7700 @ 1.80GHz",
+        "Benchmark": "677"
+    },
+    {
+        "CPU": "Intel Core2 Duo L7800 @ 2.00GHz",
+        "Benchmark": "680"
+    },
+    {
+        "CPU": "Intel Core2 Duo L9300 @ 1.60GHz",
+        "Benchmark": "690"
+    },
+    {
+        "CPU": "Intel Core2 Duo L9600 @ 2.13GHz",
+        "Benchmark": "788"
+    },
+    {
+        "CPU": "Intel Core2 Duo P7350 @ 2.00GHz",
+        "Benchmark": "726"
+    },
+    {
+        "CPU": "Intel Core2 Duo P7370 @ 2.00GHz",
+        "Benchmark": "790"
+    },
+    {
+        "CPU": "Intel Core2 Duo P7450 @ 2.13GHz",
+        "Benchmark": "793"
+    },
+    {
+        "CPU": "Intel Core2 Duo P7550 @ 2.26GHz",
+        "Benchmark": "830"
+    },
+    {
+        "CPU": "Intel Core2 Duo P7570 @ 2.26GHz",
+        "Benchmark": "870"
+    },
+    {
+        "CPU": "Intel Core2 Duo P8400 @ 2.26GHz",
+        "Benchmark": "865"
+    },
+    {
+        "CPU": "Intel Core2 Duo P8600 @ 2.40GHz",
+        "Benchmark": "855"
+    },
+    {
+        "CPU": "Intel Core2 Duo P8700 @ 2.53GHz",
+        "Benchmark": "947"
+    },
+    {
+        "CPU": "Intel Core2 Duo P8800 @ 2.66GHz",
+        "Benchmark": "937"
+    },
+    {
+        "CPU": "Intel Core2 Duo P9300 @ 2.26GHz",
+        "Benchmark": "952"
+    },
+    {
+        "CPU": "Intel Core2 Duo P9500 @ 2.53GHz",
+        "Benchmark": "993"
+    },
+    {
+        "CPU": "Intel Core2 Duo P9600 @ 2.53GHz",
+        "Benchmark": "1,04"
+    },
+    {
+        "CPU": "Intel Core2 Duo P9600 @ 2.66GHz",
+        "Benchmark": "1,093"
+    },
+    {
+        "CPU": "Intel Core2 Duo P9700 @ 2.80GHz",
+        "Benchmark": "1,178"
+    },
+    {
+        "CPU": "Intel Core2 Duo SL9400 @ 1.86GHz",
+        "Benchmark": "759"
+    },
+    {
+        "CPU": "Intel Core2 Duo SP9400 @ 2.40GHz",
+        "Benchmark": "870"
+    },
+    {
+        "CPU": "Intel Core2 Duo SU9400 @ 1.40GHz",
+        "Benchmark": "521"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5200 @ 1.60GHz",
+        "Benchmark": "470"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5250 @ 1.50GHz",
+        "Benchmark": "556"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5270 @ 1.40GHz",
+        "Benchmark": "427"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5300 @ 1.73GHz",
+        "Benchmark": "530"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5450 @ 1.66GHz",
+        "Benchmark": "583"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5470 @ 1.60GHz",
+        "Benchmark": "590"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5500 @ 1.66GHz",
+        "Benchmark": "567"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5550 @ 1.83GHz",
+        "Benchmark": "638"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5600 @ 1.83GHz",
+        "Benchmark": "675"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5670 @ 1.80GHz",
+        "Benchmark": "620"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5750 @ 2.00GHz",
+        "Benchmark": "710"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5800 @ 2.00GHz",
+        "Benchmark": "637"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5850 @ 2.16GHz",
+        "Benchmark": "721"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5870 @ 2.00GHz",
+        "Benchmark": "705"
+    },
+    {
+        "CPU": "Intel Core2 Duo T5900 @ 2.20GHz",
+        "Benchmark": "652"
+    },
+    {
+        "CPU": "Intel Core2 Duo T6400 @ 2.00GHz",
+        "Benchmark": "731"
+    },
+    {
+        "CPU": "Intel Core2 Duo T6500 @ 2.10GHz",
+        "Benchmark": "744"
+    },
+    {
+        "CPU": "Intel Core2 Duo T6570 @ 2.10GHz",
+        "Benchmark": "774"
+    },
+    {
+        "CPU": "Intel Core2 Duo T6600 @ 2.20GHz",
+        "Benchmark": "799"
+    },
+    {
+        "CPU": "Intel Core2 Duo T6670 @ 2.20GHz",
+        "Benchmark": "832"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7100 @ 1.80GHz",
+        "Benchmark": "599"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7200 @ 2.00GHz",
+        "Benchmark": "735"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7250 @ 2.00GHz",
+        "Benchmark": "697"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7300 @ 2.00GHz",
+        "Benchmark": "693"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7400 @ 2.16GHz",
+        "Benchmark": "765"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7500 @ 2.20GHz",
+        "Benchmark": "836"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7600 @ 2.33GHz",
+        "Benchmark": "791"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7700 @ 2.40GHz",
+        "Benchmark": "943"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Core2 Duo T7700 @ 2.40GHz",
+        "Benchmark": "3,497"
+    },
+    {
+        "CPU": "Intel Core2 Duo T7800 @ 2.60GHz",
+        "Benchmark": "905"
+    },
+    {
+        "CPU": "Intel Core2 Duo T8100 @ 2.10GHz",
+        "Benchmark": "779"
+    },
+    {
+        "CPU": "Intel Core2 Duo T8300 @ 2.40GHz",
+        "Benchmark": "902"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9300 @ 2.50GHz",
+        "Benchmark": "981"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9400 @ 2.53GHz",
+        "Benchmark": "1,003"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9500 @ 2.60GHz",
+        "Benchmark": "1,041"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9550 @ 2.66GHz",
+        "Benchmark": "989"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9600 @ 2.80GHz",
+        "Benchmark": "1,08"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9800 @ 2.93GHz",
+        "Benchmark": "1,193"
+    },
+    {
+        "CPU": "Intel Core2 Duo T9900 @ 3.06GHz",
+        "Benchmark": "1,199"
+    },
+    {
+        "CPU": "Intel Core2 Duo U7300 @ 1.30GHz",
+        "Benchmark": "537"
+    },
+    {
+        "CPU": "Intel Core2 Duo U7500 @ 1.06GHz",
+        "Benchmark": "392"
+    },
+    {
+        "CPU": "Intel Core2 Duo U7600 @ 1.20GHz",
+        "Benchmark": "347"
+    },
+    {
+        "CPU": "Intel Core2 Duo U7700 @ 1.33GHz",
+        "Benchmark": "420"
+    },
+    {
+        "CPU": "Intel Core2 Duo U9300 @ 1.20GHz",
+        "Benchmark": "447"
+    },
+    {
+        "CPU": "Intel Core2 Duo U9600 @ 1.60GHz",
+        "Benchmark": "587"
+    },
+    {
+        "CPU": "Intel Core2 Extreme Q6800 @ 2.93GHz",
+        "Benchmark": "2,145"
+    },
+    {
+        "CPU": "Intel Core2 Extreme Q6850 @ 3.00GHz",
+        "Benchmark": "2,242"
+    },
+    {
+        "CPU": "Intel Core2 Extreme Q9200 @ 2.40GHz",
+        "Benchmark": "2,011"
+    },
+    {
+        "CPU": "Intel Core2 Extreme Q9300 @ 2.53GHz",
+        "Benchmark": "1,993"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X6800 @ 2.93GHz",
+        "Benchmark": "1,095"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X7800 @ 2.60GHz",
+        "Benchmark": "1,138"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X7900 @ 2.80GHz",
+        "Benchmark": "1,104"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X9000 @ 2.80GHz",
+        "Benchmark": "1,099"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X9100 @ 3.06GHz",
+        "Benchmark": "1,181"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X9650 @ 3.00GHz",
+        "Benchmark": "2,381"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X9750 @ 3.16GHz",
+        "Benchmark": "2,348"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X9770 @ 3.20GHz",
+        "Benchmark": "2,689"
+    },
+    {
+        "CPU": "Intel Core2 Extreme X9775 @ 3.20GHz",
+        "Benchmark": "2,78"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q6600 @ 2.40GHz",
+        "Benchmark": "1,835"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q6700 @ 2.66GHz",
+        "Benchmark": "2,096"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q8200 @ 2.33GHz",
+        "Benchmark": "1,788"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q8300 @ 2.50GHz",
+        "Benchmark": "1,906"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q8400 @ 2.66GHz",
+        "Benchmark": "2,07"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9000 @ 2.00GHz",
+        "Benchmark": "1,586"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9100 @ 2.26GHz",
+        "Benchmark": "1,806"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9300 @ 2.50GHz",
+        "Benchmark": "1,996"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9400 @ 2.66GHz",
+        "Benchmark": "2,152"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9450 @ 2.66GHz",
+        "Benchmark": "2,19"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9500 @ 2.83GHz",
+        "Benchmark": "2,246"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9505 @ 2.83GHz",
+        "Benchmark": "2,171"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9550 @ 2.83GHz",
+        "Benchmark": "2,349"
+    },
+    {
+        "CPU": "Intel Core2 Quad Q9650 @ 3.00GHz",
+        "Benchmark": "2,488"
+    },
+    {
+        "CPU": "Intel Core2 Solo U2100 @ 1.06GHz",
+        "Benchmark": "233"
+    },
+    {
+        "CPU": "Intel Core2 Solo U3500 @ 1.40GHz",
+        "Benchmark": "272"
+    },
+    {
+        "CPU": "Intel CoreT i5-1350P",
+        "Benchmark": "19,429"
+    },
+    {
+        "CPU": "Intel CoreTM Ultra 5 115U",
+        "Benchmark": "12,771"
+    },
+    {
+        "CPU": "Intel N100",
+        "Benchmark": "5,401"
+    },
+    {
+        "CPU": "Intel N150",
+        "Benchmark": "5,552"
+    },
+    {
+        "CPU": "Intel N200",
+        "Benchmark": "4,882"
+    },
+    {
+        "CPU": "Intel N250",
+        "Benchmark": "5,05"
+    },
+    {
+        "CPU": "Intel N50",
+        "Benchmark": "2,673"
+    },
+    {
+        "CPU": "Intel N95",
+        "Benchmark": "5,357"
+    },
+    {
+        "CPU": "Intel N97",
+        "Benchmark": "5,624"
+    },
+    {
+        "CPU": "Intel Pentium 1403 @ 2.60GHz",
+        "Benchmark": "1,851"
+    },
+    {
+        "CPU": "Intel Pentium 1403 v2 @ 2.60GHz",
+        "Benchmark": "2,284"
+    },
+    {
+        "CPU": "Intel Pentium 2020M @ 2.40GHz",
+        "Benchmark": "1,401"
+    },
+    {
+        "CPU": "Intel Pentium 2030M @ 2.50GHz",
+        "Benchmark": "1,389"
+    },
+    {
+        "CPU": "Intel Pentium 2117U @ 1.80GHz",
+        "Benchmark": "1,022"
+    },
+    {
+        "CPU": "Intel Pentium 2127U @ 1.90GHz",
+        "Benchmark": "1,07"
+    },
+    {
+        "CPU": "Intel Pentium 2129Y @ 1.10GHz",
+        "Benchmark": "587"
+    },
+    {
+        "CPU": "Intel Pentium 3550M @ 2.30GHz",
+        "Benchmark": "1,282"
+    },
+    {
+        "CPU": "Intel Pentium 3556U @ 1.70GHz",
+        "Benchmark": "1,068"
+    },
+    {
+        "CPU": "Intel Pentium 3558U @ 1.70GHz",
+        "Benchmark": "1,047"
+    },
+    {
+        "CPU": "Intel Pentium 3560M @ 2.40GHz",
+        "Benchmark": "1,345"
+    },
+    {
+        "CPU": "Intel Pentium 3560Y @ 1.20GHz",
+        "Benchmark": "887"
+    },
+    {
+        "CPU": "Intel Pentium 3805U @ 1.90GHz",
+        "Benchmark": "1,194"
+    },
+    {
+        "CPU": "Intel Pentium 3825U @ 1.90GHz",
+        "Benchmark": "1,401"
+    },
+    {
+        "CPU": "Intel Pentium 4 1.50GHz",
+        "Benchmark": "86"
+    },
+    {
+        "CPU": "Intel Pentium 4 1.60GHz",
+        "Benchmark": "84"
+    },
+    {
+        "CPU": "Intel Pentium 4 1.70GHz",
+        "Benchmark": "86"
+    },
+    {
+        "CPU": "Intel Pentium 4 1.80GHz",
+        "Benchmark": "115"
+    },
+    {
+        "CPU": "Intel Pentium 4 1.90GHz",
+        "Benchmark": "104"
+    },
+    {
+        "CPU": "Intel Pentium 4 1300MHz",
+        "Benchmark": "77"
+    },
+    {
+        "CPU": "Intel Pentium 4 1400MHz",
+        "Benchmark": "83"
+    },
+    {
+        "CPU": "Intel Pentium 4 1500MHz",
+        "Benchmark": "81"
+    },
+    {
+        "CPU": "Intel Pentium 4 1700MHz",
+        "Benchmark": "100"
+    },
+    {
+        "CPU": "Intel Pentium 4 1800MHz",
+        "Benchmark": "114"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.00GHz",
+        "Benchmark": "133"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.20GHz",
+        "Benchmark": "157"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.26GHz",
+        "Benchmark": "151"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.40GHz",
+        "Benchmark": "131"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.50GHz",
+        "Benchmark": "160"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.53GHz",
+        "Benchmark": "162"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.60GHz",
+        "Benchmark": "215"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.66GHz",
+        "Benchmark": "157"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.80GHz",
+        "Benchmark": "237"
+    },
+    {
+        "CPU": "Intel Pentium 4 2.93GHz",
+        "Benchmark": "150"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.00GHz",
+        "Benchmark": "309"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.06GHz",
+        "Benchmark": "249"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.20GHz",
+        "Benchmark": "328"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.40GHz",
+        "Benchmark": "298"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.46GHz",
+        "Benchmark": "295"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.60GHz",
+        "Benchmark": "315"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.73GHz",
+        "Benchmark": "385"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.80GHz",
+        "Benchmark": "356"
+    },
+    {
+        "CPU": "Intel Pentium 4 3.83GHz",
+        "Benchmark": "154"
+    },
+    {
+        "CPU": "Intel Pentium 4 Mobile 1.60GHz",
+        "Benchmark": "116"
+    },
+    {
+        "CPU": "Intel Pentium 4 Mobile 1.80GHz",
+        "Benchmark": "114"
+    },
+    {
+        "CPU": "Intel Pentium 4 Mobile 1.90GHz",
+        "Benchmark": "136"
+    },
+    {
+        "CPU": "Intel Pentium 4 Mobile 2.00GHz",
+        "Benchmark": "132"
+    },
+    {
+        "CPU": "Intel Pentium 4405U @ 2.10GHz",
+        "Benchmark": "2,116"
+    },
+    {
+        "CPU": "Intel Pentium 4405Y @ 1.50GHz",
+        "Benchmark": "1,526"
+    },
+    {
+        "CPU": "Intel Pentium 4410Y @ 1.50GHz",
+        "Benchmark": "1,424"
+    },
+    {
+        "CPU": "Intel Pentium 4415U @ 2.30GHz",
+        "Benchmark": "2,248"
+    },
+    {
+        "CPU": "Intel Pentium 4415Y @ 1.60GHz",
+        "Benchmark": "1,576"
+    },
+    {
+        "CPU": "Intel Pentium 4417U @ 2.30GHz",
+        "Benchmark": "2,254"
+    },
+    {
+        "CPU": "Intel Pentium 4425Y @ 1.70GHz",
+        "Benchmark": "1,688"
+    },
+    {
+        "CPU": "Intel Pentium 5405U @ 2.30GHz",
+        "Benchmark": "2,244"
+    },
+    {
+        "CPU": "Intel Pentium 6405U @ 2.40GHz",
+        "Benchmark": "2,356"
+    },
+    {
+        "CPU": "Intel Pentium 6805 @ 1.10GHz",
+        "Benchmark": "4,424"
+    },
+    {
+        "CPU": "Intel Pentium 957 @ 1.20GHz",
+        "Benchmark": "622"
+    },
+    {
+        "CPU": "Intel Pentium 967 @ 1.30GHz",
+        "Benchmark": "643"
+    },
+    {
+        "CPU": "Intel Pentium 987 @ 1.50GHz",
+        "Benchmark": "696"
+    },
+    {
+        "CPU": "Intel Pentium 997 @ 1.60GHz",
+        "Benchmark": "809"
+    },
+    {
+        "CPU": "Intel Pentium A1018 @ 2.10GHz",
+        "Benchmark": "1,21"
+    },
+    {
+        "CPU": "Intel Pentium A1020 @ 2.41GHz",
+        "Benchmark": "1,249"
+    },
+    {
+        "CPU": "Intel Pentium B940 @ 2.00GHz",
+        "Benchmark": "882"
+    },
+    {
+        "CPU": "Intel Pentium B950 @ 2.10GHz",
+        "Benchmark": "1,021"
+    },
+    {
+        "CPU": "Intel Pentium B960 @ 2.20GHz",
+        "Benchmark": "1,004"
+    },
+    {
+        "CPU": "Intel Pentium B970 @ 2.30GHz",
+        "Benchmark": "1,087"
+    },
+    {
+        "CPU": "Intel Pentium B980 @ 2.40GHz",
+        "Benchmark": "1,088"
+    },
+    {
+        "CPU": "Intel Pentium D 3.40GHz",
+        "Benchmark": "782"
+    },
+    {
+        "CPU": "Intel Pentium D 805 @ 2.66GHz",
+        "Benchmark": "374"
+    },
+    {
+        "CPU": "Intel Pentium D 830 @ 3.00GHz",
+        "Benchmark": "572"
+    },
+    {
+        "CPU": "Intel Pentium D 915 @ 2.80GHz",
+        "Benchmark": "459"
+    },
+    {
+        "CPU": "Intel Pentium D 940 @ 3.20GHz",
+        "Benchmark": "552"
+    },
+    {
+        "CPU": "Intel Pentium D 950 @ 3.40GHz",
+        "Benchmark": "681"
+    },
+    {
+        "CPU": "Intel Pentium D 960 @ 3.60GHz",
+        "Benchmark": "807"
+    },
+    {
+        "CPU": "Intel Pentium D1508 @ 2.20GHz",
+        "Benchmark": "3,24"
+    },
+    {
+        "CPU": "Intel Pentium Dual T2390 @ 1.86GHz",
+        "Benchmark": "745"
+    },
+    {
+        "CPU": "Intel Pentium E2140 @ 1.60GHz",
+        "Benchmark": "538"
+    },
+    {
+        "CPU": "Intel Pentium E2160 @ 1.80GHz",
+        "Benchmark": "659"
+    },
+    {
+        "CPU": "Intel Pentium E2180 @ 2.00GHz",
+        "Benchmark": "680"
+    },
+    {
+        "CPU": "Intel Pentium E2200 @ 2.20GHz",
+        "Benchmark": "745"
+    },
+    {
+        "CPU": "Intel Pentium E2210 @ 2.20GHz",
+        "Benchmark": "702"
+    },
+    {
+        "CPU": "Intel Pentium E2220 @ 2.40GHz",
+        "Benchmark": "855"
+    },
+    {
+        "CPU": "Intel Pentium E5200 @ 2.50GHz",
+        "Benchmark": "932"
+    },
+    {
+        "CPU": "Intel Pentium E5300 @ 2.60GHz",
+        "Benchmark": "926"
+    },
+    {
+        "CPU": "Intel Pentium E5400 @ 2.70GHz",
+        "Benchmark": "995"
+    },
+    {
+        "CPU": "Intel Pentium E5500 @ 2.80GHz",
+        "Benchmark": "1,055"
+    },
+    {
+        "CPU": "Intel Pentium E5700 @ 3.00GHz",
+        "Benchmark": "1,088"
+    },
+    {
+        "CPU": "Intel Pentium E5800 @ 3.20GHz",
+        "Benchmark": "1,182"
+    },
+    {
+        "CPU": "Intel Pentium E6300 @ 2.80GHz",
+        "Benchmark": "1,032"
+    },
+    {
+        "CPU": "Intel Pentium E6500 @ 2.93GHz",
+        "Benchmark": "1,176"
+    },
+    {
+        "CPU": "Intel Pentium E6600 @ 3.06GHz",
+        "Benchmark": "1,168"
+    },
+    {
+        "CPU": "Intel Pentium E6700 @ 3.20GHz",
+        "Benchmark": "1,217"
+    },
+    {
+        "CPU": "Intel Pentium E6800 @ 3.33GHz",
+        "Benchmark": "1,155"
+    },
+    {
+        "CPU": "Intel Pentium Extreme Edition 955 @ 3.46GHz",
+        "Benchmark": "469"
+    },
+    {
+        "CPU": "Intel Pentium Extreme Edition 965 @ 3.73GHz",
+        "Benchmark": "987"
+    },
+    {
+        "CPU": "Intel Pentium G2010 @ 2.80GHz",
+        "Benchmark": "1,624"
+    },
+    {
+        "CPU": "Intel Pentium G2020 @ 2.90GHz",
+        "Benchmark": "1,696"
+    },
+    {
+        "CPU": "Intel Pentium G2020T @ 2.50GHz",
+        "Benchmark": "1,43"
+    },
+    {
+        "CPU": "Intel Pentium G2030 @ 3.00GHz",
+        "Benchmark": "1,763"
+    },
+    {
+        "CPU": "Intel Pentium G2030T @ 2.60GHz",
+        "Benchmark": "1,597"
+    },
+    {
+        "CPU": "Intel Pentium G2100T @ 2.60GHz",
+        "Benchmark": "1,691"
+    },
+    {
+        "CPU": "Intel Pentium G2120 @ 3.10GHz",
+        "Benchmark": "1,896"
+    },
+    {
+        "CPU": "Intel Pentium G2120T @ 2.70GHz",
+        "Benchmark": "1,613"
+    },
+    {
+        "CPU": "Intel Pentium G2130 @ 3.20GHz",
+        "Benchmark": "1,917"
+    },
+    {
+        "CPU": "Intel Pentium G2140 @ 3.30GHz",
+        "Benchmark": "2,092"
+    },
+    {
+        "CPU": "Intel Pentium G3220 @ 3.00GHz",
+        "Benchmark": "1,889"
+    },
+    {
+        "CPU": "Intel Pentium G3220T @ 2.60GHz",
+        "Benchmark": "1,634"
+    },
+    {
+        "CPU": "Intel Pentium G3240 @ 3.10GHz",
+        "Benchmark": "1,957"
+    },
+    {
+        "CPU": "Intel Pentium G3240T @ 2.70GHz",
+        "Benchmark": "1,674"
+    },
+    {
+        "CPU": "Intel Pentium G3250 @ 3.20GHz",
+        "Benchmark": "2,014"
+    },
+    {
+        "CPU": "Intel Pentium G3250T @ 2.80GHz",
+        "Benchmark": "1,813"
+    },
+    {
+        "CPU": "Intel Pentium G3258 @ 3.20GHz",
+        "Benchmark": "2,053"
+    },
+    {
+        "CPU": "Intel Pentium G3260 @ 3.30GHz",
+        "Benchmark": "2,108"
+    },
+    {
+        "CPU": "Intel Pentium G3260T @ 2.90GHz",
+        "Benchmark": "1,856"
+    },
+    {
+        "CPU": "Intel Pentium G3320TE @ 2.30GHz",
+        "Benchmark": "1,57"
+    },
+    {
+        "CPU": "Intel Pentium G3420 @ 3.20GHz",
+        "Benchmark": "1,987"
+    },
+    {
+        "CPU": "Intel Pentium G3420T @ 2.70GHz",
+        "Benchmark": "1,912"
+    },
+    {
+        "CPU": "Intel Pentium G3430 @ 3.30GHz",
+        "Benchmark": "2,127"
+    },
+    {
+        "CPU": "Intel Pentium G3440 @ 3.30GHz",
+        "Benchmark": "2,202"
+    },
+    {
+        "CPU": "Intel Pentium G3440T @ 2.80GHz",
+        "Benchmark": "2,107"
+    },
+    {
+        "CPU": "Intel Pentium G3450 @ 3.40GHz",
+        "Benchmark": "2,182"
+    },
+    {
+        "CPU": "Intel Pentium G3450T @ 2.90GHz",
+        "Benchmark": "1,904"
+    },
+    {
+        "CPU": "Intel Pentium G3460 @ 3.50GHz",
+        "Benchmark": "2,233"
+    },
+    {
+        "CPU": "Intel Pentium G3460T @ 3.00GHz",
+        "Benchmark": "2,036"
+    },
+    {
+        "CPU": "Intel Pentium G3470 @ 3.60GHz",
+        "Benchmark": "2,428"
+    },
+    {
+        "CPU": "Intel Pentium G4400 @ 3.30GHz",
+        "Benchmark": "2,555"
+    },
+    {
+        "CPU": "Intel Pentium G4400T @ 2.90GHz",
+        "Benchmark": "2,337"
+    },
+    {
+        "CPU": "Intel Pentium G4400TE @ 2.40GHz",
+        "Benchmark": "2,19"
+    },
+    {
+        "CPU": "Intel Pentium G4500 @ 3.50GHz",
+        "Benchmark": "2,798"
+    },
+    {
+        "CPU": "Intel Pentium G4500T @ 3.00GHz",
+        "Benchmark": "2,399"
+    },
+    {
+        "CPU": "Intel Pentium G4520 @ 3.60GHz",
+        "Benchmark": "2,721"
+    },
+    {
+        "CPU": "Intel Pentium G4560 @ 3.50GHz",
+        "Benchmark": "3,539"
+    },
+    {
+        "CPU": "Intel Pentium G4560T @ 2.90GHz",
+        "Benchmark": "2,972"
+    },
+    {
+        "CPU": "Intel Pentium G4600 @ 3.60GHz",
+        "Benchmark": "3,608"
+    },
+    {
+        "CPU": "Intel Pentium G4600T @ 3.00GHz",
+        "Benchmark": "3,062"
+    },
+    {
+        "CPU": "Intel Pentium G4620 @ 3.70GHz",
+        "Benchmark": "3,766"
+    },
+    {
+        "CPU": "Intel Pentium G620 @ 2.60GHz",
+        "Benchmark": "1,22"
+    },
+    {
+        "CPU": "Intel Pentium G620T @ 2.20GHz",
+        "Benchmark": "896"
+    },
+    {
+        "CPU": "Intel Pentium G630 @ 2.70GHz",
+        "Benchmark": "1,352"
+    },
+    {
+        "CPU": "Intel Pentium G630T @ 2.30GHz",
+        "Benchmark": "1,032"
+    },
+    {
+        "CPU": "Intel Pentium G640 @ 2.80GHz",
+        "Benchmark": "1,369"
+    },
+    {
+        "CPU": "Intel Pentium G640T @ 2.40GHz",
+        "Benchmark": "1,139"
+    },
+    {
+        "CPU": "Intel Pentium G645 @ 2.90GHz",
+        "Benchmark": "1,441"
+    },
+    {
+        "CPU": "Intel Pentium G645T @ 2.50GHz",
+        "Benchmark": "1,228"
+    },
+    {
+        "CPU": "Intel Pentium G6950 @ 2.80GHz",
+        "Benchmark": "1,238"
+    },
+    {
+        "CPU": "Intel Pentium G6951 @ 2.80GHz",
+        "Benchmark": "1,383"
+    },
+    {
+        "CPU": "Intel Pentium G6960 @ 2.93GHz",
+        "Benchmark": "1,433"
+    },
+    {
+        "CPU": "Intel Pentium G840 @ 2.80GHz",
+        "Benchmark": "1,311"
+    },
+    {
+        "CPU": "Intel Pentium G850 @ 2.90GHz",
+        "Benchmark": "1,475"
+    },
+    {
+        "CPU": "Intel Pentium G860 @ 3.00GHz",
+        "Benchmark": "1,498"
+    },
+    {
+        "CPU": "Intel Pentium G870 @ 3.10GHz",
+        "Benchmark": "1,543"
+    },
+    {
+        "CPU": "Intel Pentium GOLD 6500Y @ 1.10GHz",
+        "Benchmark": "3,027"
+    },
+    {
+        "CPU": "Intel Pentium Gold 7505 @ 2.00GHz",
+        "Benchmark": "5,194"
+    },
+    {
+        "CPU": "Intel Pentium Gold 8500",
+        "Benchmark": "5,652"
+    },
+    {
+        "CPU": "Intel Pentium Gold 8505",
+        "Benchmark": "9,251"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5400 @ 3.70GHz",
+        "Benchmark": "3,741"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5400T @ 3.10GHz",
+        "Benchmark": "3,179"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5420 @ 3.80GHz",
+        "Benchmark": "3,726"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5420T @ 3.20GHz",
+        "Benchmark": "3,39"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5500 @ 3.80GHz",
+        "Benchmark": "3,813"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5500T @ 3.20GHz",
+        "Benchmark": "3,311"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5600 @ 3.90GHz",
+        "Benchmark": "3,833"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5600F @ 3.90GHz",
+        "Benchmark": "4,083"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5600T @ 3.30GHz",
+        "Benchmark": "3,496"
+    },
+    {
+        "CPU": "Intel Pentium Gold G5620 @ 4.00GHz",
+        "Benchmark": "4,251"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6400 @ 4.00GHz",
+        "Benchmark": "4,117"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6400E @ 3.80GHz",
+        "Benchmark": "3,908"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6400T @ 3.40GHz",
+        "Benchmark": "3,546"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6405 @ 4.10GHz",
+        "Benchmark": "3,823"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6405T @ 3.50GHz",
+        "Benchmark": "3,095"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6500 @ 4.10GHz",
+        "Benchmark": "4,163"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6500T @ 3.50GHz",
+        "Benchmark": "3,874"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6505 @ 4.20GHz",
+        "Benchmark": "4,371"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6505T @ 3.60GHz",
+        "Benchmark": "3,698"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6600 @ 4.20GHz",
+        "Benchmark": "4,223"
+    },
+    {
+        "CPU": "Intel Pentium Gold G6605 @ 4.30GHz",
+        "Benchmark": "4,488"
+    },
+    {
+        "CPU": "Intel Pentium Gold G7400",
+        "Benchmark": "6,72"
+    },
+    {
+        "CPU": "Intel Pentium Gold G7400E",
+        "Benchmark": "6,134"
+    },
+    {
+        "CPU": "Intel Pentium Gold G7400T",
+        "Benchmark": "5,537"
+    },
+    {
+        "CPU": "Intel Pentium III 1400 @ 1400MHz",
+        "Benchmark": "193"
+    },
+    {
+        "CPU": "Intel Pentium III 1400S @ 1400MHz",
+        "Benchmark": "194"
+    },
+    {
+        "CPU": "Intel Pentium III Mobile 1066MHz",
+        "Benchmark": "160"
+    },
+    {
+        "CPU": "Intel Pentium III Mobile 1133MHz",
+        "Benchmark": "164"
+    },
+    {
+        "CPU": "Intel Pentium III Mobile 1200MHz",
+        "Benchmark": "156"
+    },
+    {
+        "CPU": "Intel Pentium III Mobile 800MHz",
+        "Benchmark": "119"
+    },
+    {
+        "CPU": "Intel Pentium III Mobile 866MHz",
+        "Benchmark": "99"
+    },
+    {
+        "CPU": "Intel Pentium J2850 @ 2.41GHz",
+        "Benchmark": "1,016"
+    },
+    {
+        "CPU": "Intel Pentium J2900 @ 2.41GHz",
+        "Benchmark": "1,246"
+    },
+    {
+        "CPU": "Intel Pentium J3710 @ 1.60GHz",
+        "Benchmark": "1,403"
+    },
+    {
+        "CPU": "Intel Pentium J4205 @ 1.50GHz",
+        "Benchmark": "2,331"
+    },
+    {
+        "CPU": "Intel Pentium J6426 @ 2.00GHz",
+        "Benchmark": "4,029"
+    },
+    {
+        "CPU": "Intel Pentium M 1.10GHz",
+        "Benchmark": "184"
+    },
+    {
+        "CPU": "Intel Pentium M 1.20GHz",
+        "Benchmark": "199"
+    },
+    {
+        "CPU": "Intel Pentium M 1.30GHz",
+        "Benchmark": "196"
+    },
+    {
+        "CPU": "Intel Pentium M 1.40GHz",
+        "Benchmark": "225"
+    },
+    {
+        "CPU": "Intel Pentium M 1.50GHz",
+        "Benchmark": "240"
+    },
+    {
+        "CPU": "Intel Pentium M 1.60GHz",
+        "Benchmark": "194"
+    },
+    {
+        "CPU": "Intel Pentium M 1.70GHz",
+        "Benchmark": "239"
+    },
+    {
+        "CPU": "Intel Pentium M 1.73GHz",
+        "Benchmark": "205"
+    },
+    {
+        "CPU": "Intel Pentium M 1.80GHz",
+        "Benchmark": "280"
+    },
+    {
+        "CPU": "Intel Pentium M 1.86GHz",
+        "Benchmark": "222"
+    },
+    {
+        "CPU": "Intel Pentium M 1000MHz",
+        "Benchmark": "156"
+    },
+    {
+        "CPU": "Intel Pentium M 1200MHz",
+        "Benchmark": "155"
+    },
+    {
+        "CPU": "Intel Pentium M 1300MHz",
+        "Benchmark": "197"
+    },
+    {
+        "CPU": "Intel Pentium M 1400MHz",
+        "Benchmark": "208"
+    },
+    {
+        "CPU": "Intel Pentium M 1500MHz",
+        "Benchmark": "188"
+    },
+    {
+        "CPU": "Intel Pentium M 1600MHz",
+        "Benchmark": "193"
+    },
+    {
+        "CPU": "Intel Pentium M 1700MHz",
+        "Benchmark": "237"
+    },
+    {
+        "CPU": "Intel Pentium M 2.00GHz",
+        "Benchmark": "270"
+    },
+    {
+        "CPU": "Intel Pentium M 2.10GHz",
+        "Benchmark": "292"
+    },
+    {
+        "CPU": "Intel Pentium M 2.13GHz",
+        "Benchmark": "234"
+    },
+    {
+        "CPU": "Intel Pentium M 2.26GHz",
+        "Benchmark": "227"
+    },
+    {
+        "CPU": "Intel Pentium M 900MHz",
+        "Benchmark": "141"
+    },
+    {
+        "CPU": "Intel Pentium N3510 @ 1.99GHz",
+        "Benchmark": "878"
+    },
+    {
+        "CPU": "Intel Pentium N3520 @ 2.16GHz",
+        "Benchmark": "1,141"
+    },
+    {
+        "CPU": "Intel Pentium N3530 @ 2.16GHz",
+        "Benchmark": "1,182"
+    },
+    {
+        "CPU": "Intel Pentium N3540 @ 2.16GHz",
+        "Benchmark": "1,201"
+    },
+    {
+        "CPU": "Intel Pentium N3700 @ 1.60GHz",
+        "Benchmark": "1,255"
+    },
+    {
+        "CPU": "Intel Pentium N3710 @ 1.60GHz",
+        "Benchmark": "1,385"
+    },
+    {
+        "CPU": "Intel Pentium N4200 @ 1.10GHz",
+        "Benchmark": "2,17"
+    },
+    {
+        "CPU": "Intel Pentium N6415 @ 1.20GHz",
+        "Benchmark": "2,816"
+    },
+    {
+        "CPU": "Intel Pentium P6000 @ 1.87GHz",
+        "Benchmark": "823"
+    },
+    {
+        "CPU": "Intel Pentium P6100 @ 2.00GHz",
+        "Benchmark": "887"
+    },
+    {
+        "CPU": "Intel Pentium P6200 @ 2.13GHz",
+        "Benchmark": "923"
+    },
+    {
+        "CPU": "Intel Pentium P6300 @ 2.27GHz",
+        "Benchmark": "834"
+    },
+    {
+        "CPU": "Intel Pentium Silver J5005 @ 1.50GHz",
+        "Benchmark": "3,129"
+    },
+    {
+        "CPU": "Intel Pentium Silver J5040 @ 2.00GHz",
+        "Benchmark": "3,258"
+    },
+    {
+        "CPU": "Intel Pentium Silver N5000 @ 1.10GHz",
+        "Benchmark": "2,606"
+    },
+    {
+        "CPU": "Intel Pentium Silver N5020 @ 1.10GHz",
+        "Benchmark": "3,404"
+    },
+    {
+        "CPU": "Intel Pentium Silver N5030 @ 1.10GHz",
+        "Benchmark": "2,544"
+    },
+    {
+        "CPU": "Intel Pentium Silver N6000 @ 1.10GHz",
+        "Benchmark": "2,996"
+    },
+    {
+        "CPU": "Intel Pentium Silver N6005 @ 2.00GHz",
+        "Benchmark": "5,313"
+    },
+    {
+        "CPU": "Intel Pentium SU2700 @ 1.30GHz",
+        "Benchmark": "242"
+    },
+    {
+        "CPU": "Intel Pentium SU4100 @ 1.30GHz",
+        "Benchmark": "501"
+    },
+    {
+        "CPU": "Intel Pentium T2060 @ 1.60GHz",
+        "Benchmark": "330"
+    },
+    {
+        "CPU": "Intel Pentium T2080 @ 1.73GHz",
+        "Benchmark": "341"
+    },
+    {
+        "CPU": "Intel Pentium T2130 @ 1.86GHz",
+        "Benchmark": "382"
+    },
+    {
+        "CPU": "Intel Pentium T2310 @ 1.46GHz",
+        "Benchmark": "538"
+    },
+    {
+        "CPU": "Intel Pentium T2330 @ 1.60GHz",
+        "Benchmark": "545"
+    },
+    {
+        "CPU": "Intel Pentium T2370 @ 1.73GHz",
+        "Benchmark": "558"
+    },
+    {
+        "CPU": "Intel Pentium T2390 @ 1.86GHz",
+        "Benchmark": "568"
+    },
+    {
+        "CPU": "Intel Pentium T2410 @ 2.00GHz",
+        "Benchmark": "566"
+    },
+    {
+        "CPU": "Intel Pentium T3200 @ 2.00GHz",
+        "Benchmark": "634"
+    },
+    {
+        "CPU": "Intel Pentium T3400 @ 2.16GHz",
+        "Benchmark": "664"
+    },
+    {
+        "CPU": "Intel Pentium T4200 @ 2.00GHz",
+        "Benchmark": "722"
+    },
+    {
+        "CPU": "Intel Pentium T4300 @ 2.10GHz",
+        "Benchmark": "775"
+    },
+    {
+        "CPU": "Intel Pentium T4400 @ 2.20GHz",
+        "Benchmark": "785"
+    },
+    {
+        "CPU": "Intel Pentium T4500 @ 2.30GHz",
+        "Benchmark": "833"
+    },
+    {
+        "CPU": "Intel Pentium U5400 @ 1.20GHz",
+        "Benchmark": "552"
+    },
+    {
+        "CPU": "Intel Pentium U5600 @ 1.33GHz",
+        "Benchmark": "624"
+    },
+    {
+        "CPU": "Intel T1400 @ 1.73GHz",
+        "Benchmark": "548"
+    },
+    {
+        "CPU": "Intel T1500 @ 1.86GHz",
+        "Benchmark": "548"
+    },
+    {
+        "CPU": "Intel T2050 @ 2.00GHz",
+        "Benchmark": "516"
+    },
+    {
+        "CPU": "Intel U300",
+        "Benchmark": "8,335"
+    },
+    {
+        "CPU": "Intel U300E",
+        "Benchmark": "8,581"
+    },
+    {
+        "CPU": "Intel U4100 @ 1.30GHz",
+        "Benchmark": "610"
+    },
+    {
+        "CPU": "Intel Ultra 5 115U",
+        "Benchmark": "12,736"
+    },
+    {
+        "CPU": "Intel Xeon 2.00GHz",
+        "Benchmark": "152"
+    },
+    {
+        "CPU": "Intel XEON 2.20GHz",
+        "Benchmark": "164"
+    },
+    {
+        "CPU": "Intel Xeon 2.40GHz",
+        "Benchmark": "180"
+    },
+    {
+        "CPU": "Intel Xeon 2.80GHz",
+        "Benchmark": "260"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 2.80GHz",
+        "Benchmark": "1,374"
+    },
+    {
+        "CPU": "Intel Xeon 3.00GHz",
+        "Benchmark": "425"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 3.06GHz",
+        "Benchmark": "533"
+    },
+    {
+        "CPU": "Intel Xeon 3.20GHz",
+        "Benchmark": "478"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 3.20GHz",
+        "Benchmark": "786"
+    },
+    {
+        "CPU": "Intel Xeon 3.40GHz",
+        "Benchmark": "375"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 3.40GHz",
+        "Benchmark": "843"
+    },
+    {
+        "CPU": "Intel Xeon 3.60GHz",
+        "Benchmark": "403"
+    },
+    {
+        "CPU": "Intel Xeon 3.73GHz",
+        "Benchmark": "929"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 3.73GHz",
+        "Benchmark": "1,511"
+    },
+    {
+        "CPU": "Intel Xeon 3.80GHz",
+        "Benchmark": "393"
+    },
+    {
+        "CPU": "Intel Xeon 3040 @ 1.86GHz",
+        "Benchmark": "790"
+    },
+    {
+        "CPU": "Intel Xeon 3050 @ 2.13GHz",
+        "Benchmark": "818"
+    },
+    {
+        "CPU": "Intel Xeon 3060 @ 2.40GHz",
+        "Benchmark": "983"
+    },
+    {
+        "CPU": "Intel Xeon 3065 @ 2.33GHz",
+        "Benchmark": "867"
+    },
+    {
+        "CPU": "Intel Xeon 3070 @ 2.66GHz",
+        "Benchmark": "1,025"
+    },
+    {
+        "CPU": "Intel Xeon 3075 @ 2.66GHz",
+        "Benchmark": "1,112"
+    },
+    {
+        "CPU": "Intel Xeon 3085 @ 3.00GHz",
+        "Benchmark": "1,07"
+    },
+    {
+        "CPU": "Intel Xeon 5110 @ 1.60GHz",
+        "Benchmark": "405"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 5110 @ 1.60GHz",
+        "Benchmark": "1,373"
+    },
+    {
+        "CPU": "Intel Xeon 5120 @ 1.86GHz",
+        "Benchmark": "763"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 5120 @ 1.86GHz",
+        "Benchmark": "1,486"
+    },
+    {
+        "CPU": "Intel Xeon 5130 @ 2.00GHz",
+        "Benchmark": "795"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 5130 @ 2.00GHz",
+        "Benchmark": "1,653"
+    },
+    {
+        "CPU": "Intel Xeon 5133 @ 2.20GHz",
+        "Benchmark": "887"
+    },
+    {
+        "CPU": "Intel Xeon 5140 @ 2.33GHz",
+        "Benchmark": "857"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 5140 @ 2.33GHz",
+        "Benchmark": "1,808"
+    },
+    {
+        "CPU": "Intel Xeon 5148 @ 2.33GHz",
+        "Benchmark": "912"
+    },
+    {
+        "CPU": "Intel Xeon 5150 @ 2.66GHz",
+        "Benchmark": "880"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 5150 @ 2.66GHz",
+        "Benchmark": "2,038"
+    },
+    {
+        "CPU": "Intel Xeon 5160 @ 3.00GHz",
+        "Benchmark": "963"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 5160 @ 3.00GHz",
+        "Benchmark": "2,402"
+    },
+    {
+        "CPU": "Intel Xeon 6325P",
+        "Benchmark": "16,013"
+    },
+    {
+        "CPU": "Intel Xeon 6353P",
+        "Benchmark": "27,662"
+    },
+    {
+        "CPU": "Intel Xeon 6369P",
+        "Benchmark": "29,68"
+    },
+    {
+        "CPU": "Intel Xeon 6517P",
+        "Benchmark": "49,572"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6520P",
+        "Benchmark": "99,164"
+    },
+    {
+        "CPU": "Intel Xeon 6521P",
+        "Benchmark": "57,97"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6530P",
+        "Benchmark": "124,434"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6736P",
+        "Benchmark": "125,444"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6737P",
+        "Benchmark": "127,075"
+    },
+    {
+        "CPU": "Intel Xeon 6740E",
+        "Benchmark": "76,167"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6740P",
+        "Benchmark": "122,165"
+    },
+    {
+        "CPU": "Intel Xeon 6741P",
+        "Benchmark": "100,66"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6747P",
+        "Benchmark": "135,421"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6760P",
+        "Benchmark": "153,187"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon 6787P",
+        "Benchmark": "157,926"
+    },
+    {
+        "CPU": "Intel Xeon @ 2.00GHz",
+        "Benchmark": "7,363"
+    },
+    {
+        "CPU": "Intel Xeon @ 2.20GHz",
+        "Benchmark": "1,324"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon @ 2.20GHz",
+        "Benchmark": "2,167"
+    },
+    {
+        "CPU": "Intel Xeon Bronze 3104 @ 1.70GHz",
+        "Benchmark": "4,392"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Bronze 3104 @ 1.70GHz",
+        "Benchmark": "8,048"
+    },
+    {
+        "CPU": "Intel Xeon Bronze 3106 @ 1.70GHz",
+        "Benchmark": "5,789"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Bronze 3106 @ 1.70GHz",
+        "Benchmark": "10,269"
+    },
+    {
+        "CPU": "Intel Xeon Bronze 3204 @ 1.90GHz",
+        "Benchmark": "4,778"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Bronze 3204 @ 1.90GHz",
+        "Benchmark": "8,959"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Bronze 3206R @ 1.90GHz",
+        "Benchmark": "11,45"
+    },
+    {
+        "CPU": "Intel Xeon Bronze 3408U",
+        "Benchmark": "9,969"
+    },
+    {
+        "CPU": "Intel Xeon Bronze 3508U",
+        "Benchmark": "11,224"
+    },
+    {
+        "CPU": "Intel Xeon D-1518 @ 2.20GHz",
+        "Benchmark": "4,562"
+    },
+    {
+        "CPU": "Intel Xeon D-1520 @ 2.20GHz",
+        "Benchmark": "4,917"
+    },
+    {
+        "CPU": "Intel Xeon D-1521 @ 2.40GHz",
+        "Benchmark": "5,699"
+    },
+    {
+        "CPU": "Intel Xeon D-1527 @ 2.20GHz",
+        "Benchmark": "5,213"
+    },
+    {
+        "CPU": "Intel Xeon D-1528 @ 1.90GHz",
+        "Benchmark": "6,823"
+    },
+    {
+        "CPU": "Intel Xeon D-1531 @ 2.20GHz",
+        "Benchmark": "7,592"
+    },
+    {
+        "CPU": "Intel Xeon D-1537 @ 1.70GHz",
+        "Benchmark": "7,444"
+    },
+    {
+        "CPU": "Intel Xeon D-1539 @ 1.60GHz",
+        "Benchmark": "7,572"
+    },
+    {
+        "CPU": "Intel Xeon D-1540 @ 2.00GHz",
+        "Benchmark": "10,037"
+    },
+    {
+        "CPU": "Intel Xeon D-1541 @ 2.10GHz",
+        "Benchmark": "10,024"
+    },
+    {
+        "CPU": "Intel Xeon D-1548 @ 2.00GHz",
+        "Benchmark": "9,075"
+    },
+    {
+        "CPU": "Intel Xeon D-1557 @ 1.50GHz",
+        "Benchmark": "9,285"
+    },
+    {
+        "CPU": "Intel Xeon D-1559 @ 1.50GHz",
+        "Benchmark": "8,015"
+    },
+    {
+        "CPU": "Intel Xeon D-1567 @ 2.10GHz",
+        "Benchmark": "10,447"
+    },
+    {
+        "CPU": "Intel Xeon D-1577 @ 1.30GHz",
+        "Benchmark": "11,645"
+    },
+    {
+        "CPU": "Intel Xeon D-1581 @ 1.80GHz",
+        "Benchmark": "13,173"
+    },
+    {
+        "CPU": "Intel Xeon D-1587 @ 1.70GHz",
+        "Benchmark": "13,352"
+    },
+    {
+        "CPU": "Intel Xeon D-1602 @ 2.50GHz",
+        "Benchmark": "2,459"
+    },
+    {
+        "CPU": "Intel Xeon D-1622 @ 2.60GHz",
+        "Benchmark": "6,205"
+    },
+    {
+        "CPU": "Intel Xeon D-1715TER @ 2.40GHz",
+        "Benchmark": "9,104"
+    },
+    {
+        "CPU": "Intel Xeon D-1718T @ 2.60GHz",
+        "Benchmark": "9,674"
+    },
+    {
+        "CPU": "Intel Xeon D-1726 @ 2.90GHz",
+        "Benchmark": "15,511"
+    },
+    {
+        "CPU": "Intel Xeon D-1732TE @ 1.90GHz",
+        "Benchmark": "14,254"
+    },
+    {
+        "CPU": "Intel Xeon D-1733NT @ 2.00GHz",
+        "Benchmark": "14,849"
+    },
+    {
+        "CPU": "Intel Xeon D-1736NT @ 2.70GHz",
+        "Benchmark": "17,826"
+    },
+    {
+        "CPU": "Intel Xeon D-1746TER @ 2.00GHz",
+        "Benchmark": "15,66"
+    },
+    {
+        "CPU": "Intel Xeon D-1747NTE @ 2.50GHz",
+        "Benchmark": "20,279"
+    },
+    {
+        "CPU": "Intel Xeon D-1813NT @ 2.20GHz",
+        "Benchmark": "7,732"
+    },
+    {
+        "CPU": "Intel Xeon D-1823NT @ 2.80GHz",
+        "Benchmark": "13,673"
+    },
+    {
+        "CPU": "Intel Xeon D-2123IT @ 2.20GHz",
+        "Benchmark": "6,697"
+    },
+    {
+        "CPU": "Intel Xeon D-2141I @ 2.20GHz",
+        "Benchmark": "12,117"
+    },
+    {
+        "CPU": "Intel Xeon D-2143IT @ 2.20GHz",
+        "Benchmark": "12,207"
+    },
+    {
+        "CPU": "Intel Xeon D-2146NT @ 2.30GHz",
+        "Benchmark": "11,736"
+    },
+    {
+        "CPU": "Intel Xeon D-2166NT @ 2.00GHz",
+        "Benchmark": "15,105"
+    },
+    {
+        "CPU": "Intel Xeon D-2183IT @ 2.20GHz",
+        "Benchmark": "19,377"
+    },
+    {
+        "CPU": "Intel Xeon D-2187NT @ 2.00GHz",
+        "Benchmark": "18,07"
+    },
+    {
+        "CPU": "Intel Xeon D-2712T @ 1.90GHz",
+        "Benchmark": "7,99"
+    },
+    {
+        "CPU": "Intel Xeon D-2733NT @ 2.10GHz",
+        "Benchmark": "16,206"
+    },
+    {
+        "CPU": "Intel Xeon D-2752TER @ 1.80GHz",
+        "Benchmark": "19,102"
+    },
+    {
+        "CPU": "Intel Xeon D-2753NT @ 2.00GHz",
+        "Benchmark": "20,626"
+    },
+    {
+        "CPU": "Intel Xeon D-2766NT @ 2.00GHz",
+        "Benchmark": "24,013"
+    },
+    {
+        "CPU": "Intel Xeon D-2775TE @ 2.00GHz",
+        "Benchmark": "27,299"
+    },
+    {
+        "CPU": "Intel Xeon D-2795NT @ 2.00GHz",
+        "Benchmark": "28,463"
+    },
+    {
+        "CPU": "Intel Xeon D-2796TE @ 2.00GHz",
+        "Benchmark": "26,342"
+    },
+    {
+        "CPU": "Intel Xeon D-2799 @ 2.40GHz",
+        "Benchmark": "33,792"
+    },
+    {
+        "CPU": "Intel Xeon E E-2414",
+        "Benchmark": "12,108"
+    },
+    {
+        "CPU": "Intel Xeon E E-2434",
+        "Benchmark": "15,133"
+    },
+    {
+        "CPU": "Intel Xeon E E-2486",
+        "Benchmark": "23,605"
+    },
+    {
+        "CPU": "Intel Xeon E-2104G @ 3.20GHz",
+        "Benchmark": "5,877"
+    },
+    {
+        "CPU": "Intel Xeon E-2124 @ 3.30GHz",
+        "Benchmark": "6,904"
+    },
+    {
+        "CPU": "Intel Xeon E-2124G @ 3.40GHz",
+        "Benchmark": "7,293"
+    },
+    {
+        "CPU": "Intel Xeon E-2126G @ 3.30GHz",
+        "Benchmark": "10,37"
+    },
+    {
+        "CPU": "Intel Xeon E-2134 @ 3.50GHz",
+        "Benchmark": "9,319"
+    },
+    {
+        "CPU": "Intel Xeon E-2136 @ 3.30GHz",
+        "Benchmark": "13,441"
+    },
+    {
+        "CPU": "Intel Xeon E-2144G @ 3.60GHz",
+        "Benchmark": "9,373"
+    },
+    {
+        "CPU": "Intel Xeon E-2146G @ 3.50GHz",
+        "Benchmark": "13,219"
+    },
+    {
+        "CPU": "Intel Xeon E-2174G @ 3.80GHz",
+        "Benchmark": "9,628"
+    },
+    {
+        "CPU": "Intel Xeon E-2176G @ 3.70GHz",
+        "Benchmark": "13,575"
+    },
+    {
+        "CPU": "Intel Xeon E-2176M @ 2.70GHz",
+        "Benchmark": "10,911"
+    },
+    {
+        "CPU": "Intel Xeon E-2186G @ 3.80GHz",
+        "Benchmark": "13,785"
+    },
+    {
+        "CPU": "Intel Xeon E-2186M @ 2.90GHz",
+        "Benchmark": "11,379"
+    },
+    {
+        "CPU": "Intel Xeon E-2224 @ 3.40GHz",
+        "Benchmark": "7,254"
+    },
+    {
+        "CPU": "Intel Xeon E-2224G @ 3.50GHz",
+        "Benchmark": "7,603"
+    },
+    {
+        "CPU": "Intel Xeon E-2226G @ 3.40GHz",
+        "Benchmark": "11,126"
+    },
+    {
+        "CPU": "Intel Xeon E-2234 @ 3.60GHz",
+        "Benchmark": "9,473"
+    },
+    {
+        "CPU": "Intel Xeon E-2236 @ 3.40GHz",
+        "Benchmark": "13,938"
+    },
+    {
+        "CPU": "Intel Xeon E-2244G @ 3.80GHz",
+        "Benchmark": "9,666"
+    },
+    {
+        "CPU": "Intel Xeon E-2246G @ 3.60GHz",
+        "Benchmark": "13,806"
+    },
+    {
+        "CPU": "Intel Xeon E-2254ML @ 1.70GHz",
+        "Benchmark": "6,333"
+    },
+    {
+        "CPU": "Intel Xeon E-2274G @ 4.00GHz",
+        "Benchmark": "9,907"
+    },
+    {
+        "CPU": "Intel Xeon E-2276G @ 3.80GHz",
+        "Benchmark": "14,126"
+    },
+    {
+        "CPU": "Intel Xeon E-2276M @ 2.80GHz",
+        "Benchmark": "11,726"
+    },
+    {
+        "CPU": "Intel Xeon E-2276ME @ 2.80GHz",
+        "Benchmark": "8,167"
+    },
+    {
+        "CPU": "Intel Xeon E-2276ML @ 2.00GHz",
+        "Benchmark": "6,353"
+    },
+    {
+        "CPU": "Intel Xeon E-2278G @ 3.40GHz",
+        "Benchmark": "16,964"
+    },
+    {
+        "CPU": "Intel Xeon E-2278GE @ 3.30GHz",
+        "Benchmark": "15,509"
+    },
+    {
+        "CPU": "Intel Xeon E-2278GEL @ 2.00GHz",
+        "Benchmark": "12,024"
+    },
+    {
+        "CPU": "Intel Xeon E-2286G @ 4.00GHz",
+        "Benchmark": "13,953"
+    },
+    {
+        "CPU": "Intel Xeon E-2286M @ 2.40GHz",
+        "Benchmark": "15,184"
+    },
+    {
+        "CPU": "Intel Xeon E-2288G @ 3.70GHz",
+        "Benchmark": "17,416"
+    },
+    {
+        "CPU": "Intel Xeon E-2314 @ 2.80GHz",
+        "Benchmark": "7,754"
+    },
+    {
+        "CPU": "Intel Xeon E-2324G @ 3.10GHz",
+        "Benchmark": "10,198"
+    },
+    {
+        "CPU": "Intel Xeon E-2334 @ 3.40GHz",
+        "Benchmark": "12,674"
+    },
+    {
+        "CPU": "Intel Xeon E-2336 @ 2.90GHz",
+        "Benchmark": "16,375"
+    },
+    {
+        "CPU": "Intel Xeon E-2356G @ 3.20GHz",
+        "Benchmark": "18,564"
+    },
+    {
+        "CPU": "Intel Xeon E-2374G @ 3.70GHz",
+        "Benchmark": "13,726"
+    },
+    {
+        "CPU": "Intel Xeon E-2378 @ 2.60GHz",
+        "Benchmark": "17,472"
+    },
+    {
+        "CPU": "Intel Xeon E-2378G @ 2.80GHz",
+        "Benchmark": "21,153"
+    },
+    {
+        "CPU": "Intel Xeon E-2386G @ 3.50GHz",
+        "Benchmark": "19,658"
+    },
+    {
+        "CPU": "Intel Xeon E-2388G @ 3.20GHz",
+        "Benchmark": "23,537"
+    },
+    {
+        "CPU": "Intel Xeon E-2436",
+        "Benchmark": "21,691"
+    },
+    {
+        "CPU": "Intel Xeon E-2456",
+        "Benchmark": "20,507"
+    },
+    {
+        "CPU": "Intel Xeon E-2468",
+        "Benchmark": "26,224"
+    },
+    {
+        "CPU": "Intel Xeon E-2478",
+        "Benchmark": "27,326"
+    },
+    {
+        "CPU": "Intel Xeon E-2488",
+        "Benchmark": "32,232"
+    },
+    {
+        "CPU": "Intel Xeon E3-1205 v6 @ 3.00GHz",
+        "Benchmark": "5,682"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220 @ 3.10GHz",
+        "Benchmark": "3,905"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220 V2 @ 3.10GHz",
+        "Benchmark": "4,681"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220 v3 @ 3.10GHz",
+        "Benchmark": "5,17"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220 v5 @ 3.00GHz",
+        "Benchmark": "5,778"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220 v6 @ 3.00GHz",
+        "Benchmark": "5,593"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220L @ 2.20GHz",
+        "Benchmark": "2,295"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220L V2 @ 2.30GHz",
+        "Benchmark": "2,397"
+    },
+    {
+        "CPU": "Intel Xeon E3-1220L v3 @ 1.10GHz",
+        "Benchmark": "1,407"
+    },
+    {
+        "CPU": "Intel Xeon E3-1225 @ 3.10GHz",
+        "Benchmark": "3,912"
+    },
+    {
+        "CPU": "Intel Xeon E3-1225 V2 @ 3.20GHz",
+        "Benchmark": "4,734"
+    },
+    {
+        "CPU": "Intel Xeon E3-1225 v3 @ 3.20GHz",
+        "Benchmark": "5,325"
+    },
+    {
+        "CPU": "Intel Xeon E3-1225 v5 @ 3.30GHz",
+        "Benchmark": "5,937"
+    },
+    {
+        "CPU": "Intel Xeon E3-1225 v6 @ 3.30GHz",
+        "Benchmark": "5,565"
+    },
+    {
+        "CPU": "Intel Xeon E3-1226 v3 @ 3.30GHz",
+        "Benchmark": "5,528"
+    },
+    {
+        "CPU": "Intel Xeon E3-1230 @ 3.20GHz",
+        "Benchmark": "5,131"
+    },
+    {
+        "CPU": "Intel Xeon E3-1230 V2 @ 3.30GHz",
+        "Benchmark": "6,194"
+    },
+    {
+        "CPU": "Intel Xeon E3-1230 v3 @ 3.30GHz",
+        "Benchmark": "6,832"
+    },
+    {
+        "CPU": "Intel Xeon E3-1230 v5 @ 3.40GHz",
+        "Benchmark": "7,974"
+    },
+    {
+        "CPU": "Intel Xeon E3-1230 v6 @ 3.50GHz",
+        "Benchmark": "8,138"
+    },
+    {
+        "CPU": "Intel Xeon E3-1230L v3 @ 1.80GHz",
+        "Benchmark": "5,282"
+    },
+    {
+        "CPU": "Intel Xeon E3-1231 v3 @ 3.40GHz",
+        "Benchmark": "7,041"
+    },
+    {
+        "CPU": "Intel Xeon E3-1235 @ 3.20GHz",
+        "Benchmark": "5,112"
+    },
+    {
+        "CPU": "Intel Xeon E3-1235L v5 @ 2.00GHz",
+        "Benchmark": "5,013"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240 @ 3.30GHz",
+        "Benchmark": "5,414"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240 V2 @ 3.40GHz",
+        "Benchmark": "6,375"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240 v3 @ 3.40GHz",
+        "Benchmark": "7,01"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240 v5 @ 3.50GHz",
+        "Benchmark": "8,262"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240 v6 @ 3.70GHz",
+        "Benchmark": "8,707"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240L v3 @ 2.00GHz",
+        "Benchmark": "5,651"
+    },
+    {
+        "CPU": "Intel Xeon E3-1240L v5 @ 2.10GHz",
+        "Benchmark": "6,547"
+    },
+    {
+        "CPU": "Intel Xeon E3-1241 v3 @ 3.50GHz",
+        "Benchmark": "7,154"
+    },
+    {
+        "CPU": "Intel Xeon E3-1245 @ 3.30GHz",
+        "Benchmark": "5,351"
+    },
+    {
+        "CPU": "Intel Xeon E3-1245 V2 @ 3.40GHz",
+        "Benchmark": "6,348"
+    },
+    {
+        "CPU": "Intel Xeon E3-1245 v3 @ 3.40GHz",
+        "Benchmark": "7,058"
+    },
+    {
+        "CPU": "Intel Xeon E3-1245 v5 @ 3.50GHz",
+        "Benchmark": "8,06"
+    },
+    {
+        "CPU": "Intel Xeon E3-1245 v6 @ 3.70GHz",
+        "Benchmark": "8,774"
+    },
+    {
+        "CPU": "Intel Xeon E3-1246 v3 @ 3.50GHz",
+        "Benchmark": "7,263"
+    },
+    {
+        "CPU": "Intel Xeon E3-1260L @ 2.40GHz",
+        "Benchmark": "4,079"
+    },
+    {
+        "CPU": "Intel Xeon E3-1260L v5 @ 2.90GHz",
+        "Benchmark": "8,237"
+    },
+    {
+        "CPU": "Intel Xeon E3-1265L @ 2.40GHz",
+        "Benchmark": "3,912"
+    },
+    {
+        "CPU": "Intel Xeon E3-1265L V2 @ 2.50GHz",
+        "Benchmark": "5,091"
+    },
+    {
+        "CPU": "Intel Xeon E3-1265L v3 @ 2.50GHz",
+        "Benchmark": "6,205"
+    },
+    {
+        "CPU": "Intel Xeon E3-1265L v4 @ 2.30GHz",
+        "Benchmark": "6,954"
+    },
+    {
+        "CPU": "Intel Xeon E3-1268L v3 @ 2.30GHz",
+        "Benchmark": "5,574"
+    },
+    {
+        "CPU": "Intel Xeon E3-1268L v5 @ 2.40GHz",
+        "Benchmark": "6,334"
+    },
+    {
+        "CPU": "Intel Xeon E3-1270 @ 3.40GHz",
+        "Benchmark": "5,367"
+    },
+    {
+        "CPU": "Intel Xeon E3-1270 V2 @ 3.50GHz",
+        "Benchmark": "6,488"
+    },
+    {
+        "CPU": "Intel Xeon E3-1270 v3 @ 3.50GHz",
+        "Benchmark": "7,278"
+    },
+    {
+        "CPU": "Intel Xeon E3-1270 v5 @ 3.60GHz",
+        "Benchmark": "8,31"
+    },
+    {
+        "CPU": "Intel Xeon E3-1270 v6 @ 3.80GHz",
+        "Benchmark": "8,869"
+    },
+    {
+        "CPU": "Intel Xeon E3-1270L v4 @ 3.00GHz",
+        "Benchmark": "7,662"
+    },
+    {
+        "CPU": "Intel Xeon E3-1271 v3 @ 3.60GHz",
+        "Benchmark": "7,519"
+    },
+    {
+        "CPU": "Intel Xeon E3-1275 @ 3.40GHz",
+        "Benchmark": "5,498"
+    },
+    {
+        "CPU": "Intel Xeon E3-1275 V2 @ 3.50GHz",
+        "Benchmark": "6,617"
+    },
+    {
+        "CPU": "Intel Xeon E3-1275 v3 @ 3.50GHz",
+        "Benchmark": "7,202"
+    },
+    {
+        "CPU": "Intel Xeon E3-1275 v5 @ 3.60GHz",
+        "Benchmark": "8,245"
+    },
+    {
+        "CPU": "Intel Xeon E3-1275 v6 @ 3.80GHz",
+        "Benchmark": "9,221"
+    },
+    {
+        "CPU": "Intel Xeon E3-1275L v3 @ 2.70GHz",
+        "Benchmark": "6,327"
+    },
+    {
+        "CPU": "Intel Xeon E3-1276 v3 @ 3.60GHz",
+        "Benchmark": "7,543"
+    },
+    {
+        "CPU": "Intel Xeon E3-1280 @ 3.50GHz",
+        "Benchmark": "5,65"
+    },
+    {
+        "CPU": "Intel Xeon E3-1280 V2 @ 3.60GHz",
+        "Benchmark": "6,604"
+    },
+    {
+        "CPU": "Intel Xeon E3-1280 v3 @ 3.60GHz",
+        "Benchmark": "7,245"
+    },
+    {
+        "CPU": "Intel Xeon E3-1280 v5 @ 3.70GHz",
+        "Benchmark": "8,352"
+    },
+    {
+        "CPU": "Intel Xeon E3-1280 v6 @ 3.90GHz",
+        "Benchmark": "9,093"
+    },
+    {
+        "CPU": "Intel Xeon E3-1281 v3 @ 3.70GHz",
+        "Benchmark": "7,555"
+    },
+    {
+        "CPU": "Intel Xeon E3-1285 v3 @ 3.60GHz",
+        "Benchmark": "7,211"
+    },
+    {
+        "CPU": "Intel Xeon E3-1285 v4 @ 3.50GHz",
+        "Benchmark": "7,762"
+    },
+    {
+        "CPU": "Intel Xeon E3-1285 v6 @ 4.10GHz",
+        "Benchmark": "9,371"
+    },
+    {
+        "CPU": "Intel Xeon E3-1285L v3 @ 3.10GHz",
+        "Benchmark": "6,858"
+    },
+    {
+        "CPU": "Intel Xeon E3-1285L v4 @ 3.40GHz",
+        "Benchmark": "8,09"
+    },
+    {
+        "CPU": "Intel Xeon E3-1286 v3 @ 3.70GHz",
+        "Benchmark": "7,879"
+    },
+    {
+        "CPU": "Intel Xeon E3-1286L v3 @ 3.20GHz",
+        "Benchmark": "6,929"
+    },
+    {
+        "CPU": "Intel Xeon E3-1290 @ 3.60GHz",
+        "Benchmark": "5,429"
+    },
+    {
+        "CPU": "Intel Xeon E3-1290 V2 @ 3.70GHz",
+        "Benchmark": "6,315"
+    },
+    {
+        "CPU": "Intel Xeon E3-1505L v5 @ 2.00GHz",
+        "Benchmark": "5,083"
+    },
+    {
+        "CPU": "Intel Xeon E3-1505L v6 @ 2.20GHz",
+        "Benchmark": "6,088"
+    },
+    {
+        "CPU": "Intel Xeon E3-1505M v5 @ 2.80GHz",
+        "Benchmark": "7,005"
+    },
+    {
+        "CPU": "Intel Xeon E3-1505M v6 @ 3.00GHz",
+        "Benchmark": "7,382"
+    },
+    {
+        "CPU": "Intel Xeon E3-1515M v5 @ 2.80GHz",
+        "Benchmark": "5,925"
+    },
+    {
+        "CPU": "Intel Xeon E3-1535M v5 @ 2.90GHz",
+        "Benchmark": "7,476"
+    },
+    {
+        "CPU": "Intel Xeon E3-1535M v6 @ 3.10GHz",
+        "Benchmark": "8,059"
+    },
+    {
+        "CPU": "Intel Xeon E3-1545M v5 @ 2.90GHz",
+        "Benchmark": "7,666"
+    },
+    {
+        "CPU": "Intel Xeon E3-1575M v5 @ 3.00GHz",
+        "Benchmark": "7,853"
+    },
+    {
+        "CPU": "Intel Xeon E3-1585 v5 @ 3.50GHz",
+        "Benchmark": "8,408"
+    },
+    {
+        "CPU": "Intel Xeon E3-1585L v5 @ 3.00GHz",
+        "Benchmark": "7,959"
+    },
+    {
+        "CPU": "Intel Xeon E3110 @ 3.00GHz",
+        "Benchmark": "1,295"
+    },
+    {
+        "CPU": "Intel Xeon E3113 @ 3.00GHz",
+        "Benchmark": "1,429"
+    },
+    {
+        "CPU": "Intel Xeon E3120 @ 3.16GHz",
+        "Benchmark": "1,408"
+    },
+    {
+        "CPU": "Intel Xeon E5-1410 @ 2.80GHz",
+        "Benchmark": "4,852"
+    },
+    {
+        "CPU": "Intel Xeon E5-1410 v2 @ 2.80GHz",
+        "Benchmark": "5,715"
+    },
+    {
+        "CPU": "Intel Xeon E5-1428L v2 @ 2.20GHz",
+        "Benchmark": "6,255"
+    },
+    {
+        "CPU": "Intel Xeon E5-1603 @ 2.80GHz",
+        "Benchmark": "3,477"
+    },
+    {
+        "CPU": "Intel Xeon E5-1603 v3 @ 2.80GHz",
+        "Benchmark": "4,472"
+    },
+    {
+        "CPU": "Intel Xeon E5-1603 v4 @ 2.80GHz",
+        "Benchmark": "4,681"
+    },
+    {
+        "CPU": "Intel Xeon E5-1607 @ 3.00GHz",
+        "Benchmark": "3,769"
+    },
+    {
+        "CPU": "Intel Xeon E5-1607 v2 @ 3.00GHz",
+        "Benchmark": "4,139"
+    },
+    {
+        "CPU": "Intel Xeon E5-1607 v3 @ 3.10GHz",
+        "Benchmark": "4,948"
+    },
+    {
+        "CPU": "Intel Xeon E5-1607 v4 @ 3.10GHz",
+        "Benchmark": "5,197"
+    },
+    {
+        "CPU": "Intel Xeon E5-1620 @ 3.60GHz",
+        "Benchmark": "5,846"
+    },
+    {
+        "CPU": "Intel Xeon E5-1620 v2 @ 3.70GHz",
+        "Benchmark": "6,557"
+    },
+    {
+        "CPU": "Intel Xeon E5-1620 v3 @ 3.50GHz",
+        "Benchmark": "6,991"
+    },
+    {
+        "CPU": "Intel Xeon E5-1620 v4 @ 3.50GHz",
+        "Benchmark": "7,368"
+    },
+    {
+        "CPU": "Intel Xeon E5-1630 v3 @ 3.70GHz",
+        "Benchmark": "7,41"
+    },
+    {
+        "CPU": "Intel Xeon E5-1630 v4 @ 3.70GHz",
+        "Benchmark": "7,559"
+    },
+    {
+        "CPU": "Intel Xeon E5-1650 @ 3.20GHz",
+        "Benchmark": "8,089"
+    },
+    {
+        "CPU": "Intel Xeon E5-1650 v2 @ 3.50GHz",
+        "Benchmark": "9,328"
+    },
+    {
+        "CPU": "Intel Xeon E5-1650 v3 @ 3.50GHz",
+        "Benchmark": "10,394"
+    },
+    {
+        "CPU": "Intel Xeon E5-1650 v4 @ 3.60GHz",
+        "Benchmark": "11,401"
+    },
+    {
+        "CPU": "Intel Xeon E5-1660 @ 3.30GHz",
+        "Benchmark": "8,369"
+    },
+    {
+        "CPU": "Intel Xeon E5-1660 v2 @ 3.70GHz",
+        "Benchmark": "10,302"
+    },
+    {
+        "CPU": "Intel Xeon E5-1660 v3 @ 3.00GHz",
+        "Benchmark": "12,519"
+    },
+    {
+        "CPU": "Intel Xeon E5-1660 v4 @ 3.20GHz",
+        "Benchmark": "13,501"
+    },
+    {
+        "CPU": "Intel Xeon E5-1680 v2 @ 3.00GHz",
+        "Benchmark": "12,544"
+    },
+    {
+        "CPU": "Intel Xeon E5-1680 v3 @ 3.20GHz",
+        "Benchmark": "13,124"
+    },
+    {
+        "CPU": "Intel Xeon E5-1680 v4 @ 3.40GHz",
+        "Benchmark": "14,255"
+    },
+    {
+        "CPU": "Intel Xeon E5-1681 v3 @ 2.90GHz",
+        "Benchmark": "14,82"
+    },
+    {
+        "CPU": "Intel Xeon E5-2403 @ 1.80GHz",
+        "Benchmark": "2,367"
+    },
+    {
+        "CPU": "Intel Xeon E5-2403 v2 @ 1.80GHz",
+        "Benchmark": "2,672"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2403 v2 @ 1.80GHz",
+        "Benchmark": "4,81"
+    },
+    {
+        "CPU": "Intel Xeon E5-2407 @ 2.20GHz",
+        "Benchmark": "2,675"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2407 @ 2.20GHz",
+        "Benchmark": "5,362"
+    },
+    {
+        "CPU": "Intel Xeon E5-2407 v2 @ 2.40GHz",
+        "Benchmark": "3,287"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2407 v2 @ 2.40GHz",
+        "Benchmark": "6,569"
+    },
+    {
+        "CPU": "Intel Xeon E5-2418L @ 2.00GHz",
+        "Benchmark": "3,518"
+    },
+    {
+        "CPU": "Intel Xeon E5-2418L v2 @ 2.00GHz",
+        "Benchmark": "5,38"
+    },
+    {
+        "CPU": "Intel Xeon E5-2420 @ 1.90GHz",
+        "Benchmark": "5,009"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2420 @ 1.90GHz",
+        "Benchmark": "9,295"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-2420 @ 1.90GHz",
+        "Benchmark": "3,065"
+    },
+    {
+        "CPU": "Intel Xeon E5-2420 v2 @ 2.20GHz",
+        "Benchmark": "6,371"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2420 v2 @ 2.20GHz",
+        "Benchmark": "11,745"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2428L @ 1.80GHz",
+        "Benchmark": "8,5"
+    },
+    {
+        "CPU": "Intel Xeon E5-2430 @ 2.20GHz",
+        "Benchmark": "5,702"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2430 @ 2.20GHz",
+        "Benchmark": "9,513"
+    },
+    {
+        "CPU": "Intel Xeon E5-2430 v2 @ 2.50GHz",
+        "Benchmark": "7,179"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2430 v2 @ 2.50GHz",
+        "Benchmark": "12,267"
+    },
+    {
+        "CPU": "Intel Xeon E5-2430L @ 2.00GHz",
+        "Benchmark": "5,3"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2430L @ 2.00GHz",
+        "Benchmark": "9,752"
+    },
+    {
+        "CPU": "Intel Xeon E5-2430L v2 @ 2.40GHz",
+        "Benchmark": "6,19"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2430L v2 @ 2.40GHz",
+        "Benchmark": "12,183"
+    },
+    {
+        "CPU": "Intel Xeon E5-2440 @ 2.40GHz",
+        "Benchmark": "6,091"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2440 @ 2.40GHz",
+        "Benchmark": "10,517"
+    },
+    {
+        "CPU": "Intel Xeon E5-2440 v2 @ 1.90GHz",
+        "Benchmark": "7,473"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2440 v2 @ 1.90GHz",
+        "Benchmark": "13,818"
+    },
+    {
+        "CPU": "Intel Xeon E5-2448L v2 @ 1.80GHz",
+        "Benchmark": "6,774"
+    },
+    {
+        "CPU": "Intel Xeon E5-2450 @ 2.10GHz",
+        "Benchmark": "7,534"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2450 @ 2.10GHz",
+        "Benchmark": "10,978"
+    },
+    {
+        "CPU": "Intel Xeon E5-2450 v2 @ 2.50GHz",
+        "Benchmark": "8,967"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2450 v2 @ 2.50GHz",
+        "Benchmark": "16,584"
+    },
+    {
+        "CPU": "Intel Xeon E5-2450L @ 1.80GHz",
+        "Benchmark": "5,88"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2450L @ 1.80GHz",
+        "Benchmark": "11,631"
+    },
+    {
+        "CPU": "Intel Xeon E5-2470 @ 2.30GHz",
+        "Benchmark": "8,3"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2470 @ 2.30GHz",
+        "Benchmark": "14,464"
+    },
+    {
+        "CPU": "Intel Xeon E5-2470 v2 @ 2.40GHz",
+        "Benchmark": "10,664"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2470 v2 @ 2.40GHz",
+        "Benchmark": "18,719"
+    },
+    {
+        "CPU": "Intel Xeon E5-2603 @ 1.80GHz",
+        "Benchmark": "2,319"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2603 @ 1.80GHz",
+        "Benchmark": "4,353"
+    },
+    {
+        "CPU": "Intel Xeon E5-2603 v2 @ 1.80GHz",
+        "Benchmark": "2,735"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2603 v2 @ 1.80GHz",
+        "Benchmark": "5,017"
+    },
+    {
+        "CPU": "Intel Xeon E5-2603 v3 @ 1.60GHz",
+        "Benchmark": "3,831"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2603 v3 @ 1.60GHz",
+        "Benchmark": "6,851"
+    },
+    {
+        "CPU": "Intel Xeon E5-2603 v4 @ 1.70GHz",
+        "Benchmark": "4,695"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2603 v4 @ 1.70GHz",
+        "Benchmark": "7,994"
+    },
+    {
+        "CPU": "Intel Xeon E5-2608L v3 @ 2.00GHz",
+        "Benchmark": "6,415"
+    },
+    {
+        "CPU": "Intel Xeon E5-2608L v4 @ 1.60GHz",
+        "Benchmark": "7,447"
+    },
+    {
+        "CPU": "Intel Xeon E5-2609 @ 2.40GHz",
+        "Benchmark": "2,908"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2609 @ 2.40GHz",
+        "Benchmark": "5,892"
+    },
+    {
+        "CPU": "Intel Xeon E5-2609 v2 @ 2.50GHz",
+        "Benchmark": "3,369"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2609 v2 @ 2.50GHz",
+        "Benchmark": "6,832"
+    },
+    {
+        "CPU": "Intel Xeon E5-2609 v3 @ 1.90GHz",
+        "Benchmark": "4,448"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2609 v3 @ 1.90GHz",
+        "Benchmark": "8,611"
+    },
+    {
+        "CPU": "Intel Xeon E5-2609 v4 @ 1.70GHz",
+        "Benchmark": "5,418"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2609 v4 @ 1.70GHz",
+        "Benchmark": "10,198"
+    },
+    {
+        "CPU": "Intel Xeon E5-2618L v3 @ 2.30GHz",
+        "Benchmark": "11,181"
+    },
+    {
+        "CPU": "Intel Xeon E5-2618L v4 @ 2.20GHz",
+        "Benchmark": "12,429"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2618L v4 @ 2.20GHz",
+        "Benchmark": "22,319"
+    },
+    {
+        "CPU": "Intel Xeon E5-2620 @ 2.00GHz",
+        "Benchmark": "5,305"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2620 @ 2.00GHz",
+        "Benchmark": "9,792"
+    },
+    {
+        "CPU": "Intel Xeon E5-2620 v2 @ 2.10GHz",
+        "Benchmark": "6,245"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2620 v2 @ 2.10GHz",
+        "Benchmark": "10,921"
+    },
+    {
+        "CPU": "Intel Xeon E5-2620 v3 @ 2.40GHz",
+        "Benchmark": "7,782"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2620 v3 @ 2.40GHz",
+        "Benchmark": "13,157"
+    },
+    {
+        "CPU": "Intel Xeon E5-2620 v4 @ 2.10GHz",
+        "Benchmark": "9,283"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2620 v4 @ 2.10GHz",
+        "Benchmark": "15,897"
+    },
+    {
+        "CPU": "Intel Xeon E5-2623 v3 @ 3.00GHz",
+        "Benchmark": "6,701"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2623 v3 @ 3.00GHz",
+        "Benchmark": "11,633"
+    },
+    {
+        "CPU": "Intel Xeon E5-2623 v4 @ 2.60GHz",
+        "Benchmark": "6,94"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2623 v4 @ 2.60GHz",
+        "Benchmark": "8,753"
+    },
+    {
+        "CPU": "Intel Xeon E5-2628 v3 @ 2.50GHz",
+        "Benchmark": "8,447"
+    },
+    {
+        "CPU": "Intel Xeon E5-2628L v2 @ 1.90GHz",
+        "Benchmark": "7,181"
+    },
+    {
+        "CPU": "Intel Xeon E5-2628L v3 @ 2.00GHz",
+        "Benchmark": "9,949"
+    },
+    {
+        "CPU": "Intel Xeon E5-2628L v4 @ 1.90GHz",
+        "Benchmark": "11,079"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2628L v4 @ 1.90GHz",
+        "Benchmark": "18,895"
+    },
+    {
+        "CPU": "Intel Xeon E5-2629 v3 @ 2.40GHz",
+        "Benchmark": "9,139"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630 @ 2.30GHz",
+        "Benchmark": "6,073"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630 @ 2.30GHz",
+        "Benchmark": "10,358"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630 v2 @ 2.60GHz",
+        "Benchmark": "7,458"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630 v2 @ 2.60GHz",
+        "Benchmark": "13,606"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630 v3 @ 2.40GHz",
+        "Benchmark": "10,309"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630 v3 @ 2.40GHz",
+        "Benchmark": "17,037"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630 v4 @ 2.20GHz",
+        "Benchmark": "11,506"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630 v4 @ 2.20GHz",
+        "Benchmark": "19,203"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630L @ 2.00GHz",
+        "Benchmark": "5,305"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630L @ 2.00GHz",
+        "Benchmark": "8,76"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630L v2 @ 2.40GHz",
+        "Benchmark": "6,64"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630L v2 @ 2.40GHz",
+        "Benchmark": "12,523"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630L v3 @ 1.80GHz",
+        "Benchmark": "8,661"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630L v3 @ 1.80GHz",
+        "Benchmark": "14,654"
+    },
+    {
+        "CPU": "Intel Xeon E5-2630L v4 @ 1.80GHz",
+        "Benchmark": "9,972"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2630L v4 @ 1.80GHz",
+        "Benchmark": "16,008"
+    },
+    {
+        "CPU": "Intel Xeon E5-2637 @ 3.00GHz",
+        "Benchmark": "2,978"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2637 @ 3.00GHz",
+        "Benchmark": "5,775"
+    },
+    {
+        "CPU": "Intel Xeon E5-2637 v2 @ 3.50GHz",
+        "Benchmark": "6,47"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2637 v2 @ 3.50GHz",
+        "Benchmark": "12,137"
+    },
+    {
+        "CPU": "Intel Xeon E5-2637 v3 @ 3.50GHz",
+        "Benchmark": "7,281"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2637 v3 @ 3.50GHz",
+        "Benchmark": "13,152"
+    },
+    {
+        "CPU": "Intel Xeon E5-2637 v4 @ 3.50GHz",
+        "Benchmark": "7,494"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2637 v4 @ 3.50GHz",
+        "Benchmark": "14,029"
+    },
+    {
+        "CPU": "Intel Xeon E5-2640 @ 2.50GHz",
+        "Benchmark": "6,286"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2640 @ 2.50GHz",
+        "Benchmark": "11,654"
+    },
+    {
+        "CPU": "Intel Xeon E5-2640 v2 @ 2.00GHz",
+        "Benchmark": "7,601"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2640 v2 @ 2.00GHz",
+        "Benchmark": "13,666"
+    },
+    {
+        "CPU": "Intel Xeon E5-2640 v3 @ 2.60GHz",
+        "Benchmark": "11,059"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2640 v3 @ 2.60GHz",
+        "Benchmark": "17,416"
+    },
+    {
+        "CPU": "Intel Xeon E5-2640 v4 @ 2.40GHz",
+        "Benchmark": "12,49"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2640 v4 @ 2.40GHz",
+        "Benchmark": "20,811"
+    },
+    {
+        "CPU": "Intel Xeon E5-2643 @ 3.30GHz",
+        "Benchmark": "5,21"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2643 @ 3.30GHz",
+        "Benchmark": "9,863"
+    },
+    {
+        "CPU": "Intel Xeon E5-2643 v2 @ 3.50GHz",
+        "Benchmark": "9,198"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2643 v2 @ 3.50GHz",
+        "Benchmark": "17,211"
+    },
+    {
+        "CPU": "Intel Xeon E5-2643 v3 @ 3.40GHz",
+        "Benchmark": "10,432"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2643 v3 @ 3.40GHz",
+        "Benchmark": "18,01"
+    },
+    {
+        "CPU": "Intel Xeon E5-2643 v4 @ 3.40GHz",
+        "Benchmark": "11,105"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2643 v4 @ 3.40GHz",
+        "Benchmark": "20,119"
+    },
+    {
+        "CPU": "Intel Xeon E5-2648L @ 1.80GHz",
+        "Benchmark": "5,262"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2648L @ 1.80GHz",
+        "Benchmark": "9,94"
+    },
+    {
+        "CPU": "Intel Xeon E5-2648L v2 @ 1.90GHz",
+        "Benchmark": "8,828"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2648L v2 @ 1.90GHz",
+        "Benchmark": "16,028"
+    },
+    {
+        "CPU": "Intel Xeon E5-2648L v3 @ 1.80GHz",
+        "Benchmark": "9,847"
+    },
+    {
+        "CPU": "Intel Xeon E5-2648L v4 @ 1.80GHz",
+        "Benchmark": "11,839"
+    },
+    {
+        "CPU": "Intel Xeon E5-2649 v3 @ 2.30GHz",
+        "Benchmark": "12,399"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650 @ 2.00GHz",
+        "Benchmark": "7,373"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650 @ 2.00GHz",
+        "Benchmark": "12,877"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650 v2 @ 2.60GHz",
+        "Benchmark": "9,846"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650 v2 @ 2.60GHz",
+        "Benchmark": "17,37"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650 v3 @ 2.30GHz",
+        "Benchmark": "11,75"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650 v3 @ 2.30GHz",
+        "Benchmark": "19,866"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650 v4 @ 2.20GHz",
+        "Benchmark": "13,345"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650 v4 @ 2.20GHz",
+        "Benchmark": "22,925"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650L @ 1.80GHz",
+        "Benchmark": "6,192"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650L @ 1.80GHz",
+        "Benchmark": "11,364"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650L v2 @ 1.70GHz",
+        "Benchmark": "7,586"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650L v2 @ 1.70GHz",
+        "Benchmark": "14,039"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650L v3 @ 1.80GHz",
+        "Benchmark": "11,865"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650L v3 @ 1.80GHz",
+        "Benchmark": "19,882"
+    },
+    {
+        "CPU": "Intel Xeon E5-2650L v4 @ 1.70GHz",
+        "Benchmark": "12,719"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2650L v4 @ 1.70GHz",
+        "Benchmark": "25,017"
+    },
+    {
+        "CPU": "Intel Xeon E5-2651 v2 @ 1.80GHz",
+        "Benchmark": "9,551"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2651 v2 @ 1.80GHz",
+        "Benchmark": "16,114"
+    },
+    {
+        "CPU": "Intel Xeon E5-2658 @ 2.10GHz",
+        "Benchmark": "6,073"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2658 @ 2.10GHz",
+        "Benchmark": "10,053"
+    },
+    {
+        "CPU": "Intel Xeon E5-2658 v2 @ 2.40GHz",
+        "Benchmark": "10,528"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2658 v2 @ 2.40GHz",
+        "Benchmark": "18,616"
+    },
+    {
+        "CPU": "Intel Xeon E5-2658 v3 @ 2.20GHz",
+        "Benchmark": "13,487"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2658 v3 @ 2.20GHz",
+        "Benchmark": "21,856"
+    },
+    {
+        "CPU": "Intel Xeon E5-2658 v4 @ 2.30GHz",
+        "Benchmark": "14,434"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2658 v4 @ 2.30GHz",
+        "Benchmark": "27,797"
+    },
+    {
+        "CPU": "Intel Xeon E5-2658A v3 @ 2.20GHz",
+        "Benchmark": "14,879"
+    },
+    {
+        "CPU": "Intel Xeon E5-2660 @ 2.20GHz",
+        "Benchmark": "8,096"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2660 @ 2.20GHz",
+        "Benchmark": "14,084"
+    },
+    {
+        "CPU": "Intel Xeon E5-2660 v2 @ 2.20GHz",
+        "Benchmark": "10,383"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2660 v2 @ 2.20GHz",
+        "Benchmark": "18,286"
+    },
+    {
+        "CPU": "Intel Xeon E5-2660 v3 @ 2.60GHz",
+        "Benchmark": "13,06"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2660 v3 @ 2.60GHz",
+        "Benchmark": "21,952"
+    },
+    {
+        "CPU": "Intel Xeon E5-2660 v4 @ 2.00GHz",
+        "Benchmark": "15,705"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2660 v4 @ 2.00GHz",
+        "Benchmark": "26,192"
+    },
+    {
+        "CPU": "Intel Xeon E5-2663 v3 @ 2.80GHz",
+        "Benchmark": "11,777"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2663 v3 @ 2.80GHz",
+        "Benchmark": "21,671"
+    },
+    {
+        "CPU": "Intel Xeon E5-2665 @ 2.40GHz",
+        "Benchmark": "8,258"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2665 @ 2.40GHz",
+        "Benchmark": "14,048"
+    },
+    {
+        "CPU": "Intel Xeon E5-2666 v3 @ 2.90GHz",
+        "Benchmark": "14,07"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2666 v3 @ 2.90GHz",
+        "Benchmark": "23,783"
+    },
+    {
+        "CPU": "Intel Xeon E5-2666 v4 @ 2.80GHz",
+        "Benchmark": "17,958"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2666 v4 @ 2.80GHz",
+        "Benchmark": "20,424"
+    },
+    {
+        "CPU": "Intel Xeon E5-2667 @ 2.90GHz",
+        "Benchmark": "7,442"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2667 @ 2.90GHz",
+        "Benchmark": "12,845"
+    },
+    {
+        "CPU": "Intel Xeon E5-2667 v2 @ 3.30GHz",
+        "Benchmark": "12,287"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2667 v2 @ 3.30GHz",
+        "Benchmark": "21,26"
+    },
+    {
+        "CPU": "Intel Xeon E5-2667 v3 @ 3.20GHz",
+        "Benchmark": "12,521"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2667 v3 @ 3.20GHz",
+        "Benchmark": "21,169"
+    },
+    {
+        "CPU": "Intel Xeon E5-2667 v4 @ 3.20GHz",
+        "Benchmark": "13,785"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2667 v4 @ 3.20GHz",
+        "Benchmark": "24,152"
+    },
+    {
+        "CPU": "Intel Xeon E5-2669 v3 @ 2.30GHz",
+        "Benchmark": "16,107"
+    },
+    {
+        "CPU": "Intel Xeon E5-2670 @ 2.60GHz",
+        "Benchmark": "8,984"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2670 @ 2.60GHz",
+        "Benchmark": "15,492"
+    },
+    {
+        "CPU": "Intel Xeon E5-2670 v2 @ 2.50GHz",
+        "Benchmark": "11,387"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2670 v2 @ 2.50GHz",
+        "Benchmark": "18,829"
+    },
+    {
+        "CPU": "Intel Xeon E5-2670 v3 @ 2.30GHz",
+        "Benchmark": "13,507"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2670 v3 @ 2.30GHz",
+        "Benchmark": "22,051"
+    },
+    {
+        "CPU": "Intel Xeon E5-2673 v2 @ 3.30GHz",
+        "Benchmark": "12,297"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2673 v2 @ 3.30GHz",
+        "Benchmark": "22,038"
+    },
+    {
+        "CPU": "Intel Xeon E5-2673 v3 @ 2.40GHz",
+        "Benchmark": "14,218"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2673 v3 @ 2.40GHz",
+        "Benchmark": "22,492"
+    },
+    {
+        "CPU": "Intel Xeon E5-2673 v4 @ 2.30GHz",
+        "Benchmark": "21,009"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2673 v4 @ 2.30GHz",
+        "Benchmark": "35,612"
+    },
+    {
+        "CPU": "Intel Xeon E5-2675 v3 @ 1.80GHz",
+        "Benchmark": "13,18"
+    },
+    {
+        "CPU": "Intel Xeon E5-2676 v3 @ 2.40GHz",
+        "Benchmark": "13,4"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2676 v3 @ 2.40GHz",
+        "Benchmark": "21,594"
+    },
+    {
+        "CPU": "Intel Xeon E5-2676 v4 @ 2.40GHz",
+        "Benchmark": "18,978"
+    },
+    {
+        "CPU": "Intel Xeon E5-2678 v3 @ 2.50GHz",
+        "Benchmark": "14,704"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2678 v3 @ 2.50GHz",
+        "Benchmark": "23,869"
+    },
+    {
+        "CPU": "Intel Xeon E5-2679 v4 @ 2.50GHz",
+        "Benchmark": "24,131"
+    },
+    {
+        "CPU": "Intel Xeon E5-2680 @ 2.70GHz",
+        "Benchmark": "9,358"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2680 @ 2.70GHz",
+        "Benchmark": "15,775"
+    },
+    {
+        "CPU": "Intel Xeon E5-2680 v2 @ 2.80GHz",
+        "Benchmark": "12,69"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2680 v2 @ 2.80GHz",
+        "Benchmark": "21,259"
+    },
+    {
+        "CPU": "Intel Xeon E5-2680 v3 @ 2.50GHz",
+        "Benchmark": "14,916"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2680 v3 @ 2.50GHz",
+        "Benchmark": "24,322"
+    },
+    {
+        "CPU": "Intel Xeon E5-2680 v4 @ 2.40GHz",
+        "Benchmark": "17,425"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2680 v4 @ 2.40GHz",
+        "Benchmark": "27,924"
+    },
+    {
+        "CPU": "Intel Xeon E5-2680R v4 @ 2.40GHz",
+        "Benchmark": "17,487"
+    },
+    {
+        "CPU": "Intel Xeon E5-2682 v4 @ 2.50GHz",
+        "Benchmark": "18,795"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2682 v4 @ 2.50GHz",
+        "Benchmark": "27,949"
+    },
+    {
+        "CPU": "Intel Xeon E5-2683 v3 @ 2.00GHz",
+        "Benchmark": "14,802"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2683 v3 @ 2.00GHz",
+        "Benchmark": "23,718"
+    },
+    {
+        "CPU": "Intel Xeon E5-2683 v4 @ 2.10GHz",
+        "Benchmark": "17,507"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2683 v4 @ 2.10GHz",
+        "Benchmark": "28,156"
+    },
+    {
+        "CPU": "Intel Xeon E5-2685 v3 @ 2.60GHz",
+        "Benchmark": "12,944"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2685 v3 @ 2.60GHz",
+        "Benchmark": "20,233"
+    },
+    {
+        "CPU": "Intel Xeon E5-2686 v3 @ 2.00GHz",
+        "Benchmark": "18,148"
+    },
+    {
+        "CPU": "Intel Xeon E5-2686 v4 @ 2.30GHz",
+        "Benchmark": "19,871"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2686 v4 @ 2.30GHz",
+        "Benchmark": "33,236"
+    },
+    {
+        "CPU": "Intel Xeon E5-2687W @ 3.10GHz",
+        "Benchmark": "10,006"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2687W @ 3.10GHz",
+        "Benchmark": "17,673"
+    },
+    {
+        "CPU": "Intel Xeon E5-2687W v2 @ 3.40GHz",
+        "Benchmark": "12,249"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2687W v2 @ 3.40GHz",
+        "Benchmark": "20,693"
+    },
+    {
+        "CPU": "Intel Xeon E5-2687W v3 @ 3.10GHz",
+        "Benchmark": "14,708"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2687W v3 @ 3.10GHz",
+        "Benchmark": "23,626"
+    },
+    {
+        "CPU": "Intel Xeon E5-2687W v4 @ 3.00GHz",
+        "Benchmark": "17,721"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2687W v4 @ 3.00GHz",
+        "Benchmark": "28,386"
+    },
+    {
+        "CPU": "Intel Xeon E5-2689 @ 2.60GHz",
+        "Benchmark": "9,55"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2689 @ 2.60GHz",
+        "Benchmark": "15,805"
+    },
+    {
+        "CPU": "Intel Xeon E5-2689 v4 @ 3.10GHz",
+        "Benchmark": "17,084"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2689 v4 @ 3.10GHz",
+        "Benchmark": "28,856"
+    },
+    {
+        "CPU": "Intel Xeon E5-2690 @ 2.90GHz",
+        "Benchmark": "9,761"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2690 @ 2.90GHz",
+        "Benchmark": "16,582"
+    },
+    {
+        "CPU": "Intel Xeon E5-2690 v2 @ 3.00GHz",
+        "Benchmark": "13,41"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2690 v2 @ 3.00GHz",
+        "Benchmark": "22,473"
+    },
+    {
+        "CPU": "Intel Xeon E5-2690 v3 @ 2.60GHz",
+        "Benchmark": "16,05"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2690 v3 @ 2.60GHz",
+        "Benchmark": "26,34"
+    },
+    {
+        "CPU": "Intel Xeon E5-2690 v4 @ 2.60GHz",
+        "Benchmark": "19,325"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2690 v4 @ 2.60GHz",
+        "Benchmark": "31,091"
+    },
+    {
+        "CPU": "Intel Xeon E5-2692 v2 @ 2.20GHz",
+        "Benchmark": "12,119"
+    },
+    {
+        "CPU": "Intel Xeon E5-2695 v2 @ 2.40GHz",
+        "Benchmark": "13,325"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2695 v2 @ 2.40GHz",
+        "Benchmark": "21,605"
+    },
+    {
+        "CPU": "Intel Xeon E5-2695 v3 @ 2.30GHz",
+        "Benchmark": "16,713"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2695 v3 @ 2.30GHz",
+        "Benchmark": "26,987"
+    },
+    {
+        "CPU": "Intel Xeon E5-2695 v4 @ 2.10GHz",
+        "Benchmark": "18,923"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2695 v4 @ 2.10GHz",
+        "Benchmark": "34,924"
+    },
+    {
+        "CPU": "Intel Xeon E5-2696 v2 @ 2.50GHz",
+        "Benchmark": "14,062"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2696 v2 @ 2.50GHz",
+        "Benchmark": "22,159"
+    },
+    {
+        "CPU": "Intel Xeon E5-2696 v3 @ 2.30GHz",
+        "Benchmark": "21,545"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2696 v3 @ 2.30GHz",
+        "Benchmark": "32,438"
+    },
+    {
+        "CPU": "Intel Xeon E5-2696 v4 @ 2.20GHz",
+        "Benchmark": "24,917"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2696 v4 @ 2.20GHz",
+        "Benchmark": "40,732"
+    },
+    {
+        "CPU": "Intel Xeon E5-2697 v2 @ 2.70GHz",
+        "Benchmark": "14,284"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2697 v2 @ 2.70GHz",
+        "Benchmark": "22,822"
+    },
+    {
+        "CPU": "Intel Xeon E5-2697 v3 @ 2.60GHz",
+        "Benchmark": "18,279"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2697 v3 @ 2.60GHz",
+        "Benchmark": "26,687"
+    },
+    {
+        "CPU": "Intel Xeon E5-2697 v4 @ 2.30GHz",
+        "Benchmark": "20,959"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2697 v4 @ 2.30GHz",
+        "Benchmark": "37,523"
+    },
+    {
+        "CPU": "Intel Xeon E5-2697A v4 @ 2.60GHz",
+        "Benchmark": "21,611"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2697A v4 @ 2.60GHz",
+        "Benchmark": "33,198"
+    },
+    {
+        "CPU": "Intel Xeon E5-2697R v4 @ 2.30GHz",
+        "Benchmark": "20,843"
+    },
+    {
+        "CPU": "Intel Xeon E5-2698 v3 @ 2.30GHz",
+        "Benchmark": "18,892"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2698 v3 @ 2.30GHz",
+        "Benchmark": "30,25"
+    },
+    {
+        "CPU": "Intel Xeon E5-2698 v4 @ 2.20GHz",
+        "Benchmark": "22,534"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2698 v4 @ 2.20GHz",
+        "Benchmark": "39,063"
+    },
+    {
+        "CPU": "Intel Xeon E5-2698B v3 @ 2.00GHz",
+        "Benchmark": "16,287"
+    },
+    {
+        "CPU": "Intel Xeon E5-2698R v4 @ 2.20GHz",
+        "Benchmark": "25,605"
+    },
+    {
+        "CPU": "Intel Xeon E5-2699 v3 @ 2.30GHz",
+        "Benchmark": "20,014"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2699 v3 @ 2.30GHz",
+        "Benchmark": "33,238"
+    },
+    {
+        "CPU": "Intel Xeon E5-2699 v4 @ 2.20GHz",
+        "Benchmark": "25,105"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2699 v4 @ 2.20GHz",
+        "Benchmark": "43,346"
+    },
+    {
+        "CPU": "Intel Xeon E5-2699A v4 @ 2.40GHz",
+        "Benchmark": "26,812"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2699A v4 @ 2.40GHz",
+        "Benchmark": "44,951"
+    },
+    {
+        "CPU": "Intel Xeon E5-2699C v4 @ 2.20GHz",
+        "Benchmark": "21,275"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-2699C v4 @ 2.20GHz",
+        "Benchmark": "33,981"
+    },
+    {
+        "CPU": "Intel Xeon E5-4603 @ 2.00GHz",
+        "Benchmark": "3,391"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4603 @ 2.00GHz",
+        "Benchmark": "6,69"
+    },
+    {
+        "CPU": "Intel Xeon E5-4607 v2 @ 2.60GHz",
+        "Benchmark": "6,986"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4607 v2 @ 2.60GHz",
+        "Benchmark": "7,557"
+    },
+    {
+        "CPU": "Intel Xeon E5-4610 @ 2.40GHz",
+        "Benchmark": "6,46"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4610 @ 2.40GHz",
+        "Benchmark": "23,354"
+    },
+    {
+        "CPU": "Intel Xeon E5-4610 v3 @ 1.70GHz",
+        "Benchmark": "7,229"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4610 v4 @ 1.80GHz",
+        "Benchmark": "15,084"
+    },
+    {
+        "CPU": "Intel Xeon E5-4617 @ 2.90GHz",
+        "Benchmark": "6,298"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4617 @ 2.90GHz",
+        "Benchmark": "16,902"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4617 @ 2.90GHz",
+        "Benchmark": "11,387"
+    },
+    {
+        "CPU": "Intel Xeon E5-4620 @ 2.20GHz",
+        "Benchmark": "6,872"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4620 @ 2.20GHz",
+        "Benchmark": "20,959"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4620 @ 2.20GHz",
+        "Benchmark": "11,474"
+    },
+    {
+        "CPU": "Intel Xeon E5-4620 v2 @ 2.60GHz",
+        "Benchmark": "9,424"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4620 v2 @ 2.60GHz",
+        "Benchmark": "17,849"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4620 v2 @ 2.60GHz",
+        "Benchmark": "16,97"
+    },
+    {
+        "CPU": "Intel Xeon E5-4620 v3 @ 2.00GHz",
+        "Benchmark": "10,525"
+    },
+    {
+        "CPU": "Intel Xeon E5-4627 v2 @ 3.30GHz",
+        "Benchmark": "9,425"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4627 v2 @ 3.30GHz",
+        "Benchmark": "32,453"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4627 v2 @ 3.30GHz",
+        "Benchmark": "15,898"
+    },
+    {
+        "CPU": "Intel Xeon E5-4627 v3 @ 2.60GHz",
+        "Benchmark": "11,344"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4627 v3 @ 2.60GHz",
+        "Benchmark": "20,294"
+    },
+    {
+        "CPU": "Intel Xeon E5-4627 v4 @ 2.60GHz",
+        "Benchmark": "12,969"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4627 v4 @ 2.60GHz",
+        "Benchmark": "38,201"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4627 v4 @ 2.60GHz",
+        "Benchmark": "22,336"
+    },
+    {
+        "CPU": "Intel Xeon E5-4628L v4 @ 1.80GHz",
+        "Benchmark": "11,503"
+    },
+    {
+        "CPU": "Intel Xeon E5-4640 @ 2.40GHz",
+        "Benchmark": "7,012"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4640 @ 2.40GHz",
+        "Benchmark": "21,374"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4640 v2 @ 2.20GHz",
+        "Benchmark": "19,028"
+    },
+    {
+        "CPU": "Intel Xeon E5-4640 v3 @ 1.90GHz",
+        "Benchmark": "10,372"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4640 v4 @ 2.10GHz",
+        "Benchmark": "22,559"
+    },
+    {
+        "CPU": "Intel Xeon E5-4648 v3 @ 1.70GHz",
+        "Benchmark": "9,061"
+    },
+    {
+        "CPU": "Intel Xeon E5-4650 @ 2.70GHz",
+        "Benchmark": "8,407"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4650 @ 2.70GHz",
+        "Benchmark": "27,008"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4650 @ 2.70GHz",
+        "Benchmark": "13,713"
+    },
+    {
+        "CPU": "Intel Xeon E5-4650 v2 @ 2.40GHz",
+        "Benchmark": "10,818"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4650 v2 @ 2.40GHz",
+        "Benchmark": "31,723"
+    },
+    {
+        "CPU": "Intel Xeon E5-4650 v3 @ 2.10GHz",
+        "Benchmark": "10,838"
+    },
+    {
+        "CPU": "Intel Xeon E5-4650 v4 @ 2.20GHz",
+        "Benchmark": "16,225"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4650 v4 @ 2.20GHz",
+        "Benchmark": "41,126"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4650 v4 @ 2.20GHz",
+        "Benchmark": "25,851"
+    },
+    {
+        "CPU": "Intel Xeon E5-4650L @ 2.60GHz",
+        "Benchmark": "8,533"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4650L @ 2.60GHz",
+        "Benchmark": "28,193"
+    },
+    {
+        "CPU": "Intel Xeon E5-4655 v3 @ 2.90GHz",
+        "Benchmark": "9,377"
+    },
+    {
+        "CPU": "Intel Xeon E5-4655 v4 @ 2.50GHz",
+        "Benchmark": "10,912"
+    },
+    {
+        "CPU": "Intel Xeon E5-4657L v2 @ 2.40GHz",
+        "Benchmark": "11,613"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4657L v2 @ 2.40GHz",
+        "Benchmark": "37,02"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4657L v2 @ 2.40GHz",
+        "Benchmark": "21,548"
+    },
+    {
+        "CPU": "Intel Xeon E5-4660 v3 @ 2.10GHz",
+        "Benchmark": "14,256"
+    },
+    {
+        "CPU": "Intel Xeon E5-4660 v4 @ 2.20GHz",
+        "Benchmark": "15,375"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4660 v4 @ 2.20GHz",
+        "Benchmark": "54,621"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4660 v4 @ 2.20GHz",
+        "Benchmark": "24,421"
+    },
+    {
+        "CPU": "Intel Xeon E5-4667 v3 @ 2.00GHz",
+        "Benchmark": "15,397"
+    },
+    {
+        "CPU": "Intel Xeon E5-4667 v4 @ 2.20GHz",
+        "Benchmark": "20,319"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4667 v4 @ 2.20GHz",
+        "Benchmark": "53,402"
+    },
+    {
+        "CPU": "Intel Xeon E5-4669 v3 @ 2.10GHz",
+        "Benchmark": "17,43"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4669 v3 @ 2.10GHz",
+        "Benchmark": "41,232"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4669 v3 @ 2.10GHz",
+        "Benchmark": "31,494"
+    },
+    {
+        "CPU": "Intel Xeon E5-4669 v4 @ 2.20GHz",
+        "Benchmark": "11,523"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E5-4669 v4 @ 2.20GHz",
+        "Benchmark": "63,658"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5-4669 v4 @ 2.20GHz",
+        "Benchmark": "39,177"
+    },
+    {
+        "CPU": "Intel Xeon E5205 @ 1.86GHz",
+        "Benchmark": "838"
+    },
+    {
+        "CPU": "Intel Xeon E5240 @ 3.00GHz",
+        "Benchmark": "1,448"
+    },
+    {
+        "CPU": "Intel Xeon E5310 @ 1.60GHz",
+        "Benchmark": "1,306"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5310 @ 1.60GHz",
+        "Benchmark": "2,629"
+    },
+    {
+        "CPU": "Intel Xeon E5320 @ 1.86GHz",
+        "Benchmark": "1,469"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5320 @ 1.86GHz",
+        "Benchmark": "2,911"
+    },
+    {
+        "CPU": "Intel Xeon E5335 @ 2.00GHz",
+        "Benchmark": "1,549"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5335 @ 2.00GHz",
+        "Benchmark": "3,15"
+    },
+    {
+        "CPU": "Intel Xeon E5345 @ 2.33GHz",
+        "Benchmark": "1,868"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5345 @ 2.33GHz",
+        "Benchmark": "3,458"
+    },
+    {
+        "CPU": "Intel Xeon E5405 @ 2.00GHz",
+        "Benchmark": "1,75"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5405 @ 2.00GHz",
+        "Benchmark": "3,402"
+    },
+    {
+        "CPU": "Intel Xeon E5410 @ 2.33GHz",
+        "Benchmark": "2,032"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5410 @ 2.33GHz",
+        "Benchmark": "3,829"
+    },
+    {
+        "CPU": "Intel Xeon E5420 @ 2.50GHz",
+        "Benchmark": "2,022"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5420 @ 2.50GHz",
+        "Benchmark": "4,085"
+    },
+    {
+        "CPU": "Intel Xeon E5430 @ 2.66GHz",
+        "Benchmark": "2,251"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5430 @ 2.66GHz",
+        "Benchmark": "4,294"
+    },
+    {
+        "CPU": "Intel Xeon E5440 @ 2.83GHz",
+        "Benchmark": "2,385"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5440 @ 2.83GHz",
+        "Benchmark": "4,44"
+    },
+    {
+        "CPU": "Intel Xeon E5450 @ 3.00GHz",
+        "Benchmark": "2,571"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5450 @ 3.00GHz",
+        "Benchmark": "4,736"
+    },
+    {
+        "CPU": "Intel Xeon E5462 @ 2.80GHz",
+        "Benchmark": "2,231"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5462 @ 2.80GHz",
+        "Benchmark": "4,563"
+    },
+    {
+        "CPU": "Intel Xeon E5472 @ 3.00GHz",
+        "Benchmark": "2,333"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5472 @ 3.00GHz",
+        "Benchmark": "4,918"
+    },
+    {
+        "CPU": "Intel Xeon E5502 @ 1.87GHz",
+        "Benchmark": "837"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5502 @ 1.87GHz",
+        "Benchmark": "1,853"
+    },
+    {
+        "CPU": "Intel Xeon E5503 @ 2.00GHz",
+        "Benchmark": "804"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5503 @ 2.00GHz",
+        "Benchmark": "1,787"
+    },
+    {
+        "CPU": "Intel Xeon E5504 @ 2.00GHz",
+        "Benchmark": "1,489"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5504 @ 2.00GHz",
+        "Benchmark": "3,318"
+    },
+    {
+        "CPU": "Intel Xeon E5506 @ 2.13GHz",
+        "Benchmark": "1,961"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5506 @ 2.13GHz",
+        "Benchmark": "3,71"
+    },
+    {
+        "CPU": "Intel Xeon E5507 @ 2.27GHz",
+        "Benchmark": "1,905"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5507 @ 2.27GHz",
+        "Benchmark": "4,256"
+    },
+    {
+        "CPU": "Intel Xeon E5520 @ 2.27GHz",
+        "Benchmark": "2,533"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5520 @ 2.27GHz",
+        "Benchmark": "4,655"
+    },
+    {
+        "CPU": "Intel Xeon E5530 @ 2.40GHz",
+        "Benchmark": "2,739"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5530 @ 2.40GHz",
+        "Benchmark": "5,225"
+    },
+    {
+        "CPU": "Intel Xeon E5540 @ 2.53GHz",
+        "Benchmark": "2,805"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5540 @ 2.53GHz",
+        "Benchmark": "4,935"
+    },
+    {
+        "CPU": "Intel Xeon E5603 @ 1.60GHz",
+        "Benchmark": "1,935"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5603 @ 1.60GHz",
+        "Benchmark": "3,548"
+    },
+    {
+        "CPU": "Intel Xeon E5606 @ 2.13GHz",
+        "Benchmark": "2,384"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5606 @ 2.13GHz",
+        "Benchmark": "4,375"
+    },
+    {
+        "CPU": "Intel Xeon E5607 @ 2.27GHz",
+        "Benchmark": "2,686"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5607 @ 2.27GHz",
+        "Benchmark": "5,031"
+    },
+    {
+        "CPU": "Intel Xeon E5620 @ 2.40GHz",
+        "Benchmark": "3,623"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5620 @ 2.40GHz",
+        "Benchmark": "6,554"
+    },
+    {
+        "CPU": "Intel Xeon E5630 @ 2.53GHz",
+        "Benchmark": "3,809"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5630 @ 2.53GHz",
+        "Benchmark": "6,819"
+    },
+    {
+        "CPU": "Intel Xeon E5640 @ 2.67GHz",
+        "Benchmark": "3,837"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5640 @ 2.67GHz",
+        "Benchmark": "7,455"
+    },
+    {
+        "CPU": "Intel Xeon E5645 @ 2.40GHz",
+        "Benchmark": "4,972"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5645 @ 2.40GHz",
+        "Benchmark": "9,213"
+    },
+    {
+        "CPU": "Intel Xeon E5649 @ 2.53GHz",
+        "Benchmark": "5,659"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E5649 @ 2.53GHz",
+        "Benchmark": "9,554"
+    },
+    {
+        "CPU": "Intel Xeon E7- 2830 @ 2.13GHz",
+        "Benchmark": "2,027"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7- 4807 @ 1.87GHz",
+        "Benchmark": "8,352"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7- 4807 @ 1.87GHz",
+        "Benchmark": "6,223"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7- 4860 @ 2.27GHz",
+        "Benchmark": "22,121"
+    },
+    {
+        "CPU": "[8-Way CPU] Intel Xeon E7- 4870 @ 2.40GHz",
+        "Benchmark": "36,026"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7- 4870 @ 2.40GHz",
+        "Benchmark": "24,278"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7- 4870 @ 2.40GHz",
+        "Benchmark": "11,939"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7- 8837 @ 2.67GHz",
+        "Benchmark": "17,958"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7- 8870 @ 2.40GHz",
+        "Benchmark": "25,895"
+    },
+    {
+        "CPU": "Intel Xeon E7-4809 v2 @ 1.90GHz",
+        "Benchmark": "16,471"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7-4820 v2 @ 2.00GHz",
+        "Benchmark": "9,61"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-4830 @ 2.13GHz",
+        "Benchmark": "19,981"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-4830 v3 @ 2.10GHz",
+        "Benchmark": "41,102"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-4850 @ 2.00GHz",
+        "Benchmark": "21,385"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7-4850 @ 2.00GHz",
+        "Benchmark": "9,571"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-4870 v2 @ 2.30GHz",
+        "Benchmark": "45,23"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-4880 v2 @ 2.50GHz",
+        "Benchmark": "38,263"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-4890 v2 @ 2.80GHz",
+        "Benchmark": "47,367"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7-4890 v2 @ 2.80GHz",
+        "Benchmark": "25,055"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8857 v2 @ 3.00GHz",
+        "Benchmark": "36,304"
+    },
+    {
+        "CPU": "[3-Way CPU] Intel Xeon E7-8860 v4 @ 2.20GHz",
+        "Benchmark": "22,737"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8867 v3 @ 2.50GHz",
+        "Benchmark": "46,001"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8870 v4 @ 2.10GHz",
+        "Benchmark": "63,598"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7-8880 v2 @ 2.50GHz",
+        "Benchmark": "25,966"
+    },
+    {
+        "CPU": "Intel Xeon E7-8880 v3 @ 2.30GHz",
+        "Benchmark": "18,244"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8880 v3 @ 2.30GHz",
+        "Benchmark": "50,157"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7-8880 v3 @ 2.30GHz",
+        "Benchmark": "34,583"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8880 v4 @ 2.20GHz",
+        "Benchmark": "56,162"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon E7-8880 v4 @ 2.20GHz",
+        "Benchmark": "37,875"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8890 v3 @ 2.50GHz",
+        "Benchmark": "51,476"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8890 v4 @ 2.20GHz",
+        "Benchmark": "67,296"
+    },
+    {
+        "CPU": "Intel Xeon E7-8891 v3 @ 2.80GHz",
+        "Benchmark": "21,615"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8891 v4 @ 2.80GHz",
+        "Benchmark": "48,879"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8893 v4 @ 3.20GHz",
+        "Benchmark": "28,424"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8894 v4 @ 2.40GHz",
+        "Benchmark": "60,496"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7-8895 v2 @ 2.80GHz",
+        "Benchmark": "57,307"
+    },
+    {
+        "CPU": "Intel Xeon E7320 @ 2.13GHz",
+        "Benchmark": "1,469"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7320 @ 2.13GHz",
+        "Benchmark": "5,286"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7330 @ 2.40GHz",
+        "Benchmark": "6,792"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7340 @ 2.40GHz",
+        "Benchmark": "6,544"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7450 @ 2.40GHz",
+        "Benchmark": "9,849"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7530 @ 1.87GHz",
+        "Benchmark": "7,231"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon E7540 @ 2.00GHz",
+        "Benchmark": "9,409"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5115 @ 2.40GHz",
+        "Benchmark": "14,875"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5115 @ 2.40GHz",
+        "Benchmark": "25,268"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5117 @ 2.00GHz",
+        "Benchmark": "16,487"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 5117 @ 2.00GHz",
+        "Benchmark": "46,875"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5117 @ 2.00GHz",
+        "Benchmark": "26,721"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5118 @ 2.30GHz",
+        "Benchmark": "16,694"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5118 @ 2.30GHz",
+        "Benchmark": "24,699"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5120 @ 2.20GHz",
+        "Benchmark": "18,343"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5120 @ 2.20GHz",
+        "Benchmark": "28,423"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5120T @ 2.20GHz",
+        "Benchmark": "18,127"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5122 @ 3.60GHz",
+        "Benchmark": "8,883"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5122 @ 3.60GHz",
+        "Benchmark": "16,495"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5215 @ 2.20GHz",
+        "Benchmark": "16,304"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5215 @ 2.50GHz",
+        "Benchmark": "15,719"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5215 @ 2.50GHz",
+        "Benchmark": "22,674"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5217 @ 3.00GHz",
+        "Benchmark": "15,429"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5217 @ 3.00GHz",
+        "Benchmark": "25,455"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5218 @ 2.30GHz",
+        "Benchmark": "21,671"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 5218 @ 2.30GHz",
+        "Benchmark": "54,123"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5218 @ 2.30GHz",
+        "Benchmark": "32,478"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5218N @ 2.30GHz",
+        "Benchmark": "34,323"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5218R @ 2.10GHz",
+        "Benchmark": "24,742"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5218R @ 2.10GHz",
+        "Benchmark": "40,243"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5218T @ 2.10GHz",
+        "Benchmark": "21,433"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5218T @ 2.10GHz",
+        "Benchmark": "35,03"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5220 @ 2.20GHz",
+        "Benchmark": "24,154"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5220 @ 2.20GHz",
+        "Benchmark": "42,155"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5220R @ 2.20GHz",
+        "Benchmark": "31,363"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5220R @ 2.20GHz",
+        "Benchmark": "53,883"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5220S @ 2.70GHz",
+        "Benchmark": "39,678"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5222 @ 3.80GHz",
+        "Benchmark": "9,483"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5222 @ 3.80GHz",
+        "Benchmark": "17,276"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5315Y @ 3.20GHz",
+        "Benchmark": "20,82"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5315Y @ 3.20GHz",
+        "Benchmark": "35,567"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5317 @ 3.00GHz",
+        "Benchmark": "27,448"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5317 @ 3.00GHz",
+        "Benchmark": "41,459"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5318H @ 2.50GHz",
+        "Benchmark": "29,301"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 5318H @ 2.50GHz",
+        "Benchmark": "70,723"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5318H @ 2.50GHz",
+        "Benchmark": "50,218"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5318N @ 2.10GHz",
+        "Benchmark": "64,453"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5318Y @ 2.10GHz",
+        "Benchmark": "33,139"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5318Y @ 2.10GHz",
+        "Benchmark": "57,783"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5320 @ 2.20GHz",
+        "Benchmark": "37,558"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5320 @ 2.20GHz",
+        "Benchmark": "64,917"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5320H @ 2.40GHz",
+        "Benchmark": "31,718"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 5320H @ 2.40GHz",
+        "Benchmark": "83,263"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5320H @ 2.40GHz",
+        "Benchmark": "53,931"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5412U",
+        "Benchmark": "52,218"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5415+",
+        "Benchmark": "24,969"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5415+",
+        "Benchmark": "41,851"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5416S",
+        "Benchmark": "35,814"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5416S",
+        "Benchmark": "56,185"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5418Y",
+        "Benchmark": "46,137"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5418Y",
+        "Benchmark": "79,938"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5420+",
+        "Benchmark": "58,209"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5420+",
+        "Benchmark": "87,881"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5512U",
+        "Benchmark": "60,337"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5515+",
+        "Benchmark": "26,501"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 5515+",
+        "Benchmark": "47,031"
+    },
+    {
+        "CPU": "Intel Xeon Gold 5520+",
+        "Benchmark": "61,227"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6122 @ 1.80GHz",
+        "Benchmark": "23,781"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6122 @ 1.80GHz",
+        "Benchmark": "39,249"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6126 @ 2.60GHz",
+        "Benchmark": "19,811"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6126 @ 2.60GHz",
+        "Benchmark": "32,072"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6128 @ 3.40GHz",
+        "Benchmark": "12,811"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6128 @ 3.40GHz",
+        "Benchmark": "22,674"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6130 @ 2.10GHz",
+        "Benchmark": "21,17"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6130 @ 2.10GHz",
+        "Benchmark": "58,852"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6130 @ 2.10GHz",
+        "Benchmark": "33,001"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6130H @ 2.10GHz",
+        "Benchmark": "35,44"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6130T @ 2.10GHz",
+        "Benchmark": "21,804"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6132 @ 2.60GHz",
+        "Benchmark": "22,265"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6132 @ 2.60GHz",
+        "Benchmark": "33,797"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6134 @ 3.20GHz",
+        "Benchmark": "16,512"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6134 @ 3.20GHz",
+        "Benchmark": "40,698"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6134 @ 3.20GHz",
+        "Benchmark": "27,922"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6136 @ 3.00GHz",
+        "Benchmark": "20,977"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6136 @ 3.00GHz",
+        "Benchmark": "59,759"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6136 @ 3.00GHz",
+        "Benchmark": "34,656"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6137 @ 3.90GHz",
+        "Benchmark": "19,365"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6137 @ 3.90GHz",
+        "Benchmark": "33,252"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6138 @ 2.00GHz",
+        "Benchmark": "24,013"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6138 @ 2.00GHz",
+        "Benchmark": "69,395"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6138 @ 2.00GHz",
+        "Benchmark": "42,134"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6138T @ 2.00GHz",
+        "Benchmark": "20,356"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6138T @ 2.00GHz",
+        "Benchmark": "36,497"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6139 @ 2.30GHz",
+        "Benchmark": "40,21"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6140 @ 2.30GHz",
+        "Benchmark": "24,421"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6140 @ 2.30GHz",
+        "Benchmark": "40,665"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6142 @ 2.60GHz",
+        "Benchmark": "25,49"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6142 @ 2.60GHz",
+        "Benchmark": "36,388"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6143 @ 2.80GHz",
+        "Benchmark": "24,786"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6143 @ 2.80GHz",
+        "Benchmark": "46,473"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6144 @ 3.50GHz",
+        "Benchmark": "19,146"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6144 @ 3.50GHz",
+        "Benchmark": "31,475"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6146 @ 3.20GHz",
+        "Benchmark": "23,296"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6146 @ 3.20GHz",
+        "Benchmark": "37,808"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6148 @ 2.40GHz",
+        "Benchmark": "29,116"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6148 @ 2.40GHz",
+        "Benchmark": "46,535"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6149 @ 3.10GHz",
+        "Benchmark": "36,738"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6150 @ 2.70GHz",
+        "Benchmark": "26,695"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6150 @ 2.70GHz",
+        "Benchmark": "64,115"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6150 @ 2.70GHz",
+        "Benchmark": "47,289"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6152 @ 2.10GHz",
+        "Benchmark": "24,287"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6152 @ 2.10GHz",
+        "Benchmark": "52,677"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6152 @ 2.10GHz",
+        "Benchmark": "46,095"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6154 @ 3.00GHz",
+        "Benchmark": "27,56"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6154 @ 3.00GHz",
+        "Benchmark": "48,958"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6208U @ 2.90GHz",
+        "Benchmark": "24,67"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6210U @ 2.50GHz",
+        "Benchmark": "29,344"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6212U @ 2.40GHz",
+        "Benchmark": "27,47"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6222V @ 1.80GHz",
+        "Benchmark": "24,254"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6226 @ 2.70GHz",
+        "Benchmark": "20,429"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6226 @ 2.70GHz",
+        "Benchmark": "64,957"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6226 @ 2.70GHz",
+        "Benchmark": "32,991"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6226R @ 2.90GHz",
+        "Benchmark": "26,405"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6226R @ 2.90GHz",
+        "Benchmark": "39,787"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6230 @ 2.10GHz",
+        "Benchmark": "26,076"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6230 @ 2.10GHz",
+        "Benchmark": "44,057"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6230R @ 2.10GHz",
+        "Benchmark": "33,608"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6230R @ 2.10GHz",
+        "Benchmark": "51,668"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6234 @ 3.30GHz",
+        "Benchmark": "17,752"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6234 @ 3.30GHz",
+        "Benchmark": "29,57"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6238 @ 2.10GHz",
+        "Benchmark": "29,118"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6238R @ 2.20GHz",
+        "Benchmark": "34,751"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6238R @ 2.20GHz",
+        "Benchmark": "58,725"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6240 @ 2.60GHz",
+        "Benchmark": "24,677"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6240 @ 2.60GHz",
+        "Benchmark": "48,052"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6240R @ 2.40GHz",
+        "Benchmark": "33,353"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6240R @ 2.40GHz",
+        "Benchmark": "55,775"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6242 @ 2.80GHz",
+        "Benchmark": "24,994"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6242 @ 2.80GHz",
+        "Benchmark": "37,742"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6242R @ 3.10GHz",
+        "Benchmark": "34,292"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6242R @ 3.10GHz",
+        "Benchmark": "55,073"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6244 @ 3.60GHz",
+        "Benchmark": "18,657"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6244 @ 3.60GHz",
+        "Benchmark": "32,806"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6246 @ 3.30GHz",
+        "Benchmark": "22,571"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6246 @ 3.30GHz",
+        "Benchmark": "42,206"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6246R @ 3.40GHz",
+        "Benchmark": "30,468"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6246R @ 3.40GHz",
+        "Benchmark": "47,003"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6248 @ 2.50GHz",
+        "Benchmark": "29,552"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6248 @ 2.50GHz",
+        "Benchmark": "43,878"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6248R @ 3.00GHz",
+        "Benchmark": "35,434"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6248R @ 3.00GHz",
+        "Benchmark": "59,745"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6250 @ 3.90GHz",
+        "Benchmark": "20,552"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6250 @ 3.90GHz",
+        "Benchmark": "35,152"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6252 @ 2.10GHz",
+        "Benchmark": "27,148"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6252 @ 2.10GHz",
+        "Benchmark": "49,891"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6252N @ 2.30GHz",
+        "Benchmark": "49,269"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6253CL @ 3.10GHz",
+        "Benchmark": "28,549"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6253CL @ 3.10GHz",
+        "Benchmark": "49,872"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6254 @ 3.10GHz",
+        "Benchmark": "32,494"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6254 @ 3.10GHz",
+        "Benchmark": "52,41"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6256 @ 3.60GHz",
+        "Benchmark": "23,287"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6256 @ 3.60GHz",
+        "Benchmark": "76,542"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6256 @ 3.60GHz",
+        "Benchmark": "46,324"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6258R @ 2.70GHz",
+        "Benchmark": "40,252"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6258R @ 2.70GHz",
+        "Benchmark": "64,678"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6262 @ 1.90GHz",
+        "Benchmark": "21,823"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6262 @ 1.90GHz",
+        "Benchmark": "47,488"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6262V @ 1.90GHz",
+        "Benchmark": "50,835"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6266C @ 3.00GHz",
+        "Benchmark": "29,049"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6266C @ 3.00GHz",
+        "Benchmark": "51,998"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6268CL @ 2.80GHz",
+        "Benchmark": "34,558"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6268CL @ 2.80GHz",
+        "Benchmark": "61,095"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6278C @ 2.60GHz",
+        "Benchmark": "32,835"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6312U @ 2.40GHz",
+        "Benchmark": "42,329"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6314U @ 2.30GHz",
+        "Benchmark": "48,648"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6326 @ 2.90GHz",
+        "Benchmark": "34,24"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6326 @ 2.90GHz",
+        "Benchmark": "53,385"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6330 @ 2.00GHz",
+        "Benchmark": "43,056"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6330 @ 2.00GHz",
+        "Benchmark": "59,734"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6330N @ 2.20GHz",
+        "Benchmark": "36,36"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6334 @ 3.60GHz",
+        "Benchmark": "20,512"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6334 @ 3.60GHz",
+        "Benchmark": "34,628"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6336Y @ 2.40GHz",
+        "Benchmark": "45,517"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6336Y @ 2.40GHz",
+        "Benchmark": "71,408"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6338 @ 2.00GHz",
+        "Benchmark": "38,52"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6338 @ 2.00GHz",
+        "Benchmark": "66,598"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6338N @ 2.20GHz",
+        "Benchmark": "42,086"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6338N @ 2.20GHz",
+        "Benchmark": "65,86"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6342 @ 2.80GHz",
+        "Benchmark": "47,076"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6342 @ 2.80GHz",
+        "Benchmark": "72,919"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6346 @ 3.10GHz",
+        "Benchmark": "37,665"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6346 @ 3.10GHz",
+        "Benchmark": "55,571"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6348 @ 2.60GHz",
+        "Benchmark": "51,843"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6348 @ 2.60GHz",
+        "Benchmark": "76,125"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6348H @ 2.30GHz",
+        "Benchmark": "5,967"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6354 @ 3.00GHz",
+        "Benchmark": "39,88"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6354 @ 3.00GHz",
+        "Benchmark": "64,663"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6414U",
+        "Benchmark": "57,2"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6416H",
+        "Benchmark": "40,606"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6416H",
+        "Benchmark": "72,456"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6418H",
+        "Benchmark": "84,526"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6421N",
+        "Benchmark": "58,797"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6423N",
+        "Benchmark": "57,434"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6426Y",
+        "Benchmark": "38,373"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6426Y",
+        "Benchmark": "68,988"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6428N",
+        "Benchmark": "86,03"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6430",
+        "Benchmark": "81,919"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6434",
+        "Benchmark": "28,111"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6434",
+        "Benchmark": "46,362"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6438N",
+        "Benchmark": "52,789"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6438Y+",
+        "Benchmark": "94,596"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6442Y",
+        "Benchmark": "58,534"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6442Y",
+        "Benchmark": "92,289"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6444Y",
+        "Benchmark": "47,176"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6444Y",
+        "Benchmark": "75,558"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Gold 6448H",
+        "Benchmark": "123,361"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6448Y",
+        "Benchmark": "60,449"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6448Y",
+        "Benchmark": "102,292"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6450C",
+        "Benchmark": "38,571"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6454S",
+        "Benchmark": "85,725"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6526Y",
+        "Benchmark": "45,715"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6526Y",
+        "Benchmark": "68,018"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6530",
+        "Benchmark": "65,533"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6530",
+        "Benchmark": "93,111"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6534",
+        "Benchmark": "51,562"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6538N",
+        "Benchmark": "44,895"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6542Y",
+        "Benchmark": "59,047"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6542Y",
+        "Benchmark": "95,369"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6544Y",
+        "Benchmark": "50,319"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6544Y",
+        "Benchmark": "80,247"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6548N",
+        "Benchmark": "108,814"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6548Y+",
+        "Benchmark": "70,439"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6548Y+",
+        "Benchmark": "89,371"
+    },
+    {
+        "CPU": "Intel Xeon Gold 6554S",
+        "Benchmark": "50,777"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Gold 6554S",
+        "Benchmark": "108,431"
+    },
+    {
+        "CPU": "Intel Xeon L3110 @ 3.00GHz",
+        "Benchmark": "1,338"
+    },
+    {
+        "CPU": "Intel Xeon L3360 @ 2.83GHz",
+        "Benchmark": "2,412"
+    },
+    {
+        "CPU": "Intel Xeon L3406 @ 2.27GHz",
+        "Benchmark": "1,104"
+    },
+    {
+        "CPU": "Intel Xeon L3426 @ 1.87GHz",
+        "Benchmark": "2,47"
+    },
+    {
+        "CPU": "Intel Xeon L5240 @ 3.00GHz",
+        "Benchmark": "1,337"
+    },
+    {
+        "CPU": "Intel Xeon L5310 @ 1.60GHz",
+        "Benchmark": "1,385"
+    },
+    {
+        "CPU": "Intel Xeon L5320 @ 1.86GHz",
+        "Benchmark": "1,118"
+    },
+    {
+        "CPU": "Intel Xeon L5335 @ 2.00GHz",
+        "Benchmark": "1,737"
+    },
+    {
+        "CPU": "Intel Xeon L5408 @ 2.13GHz",
+        "Benchmark": "1,769"
+    },
+    {
+        "CPU": "Intel Xeon L5410 @ 2.33GHz",
+        "Benchmark": "1,853"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5410 @ 2.33GHz",
+        "Benchmark": "3,974"
+    },
+    {
+        "CPU": "Intel Xeon L5420 @ 2.50GHz",
+        "Benchmark": "2,143"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5420 @ 2.50GHz",
+        "Benchmark": "4,251"
+    },
+    {
+        "CPU": "Intel Xeon L5430 @ 2.66GHz",
+        "Benchmark": "2,26"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5430 @ 2.66GHz",
+        "Benchmark": "4,269"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5506 @ 2.13GHz",
+        "Benchmark": "4,019"
+    },
+    {
+        "CPU": "Intel Xeon L5520 @ 2.27GHz",
+        "Benchmark": "2,274"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5520 @ 2.27GHz",
+        "Benchmark": "4,561"
+    },
+    {
+        "CPU": "Intel Xeon L5530 @ 2.40GHz",
+        "Benchmark": "2,522"
+    },
+    {
+        "CPU": "Intel Xeon L5609 @ 1.87GHz",
+        "Benchmark": "3,298"
+    },
+    {
+        "CPU": "Intel Xeon L5630 @ 2.13GHz",
+        "Benchmark": "3,048"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5630 @ 2.13GHz",
+        "Benchmark": "5,267"
+    },
+    {
+        "CPU": "Intel Xeon L5638 @ 2.00GHz",
+        "Benchmark": "3,707"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5638 @ 2.00GHz",
+        "Benchmark": "7,217"
+    },
+    {
+        "CPU": "Intel Xeon L5639 @ 2.13GHz",
+        "Benchmark": "4,419"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5639 @ 2.13GHz",
+        "Benchmark": "5,768"
+    },
+    {
+        "CPU": "Intel Xeon L5640 @ 2.27GHz",
+        "Benchmark": "4,645"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon L5640 @ 2.27GHz",
+        "Benchmark": "8,633"
+    },
+    {
+        "CPU": "Intel Xeon L7455 @ 2.13GHz",
+        "Benchmark": "2,494"
+    },
+    {
+        "CPU": "Intel Xeon Max 9480",
+        "Benchmark": "84,512"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Max 9480",
+        "Benchmark": "111,213"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon MP 3.00GHz",
+        "Benchmark": "580"
+    },
+    {
+        "CPU": "Intel Xeon MV 3.20GHz",
+        "Benchmark": "756"
+    },
+    {
+        "CPU": "Intel Xeon Phi 7210 @ 1.30GHz",
+        "Benchmark": "7,306"
+    },
+    {
+        "CPU": "Intel Xeon Phi 7290 @ 1.50GHz",
+        "Benchmark": "17,839"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 6162 @ 1.90GHz",
+        "Benchmark": "44,322"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8124M @ 3.00GHz",
+        "Benchmark": "25,35"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8124M @ 3.00GHz",
+        "Benchmark": "48,775"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8151 @ 3.40GHz",
+        "Benchmark": "16,208"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8151 @ 3.40GHz",
+        "Benchmark": "43,342"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8153 @ 2.00GHz",
+        "Benchmark": "27,205"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8156 @ 3.60GHz",
+        "Benchmark": "16,852"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8160 @ 2.10GHz",
+        "Benchmark": "28,825"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Platinum 8160 @ 2.10GHz",
+        "Benchmark": "72,905"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8160 @ 2.10GHz",
+        "Benchmark": "48,801"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8160M @ 2.10GHz",
+        "Benchmark": "53,398"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8167M @ 2.00GHz",
+        "Benchmark": "25,396"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8168 @ 2.70GHz",
+        "Benchmark": "32,373"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8168 @ 2.70GHz",
+        "Benchmark": "53,999"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8170M @ 2.10GHz",
+        "Benchmark": "42,425"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8171M @ 2.60GHz",
+        "Benchmark": "29,613"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8171M @ 2.60GHz",
+        "Benchmark": "55,366"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8173M @ 2.00GHz",
+        "Benchmark": "28,025"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8173M @ 2.00GHz",
+        "Benchmark": "50,859"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8175M @ 2.50GHz",
+        "Benchmark": "26,659"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8176 @ 2.10GHz",
+        "Benchmark": "23,179"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8176 @ 2.10GHz",
+        "Benchmark": "54,867"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Platinum 8176M @ 2.10GHz",
+        "Benchmark": "88,102"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8180 @ 2.50GHz",
+        "Benchmark": "38,259"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8180 @ 2.50GHz",
+        "Benchmark": "53,874"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8180M @ 2.50GHz",
+        "Benchmark": "30,313"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8180M @ 2.50GHz",
+        "Benchmark": "55,092"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Platinum 8180M @ 2.50GHz",
+        "Benchmark": "47,049"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8252C @ 3.80GHz",
+        "Benchmark": "28,147"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8252C @ 3.80GHz",
+        "Benchmark": "48,958"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8253 @ 2.20GHz",
+        "Benchmark": "30,507"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8256 @ 3.80GHz",
+        "Benchmark": "16,787"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8259CL @ 2.50GHz",
+        "Benchmark": "31,403"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8259CL @ 2.50GHz",
+        "Benchmark": "53,01"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8260 @ 2.40GHz",
+        "Benchmark": "30,347"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon Platinum 8260 @ 2.40GHz",
+        "Benchmark": "83,793"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8260 @ 2.40GHz",
+        "Benchmark": "52,668"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8260C @ 2.40GHz",
+        "Benchmark": "34,42"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8260M @ 2.30GHz",
+        "Benchmark": "33,97"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8260M @ 2.30GHz",
+        "Benchmark": "55,297"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8260M @ 2.40GHz",
+        "Benchmark": "34,592"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8260M @ 2.40GHz",
+        "Benchmark": "55,438"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8268 @ 2.90GHz",
+        "Benchmark": "34,062"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8268 @ 2.90GHz",
+        "Benchmark": "58,264"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8269CY @ 2.50GHz",
+        "Benchmark": "61,811"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8270 @ 2.70GHz",
+        "Benchmark": "29,986"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8270CL @ 2.70GHz",
+        "Benchmark": "55,854"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8273CL @ 2.20GHz",
+        "Benchmark": "35,871"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8273CL @ 2.20GHz",
+        "Benchmark": "53,031"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8275CL @ 3.00GHz",
+        "Benchmark": "40,794"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8275CL @ 3.00GHz",
+        "Benchmark": "66,812"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8276L @ 2.20GHz",
+        "Benchmark": "60,188"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8280 @ 2.70GHz",
+        "Benchmark": "36,83"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8280 @ 2.70GHz",
+        "Benchmark": "63,867"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8336C",
+        "Benchmark": "74,875"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8338C @ 2.60GHz",
+        "Benchmark": "81,817"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8347C @ 2.10GHz",
+        "Benchmark": "49,386"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8352V @ 2.10GHz",
+        "Benchmark": "70,327"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8352Y @ 2.20GHz",
+        "Benchmark": "68,643"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8358 @ 2.60GHz",
+        "Benchmark": "54,416"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8358 @ 2.60GHz",
+        "Benchmark": "83,074"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8358P @ 2.60GHz",
+        "Benchmark": "82,052"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8360Y @ 2.40GHz",
+        "Benchmark": "54,078"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8362 @ 2.80GHz",
+        "Benchmark": "56,787"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8368 @ 2.40GHz",
+        "Benchmark": "88,038"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8368Q @ 2.60GHz",
+        "Benchmark": "46,681"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8369B @ 2.90GHz",
+        "Benchmark": "87,459"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8375C @ 2.90GHz",
+        "Benchmark": "56,202"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8375C @ 2.90GHz",
+        "Benchmark": "86,451"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8380 @ 2.30GHz",
+        "Benchmark": "62,318"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8380 @ 2.30GHz",
+        "Benchmark": "91,257"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8450H",
+        "Benchmark": "87,103"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8454H",
+        "Benchmark": "62,347"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8457C",
+        "Benchmark": "109,905"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8458P",
+        "Benchmark": "117,136"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8461V",
+        "Benchmark": "74,982"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8462Y+",
+        "Benchmark": "111,234"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8468",
+        "Benchmark": "118,664"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8470",
+        "Benchmark": "109,61"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8470 @2.00GHz",
+        "Benchmark": "89,85"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8475B",
+        "Benchmark": "3,28"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8479 @2.00GHz",
+        "Benchmark": "24,087"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8480+",
+        "Benchmark": "126,353"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8481C @ 2.70GHz",
+        "Benchmark": "11,681"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8488C",
+        "Benchmark": "88,667"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8488C",
+        "Benchmark": "127,207"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8558",
+        "Benchmark": "73,758"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8562Y+",
+        "Benchmark": "108,451"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8568Y+",
+        "Benchmark": "122,746"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8570",
+        "Benchmark": "137,588"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8571N",
+        "Benchmark": "68,385"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8575C",
+        "Benchmark": "3,342"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum 8580",
+        "Benchmark": "114,407"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8581C @ 2.30GHz",
+        "Benchmark": "8,04"
+    },
+    {
+        "CPU": "Intel Xeon Platinum 8592+",
+        "Benchmark": "84,013"
+    },
+    {
+        "CPU": "Intel Xeon Platinum P-8124 @ 3.00GHz",
+        "Benchmark": "22,674"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Platinum P-8124 @ 3.00GHz",
+        "Benchmark": "43,913"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4108 @ 1.80GHz",
+        "Benchmark": "9,096"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4108 @ 1.80GHz",
+        "Benchmark": "15,912"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4109T @ 2.00GHz",
+        "Benchmark": "10,348"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4110 @ 2.10GHz",
+        "Benchmark": "10,274"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4110 @ 2.10GHz",
+        "Benchmark": "17,009"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4112 @ 2.60GHz",
+        "Benchmark": "6,521"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4112 @ 2.60GHz",
+        "Benchmark": "12,264"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4114 @ 2.20GHz",
+        "Benchmark": "13,058"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4114 @ 2.20GHz",
+        "Benchmark": "20,641"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4114T @ 2.20GHz",
+        "Benchmark": "23,985"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4116 @ 2.10GHz",
+        "Benchmark": "14,956"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4116 @ 2.10GHz",
+        "Benchmark": "25,402"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4116T @ 2.10GHz",
+        "Benchmark": "15,187"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4123 @ 3.00GHz",
+        "Benchmark": "14,405"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4208 @ 2.10GHz",
+        "Benchmark": "11,198"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4208 @ 2.10GHz",
+        "Benchmark": "18,247"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4209T @ 2.20GHz",
+        "Benchmark": "11,08"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4210 @ 2.20GHz",
+        "Benchmark": "13,556"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4210 @ 2.20GHz",
+        "Benchmark": "23,258"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4210R @ 2.40GHz",
+        "Benchmark": "15,162"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4210R @ 2.40GHz",
+        "Benchmark": "23,12"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4214 @ 2.20GHz",
+        "Benchmark": "16,32"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4214 @ 2.20GHz",
+        "Benchmark": "25,806"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4214R @ 2.40GHz",
+        "Benchmark": "17,834"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4214R @ 2.40GHz",
+        "Benchmark": "27,534"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4214Y @ 2.20GHz",
+        "Benchmark": "16,442"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4215 @ 2.50GHz",
+        "Benchmark": "14,439"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4215 @ 2.50GHz",
+        "Benchmark": "23,177"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4215R @ 3.20GHz",
+        "Benchmark": "14,987"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4215R @ 3.20GHz",
+        "Benchmark": "24,815"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4216 @ 2.10GHz",
+        "Benchmark": "20,877"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4216 @ 2.10GHz",
+        "Benchmark": "28,335"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4216R @ 2.20GHz",
+        "Benchmark": "24,027"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4309Y @ 2.80GHz",
+        "Benchmark": "18,898"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4309Y @ 2.80GHz",
+        "Benchmark": "30,847"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4310 @ 2.10GHz",
+        "Benchmark": "21,903"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4310 @ 2.10GHz",
+        "Benchmark": "34,393"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4310T @ 2.30GHz",
+        "Benchmark": "20,607"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4314 @ 2.40GHz",
+        "Benchmark": "28,946"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4314 @ 2.40GHz",
+        "Benchmark": "44,41"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4316 @ 2.30GHz",
+        "Benchmark": "31,903"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4316 @ 2.30GHz",
+        "Benchmark": "53,991"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4410T",
+        "Benchmark": "28,759"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4410T",
+        "Benchmark": "45,27"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4410Y",
+        "Benchmark": "24,797"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4410Y",
+        "Benchmark": "43,547"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4416+",
+        "Benchmark": "44,14"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4416+",
+        "Benchmark": "68,83"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4509Y",
+        "Benchmark": "18,749"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4509Y",
+        "Benchmark": "39,561"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4510",
+        "Benchmark": "32,992"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4510",
+        "Benchmark": "52,465"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4510T",
+        "Benchmark": "29,119"
+    },
+    {
+        "CPU": "Intel Xeon Silver 4514Y",
+        "Benchmark": "28,456"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon Silver 4514Y",
+        "Benchmark": "49,035"
+    },
+    {
+        "CPU": "Intel Xeon W-10855M @ 2.80GHz",
+        "Benchmark": "12,298"
+    },
+    {
+        "CPU": "Intel Xeon W-10885M @ 2.40GHz",
+        "Benchmark": "15,464"
+    },
+    {
+        "CPU": "Intel Xeon W-11155MLE @ 1.80GHz",
+        "Benchmark": "8,502"
+    },
+    {
+        "CPU": "Intel Xeon W-11555MLE @ 1.90GHz",
+        "Benchmark": "12,591"
+    },
+    {
+        "CPU": "Intel Xeon W-11555MRE @ 2.60GHz",
+        "Benchmark": "17,484"
+    },
+    {
+        "CPU": "Intel Xeon W-11855M @ 3.20GHz",
+        "Benchmark": "17,888"
+    },
+    {
+        "CPU": "Intel Xeon W-11865MLE @ 1.50GHz",
+        "Benchmark": "15,917"
+    },
+    {
+        "CPU": "Intel Xeon W-11865MRE @ 2.60GHz",
+        "Benchmark": "19,589"
+    },
+    {
+        "CPU": "Intel Xeon W-11955M @ 2.60GHz",
+        "Benchmark": "22,093"
+    },
+    {
+        "CPU": "Intel Xeon W-1250 @ 3.30GHz",
+        "Benchmark": "13,737"
+    },
+    {
+        "CPU": "Intel Xeon W-1250E @ 3.50GHz",
+        "Benchmark": "12,212"
+    },
+    {
+        "CPU": "Intel Xeon W-1250P @ 4.10GHz",
+        "Benchmark": "14,355"
+    },
+    {
+        "CPU": "Intel Xeon W-1270 @ 3.40GHz",
+        "Benchmark": "17,573"
+    },
+    {
+        "CPU": "Intel Xeon W-1270E @ 3.40GHz",
+        "Benchmark": "18,635"
+    },
+    {
+        "CPU": "Intel Xeon W-1270P @ 3.80GHz",
+        "Benchmark": "17,099"
+    },
+    {
+        "CPU": "Intel Xeon W-1270TE @ 2.00GHz",
+        "Benchmark": "13,553"
+    },
+    {
+        "CPU": "Intel Xeon W-1290 @ 3.20GHz",
+        "Benchmark": "20,073"
+    },
+    {
+        "CPU": "Intel Xeon W-1290E @ 3.50GHz",
+        "Benchmark": "19,06"
+    },
+    {
+        "CPU": "Intel Xeon W-1290P @ 3.70GHz",
+        "Benchmark": "22,344"
+    },
+    {
+        "CPU": "Intel Xeon W-1290T @ 1.90GHz",
+        "Benchmark": "18,409"
+    },
+    {
+        "CPU": "Intel Xeon W-1290TE @ 1.80GHz",
+        "Benchmark": "14,505"
+    },
+    {
+        "CPU": "Intel Xeon W-1350 @ 3.30GHz",
+        "Benchmark": "18,775"
+    },
+    {
+        "CPU": "Intel Xeon W-1350P @ 4.00GHz",
+        "Benchmark": "19,611"
+    },
+    {
+        "CPU": "Intel Xeon W-1370 @ 2.90GHz",
+        "Benchmark": "22,926"
+    },
+    {
+        "CPU": "Intel Xeon W-1370P @ 3.60GHz",
+        "Benchmark": "22,814"
+    },
+    {
+        "CPU": "Intel Xeon W-1390 @ 2.80GHz",
+        "Benchmark": "23,902"
+    },
+    {
+        "CPU": "Intel Xeon W-1390P @ 3.50GHz",
+        "Benchmark": "25,159"
+    },
+    {
+        "CPU": "Intel Xeon W-2102 @ 2.90GHz",
+        "Benchmark": "5,028"
+    },
+    {
+        "CPU": "Intel Xeon W-2104 @ 3.20GHz",
+        "Benchmark": "5,545"
+    },
+    {
+        "CPU": "Intel Xeon W-2123 @ 3.60GHz",
+        "Benchmark": "8,506"
+    },
+    {
+        "CPU": "Intel Xeon W-2125 @ 4.00GHz",
+        "Benchmark": "10,06"
+    },
+    {
+        "CPU": "Intel Xeon W-2133 @ 3.60GHz",
+        "Benchmark": "12,678"
+    },
+    {
+        "CPU": "Intel Xeon W-2135 @ 3.70GHz",
+        "Benchmark": "14,412"
+    },
+    {
+        "CPU": "Intel Xeon W-2140B @ 3.20GHz",
+        "Benchmark": "17,329"
+    },
+    {
+        "CPU": "Intel Xeon W-2145 @ 3.70GHz",
+        "Benchmark": "17,971"
+    },
+    {
+        "CPU": "Intel Xeon W-2150B @ 3.00GHz",
+        "Benchmark": "20,52"
+    },
+    {
+        "CPU": "Intel Xeon W-2155 @ 3.30GHz",
+        "Benchmark": "21,071"
+    },
+    {
+        "CPU": "Intel Xeon W-2170B @ 2.50GHz",
+        "Benchmark": "24,299"
+    },
+    {
+        "CPU": "Intel Xeon W-2175 @ 2.50GHz",
+        "Benchmark": "23,429"
+    },
+    {
+        "CPU": "Intel Xeon W-2191B @ 2.30GHz",
+        "Benchmark": "28,227"
+    },
+    {
+        "CPU": "Intel Xeon W-2195 @ 2.30GHz",
+        "Benchmark": "27,914"
+    },
+    {
+        "CPU": "Intel Xeon W-2223 @ 3.60GHz",
+        "Benchmark": "8,561"
+    },
+    {
+        "CPU": "Intel Xeon W-2225 @ 4.10GHz",
+        "Benchmark": "10,487"
+    },
+    {
+        "CPU": "Intel Xeon W-2235 @ 3.80GHz",
+        "Benchmark": "14,357"
+    },
+    {
+        "CPU": "Intel Xeon W-2245 @ 3.90GHz",
+        "Benchmark": "19,447"
+    },
+    {
+        "CPU": "Intel Xeon W-2255 @ 3.70GHz",
+        "Benchmark": "22,394"
+    },
+    {
+        "CPU": "Intel Xeon W-2265 @ 3.50GHz",
+        "Benchmark": "25,619"
+    },
+    {
+        "CPU": "Intel Xeon W-2275 @ 3.30GHz",
+        "Benchmark": "27,961"
+    },
+    {
+        "CPU": "Intel Xeon W-2295 @ 3.00GHz",
+        "Benchmark": "30,892"
+    },
+    {
+        "CPU": "Intel Xeon W-3175X @ 3.10GHz",
+        "Benchmark": "46,125"
+    },
+    {
+        "CPU": "Intel Xeon W-3223 @ 3.50GHz",
+        "Benchmark": "17,009"
+    },
+    {
+        "CPU": "Intel Xeon W-3225 @ 3.70GHz",
+        "Benchmark": "18,251"
+    },
+    {
+        "CPU": "Intel Xeon W-3235 @ 3.30GHz",
+        "Benchmark": "25,554"
+    },
+    {
+        "CPU": "Intel Xeon W-3245 @ 3.20GHz",
+        "Benchmark": "31,066"
+    },
+    {
+        "CPU": "Intel Xeon W-3245M @ 3.20GHz",
+        "Benchmark": "28,067"
+    },
+    {
+        "CPU": "Intel Xeon W-3265 @ 2.70GHz",
+        "Benchmark": "30,105"
+    },
+    {
+        "CPU": "Intel Xeon W-3265M @ 2.70GHz",
+        "Benchmark": "34,147"
+    },
+    {
+        "CPU": "Intel Xeon W-3275 @ 2.50GHz",
+        "Benchmark": "41,469"
+    },
+    {
+        "CPU": "Intel Xeon W-3275M @ 2.50GHz",
+        "Benchmark": "40,419"
+    },
+    {
+        "CPU": "Intel Xeon W-3323 @ 3.50GHz",
+        "Benchmark": "27,822"
+    },
+    {
+        "CPU": "Intel Xeon W-3335 @ 3.40GHz",
+        "Benchmark": "39,293"
+    },
+    {
+        "CPU": "Intel Xeon W-3345 @ 3.00GHz",
+        "Benchmark": "47,664"
+    },
+    {
+        "CPU": "Intel Xeon W-3365 @ 2.70GHz",
+        "Benchmark": "59,038"
+    },
+    {
+        "CPU": "Intel Xeon W-3375 @ 2.50GHz",
+        "Benchmark": "59,091"
+    },
+    {
+        "CPU": "Intel Xeon w3-2423",
+        "Benchmark": "15,52"
+    },
+    {
+        "CPU": "Intel Xeon w3-2425",
+        "Benchmark": "18,941"
+    },
+    {
+        "CPU": "Intel Xeon w3-2435",
+        "Benchmark": "26,434"
+    },
+    {
+        "CPU": "Intel Xeon w3-2525",
+        "Benchmark": "26,48"
+    },
+    {
+        "CPU": "Intel Xeon w3-2535",
+        "Benchmark": "35,828"
+    },
+    {
+        "CPU": "Intel Xeon W3503 @ 2.40GHz",
+        "Benchmark": "1,118"
+    },
+    {
+        "CPU": "Intel Xeon W3505 @ 2.53GHz",
+        "Benchmark": "1,181"
+    },
+    {
+        "CPU": "Intel Xeon W3520 @ 2.67GHz",
+        "Benchmark": "2,926"
+    },
+    {
+        "CPU": "Intel Xeon W3530 @ 2.80GHz",
+        "Benchmark": "3,067"
+    },
+    {
+        "CPU": "Intel Xeon W3540 @ 2.93GHz",
+        "Benchmark": "3,109"
+    },
+    {
+        "CPU": "Intel Xeon W3550 @ 3.07GHz",
+        "Benchmark": "3,245"
+    },
+    {
+        "CPU": "Intel Xeon W3565 @ 3.20GHz",
+        "Benchmark": "3,38"
+    },
+    {
+        "CPU": "Intel Xeon W3570 @ 3.20GHz",
+        "Benchmark": "3,267"
+    },
+    {
+        "CPU": "Intel Xeon W3580 @ 3.33GHz",
+        "Benchmark": "3,638"
+    },
+    {
+        "CPU": "Intel Xeon W3670 @ 3.20GHz",
+        "Benchmark": "6,413"
+    },
+    {
+        "CPU": "Intel Xeon W3680 @ 3.33GHz",
+        "Benchmark": "7,026"
+    },
+    {
+        "CPU": "Intel Xeon W3690 @ 3.47GHz",
+        "Benchmark": "7,205"
+    },
+    {
+        "CPU": "Intel Xeon w5-2445",
+        "Benchmark": "32,287"
+    },
+    {
+        "CPU": "Intel Xeon w5-2455X",
+        "Benchmark": "37,37"
+    },
+    {
+        "CPU": "Intel Xeon w5-2465X",
+        "Benchmark": "45,794"
+    },
+    {
+        "CPU": "Intel Xeon w5-2545",
+        "Benchmark": "41,406"
+    },
+    {
+        "CPU": "Intel Xeon w5-2555X",
+        "Benchmark": "48,709"
+    },
+    {
+        "CPU": "Intel Xeon w5-2565X",
+        "Benchmark": "52,646"
+    },
+    {
+        "CPU": "Intel Xeon w5-3423",
+        "Benchmark": "28,251"
+    },
+    {
+        "CPU": "Intel Xeon w5-3425",
+        "Benchmark": "36,024"
+    },
+    {
+        "CPU": "Intel Xeon w5-3433",
+        "Benchmark": "34,722"
+    },
+    {
+        "CPU": "Intel Xeon w5-3435X",
+        "Benchmark": "45,872"
+    },
+    {
+        "CPU": "Intel Xeon w5-3525",
+        "Benchmark": "49,19"
+    },
+    {
+        "CPU": "Intel Xeon w5-3535X",
+        "Benchmark": "54,276"
+    },
+    {
+        "CPU": "Intel Xeon W5580 @ 3.20GHz",
+        "Benchmark": "3,459"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon W5580 @ 3.20GHz",
+        "Benchmark": "5,979"
+    },
+    {
+        "CPU": "Intel Xeon W5590 @ 3.33GHz",
+        "Benchmark": "3,342"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon W5590 @ 3.33GHz",
+        "Benchmark": "6,718"
+    },
+    {
+        "CPU": "Intel Xeon w7-2475X",
+        "Benchmark": "53,875"
+    },
+    {
+        "CPU": "Intel Xeon w7-2495X",
+        "Benchmark": "57,751"
+    },
+    {
+        "CPU": "Intel Xeon w7-2575X",
+        "Benchmark": "58,625"
+    },
+    {
+        "CPU": "Intel Xeon w7-2595X",
+        "Benchmark": "66,742"
+    },
+    {
+        "CPU": "Intel Xeon w7-3445",
+        "Benchmark": "48,476"
+    },
+    {
+        "CPU": "Intel Xeon w7-3455",
+        "Benchmark": "58,05"
+    },
+    {
+        "CPU": "Intel Xeon w7-3465X",
+        "Benchmark": "62,805"
+    },
+    {
+        "CPU": "Intel Xeon w7-3565X",
+        "Benchmark": "73,318"
+    },
+    {
+        "CPU": "Intel Xeon w9-3475X",
+        "Benchmark": "64,686"
+    },
+    {
+        "CPU": "Intel Xeon w9-3495X",
+        "Benchmark": "91,952"
+    },
+    {
+        "CPU": "Intel Xeon w9-3575X",
+        "Benchmark": "82,62"
+    },
+    {
+        "CPU": "Intel Xeon w9-3595X",
+        "Benchmark": "101,511"
+    },
+    {
+        "CPU": "Intel Xeon X3210 @ 2.13GHz",
+        "Benchmark": "1,293"
+    },
+    {
+        "CPU": "Intel Xeon X3220 @ 2.40GHz",
+        "Benchmark": "1,973"
+    },
+    {
+        "CPU": "Intel Xeon X3230 @ 2.66GHz",
+        "Benchmark": "2,052"
+    },
+    {
+        "CPU": "Intel Xeon X3320 @ 2.50GHz",
+        "Benchmark": "2,034"
+    },
+    {
+        "CPU": "Intel Xeon X3323 @ 2.50GHz",
+        "Benchmark": "2,03"
+    },
+    {
+        "CPU": "Intel Xeon X3330 @ 2.66GHz",
+        "Benchmark": "2,102"
+    },
+    {
+        "CPU": "Intel Xeon X3350 @ 2.66GHz",
+        "Benchmark": "2,263"
+    },
+    {
+        "CPU": "Intel Xeon X3353 @ 2.66GHz",
+        "Benchmark": "2,283"
+    },
+    {
+        "CPU": "Intel Xeon X3360 @ 2.83GHz",
+        "Benchmark": "2,424"
+    },
+    {
+        "CPU": "Intel Xeon X3363 @ 2.83GHz",
+        "Benchmark": "2,37"
+    },
+    {
+        "CPU": "Intel Xeon X3370 @ 3.00GHz",
+        "Benchmark": "2,505"
+    },
+    {
+        "CPU": "Intel Xeon X3380 @ 3.16GHz",
+        "Benchmark": "2,568"
+    },
+    {
+        "CPU": "Intel Xeon X3430 @ 2.40GHz",
+        "Benchmark": "2,313"
+    },
+    {
+        "CPU": "Intel Xeon X3440 @ 2.53GHz",
+        "Benchmark": "2,759"
+    },
+    {
+        "CPU": "Intel Xeon X3450 @ 2.67GHz",
+        "Benchmark": "2,869"
+    },
+    {
+        "CPU": "Intel Xeon X3460 @ 2.80GHz",
+        "Benchmark": "2,972"
+    },
+    {
+        "CPU": "Intel Xeon X3470 @ 2.93GHz",
+        "Benchmark": "3,306"
+    },
+    {
+        "CPU": "Intel Xeon X3480 @ 3.07GHz",
+        "Benchmark": "3,273"
+    },
+    {
+        "CPU": "Intel Xeon X5260 @ 3.33GHz",
+        "Benchmark": "1,238"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5260 @ 3.33GHz",
+        "Benchmark": "2,389"
+    },
+    {
+        "CPU": "Intel Xeon X5270 @ 3.50GHz",
+        "Benchmark": "1,524"
+    },
+    {
+        "CPU": "Intel Xeon X5272 @ 3.40GHz",
+        "Benchmark": "1,451"
+    },
+    {
+        "CPU": "Intel Xeon X5355 @ 2.66GHz",
+        "Benchmark": "2,033"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5355 @ 2.66GHz",
+        "Benchmark": "3,819"
+    },
+    {
+        "CPU": "Intel Xeon X5365 @ 3.00GHz",
+        "Benchmark": "2,331"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5365 @ 3.00GHz",
+        "Benchmark": "4,371"
+    },
+    {
+        "CPU": "Intel Xeon X5450 @ 3.00GHz",
+        "Benchmark": "2,418"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5450 @ 3.00GHz",
+        "Benchmark": "4,841"
+    },
+    {
+        "CPU": "Intel Xeon X5460 @ 3.16GHz",
+        "Benchmark": "2,582"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5460 @ 3.16GHz",
+        "Benchmark": "5,066"
+    },
+    {
+        "CPU": "Intel Xeon X5470 @ 3.33GHz",
+        "Benchmark": "2,869"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5470 @ 3.33GHz",
+        "Benchmark": "5,125"
+    },
+    {
+        "CPU": "Intel Xeon X5472 @ 3.00GHz",
+        "Benchmark": "2,197"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5472 @ 3.00GHz",
+        "Benchmark": "5,025"
+    },
+    {
+        "CPU": "Intel Xeon X5482 @ 3.20GHz",
+        "Benchmark": "2,755"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5482 @ 3.20GHz",
+        "Benchmark": "5,108"
+    },
+    {
+        "CPU": "Intel Xeon X5492 @ 3.40GHz",
+        "Benchmark": "2,912"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5492 @ 3.40GHz",
+        "Benchmark": "5,469"
+    },
+    {
+        "CPU": "Intel Xeon X5550 @ 2.67GHz",
+        "Benchmark": "3,027"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5550 @ 2.67GHz",
+        "Benchmark": "5,637"
+    },
+    {
+        "CPU": "Intel Xeon X5560 @ 2.80GHz",
+        "Benchmark": "3,21"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5560 @ 2.80GHz",
+        "Benchmark": "5,596"
+    },
+    {
+        "CPU": "Intel Xeon X5570 @ 2.93GHz",
+        "Benchmark": "3,312"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5570 @ 2.93GHz",
+        "Benchmark": "6,253"
+    },
+    {
+        "CPU": "Intel Xeon X5647 @ 2.93GHz",
+        "Benchmark": "4,441"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5647 @ 2.93GHz",
+        "Benchmark": "8,369"
+    },
+    {
+        "CPU": "Intel Xeon X5650 @ 2.67GHz",
+        "Benchmark": "5,739"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5650 @ 2.67GHz",
+        "Benchmark": "10,16"
+    },
+    {
+        "CPU": "Intel Xeon X5660 @ 2.80GHz",
+        "Benchmark": "5,979"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5660 @ 2.80GHz",
+        "Benchmark": "10,343"
+    },
+    {
+        "CPU": "Intel Xeon X5667 @ 3.07GHz",
+        "Benchmark": "4,659"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5667 @ 3.07GHz",
+        "Benchmark": "8,462"
+    },
+    {
+        "CPU": "Intel Xeon X5670 @ 2.93GHz",
+        "Benchmark": "6,141"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5670 @ 2.93GHz",
+        "Benchmark": "10,819"
+    },
+    {
+        "CPU": "Intel Xeon X5672 @ 3.20GHz",
+        "Benchmark": "4,996"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5672 @ 3.20GHz",
+        "Benchmark": "8,828"
+    },
+    {
+        "CPU": "Intel Xeon X5675 @ 3.07GHz",
+        "Benchmark": "6,396"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5675 @ 3.07GHz",
+        "Benchmark": "11,624"
+    },
+    {
+        "CPU": "Intel Xeon X5677 @ 3.47GHz",
+        "Benchmark": "5,053"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5677 @ 3.47GHz",
+        "Benchmark": "8,971"
+    },
+    {
+        "CPU": "Intel Xeon X5679 @ 3.20GHz",
+        "Benchmark": "7,095"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5679 @ 3.20GHz",
+        "Benchmark": "9,634"
+    },
+    {
+        "CPU": "Intel Xeon X5680 @ 3.33GHz",
+        "Benchmark": "6,876"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5680 @ 3.33GHz",
+        "Benchmark": "12,581"
+    },
+    {
+        "CPU": "Intel Xeon X5687 @ 3.60GHz",
+        "Benchmark": "5,349"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5687 @ 3.60GHz",
+        "Benchmark": "9,417"
+    },
+    {
+        "CPU": "Intel Xeon X5690 @ 3.47GHz",
+        "Benchmark": "7,039"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X5690 @ 3.47GHz",
+        "Benchmark": "12,902"
+    },
+    {
+        "CPU": "Intel Xeon X5698 @ 4.40GHz",
+        "Benchmark": "3,447"
+    },
+    {
+        "CPU": "Intel Xeon X6550 @ 2.00GHz",
+        "Benchmark": "1,936"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon X7350 @ 2.93GHz",
+        "Benchmark": "7,836"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X7460 @ 2.66GHz",
+        "Benchmark": "4,803"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon X7550 @ 2.00GHz",
+        "Benchmark": "12,358"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X7550 @ 2.00GHz",
+        "Benchmark": "7,873"
+    },
+    {
+        "CPU": "[Quad CPU] Intel Xeon X7560 @ 2.27GHz",
+        "Benchmark": "16,464"
+    },
+    {
+        "CPU": "[Dual CPU] Intel Xeon X7560 @ 2.27GHz",
+        "Benchmark": "8,028"
+    },
+    {
+        "CPU": "JLQ JR510",
+        "Benchmark": "1,047"
+    },
+    {
+        "CPU": "lisa based Qualcomm Technologies, Inc. SM7325",
+        "Benchmark": "5,456"
+    },
+    {
+        "CPU": "M7221",
+        "Benchmark": "760"
+    },
+    {
+        "CPU": "Manta",
+        "Benchmark": "356"
+    },
+    {
+        "CPU": "Mars based on Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "5,23"
+    },
+    {
+        "CPU": "MediaTek Dimensity 1000+ (MT6889)",
+        "Benchmark": "4,892"
+    },
+    {
+        "CPU": "Mediatek Dimensity 7025 (MT6855)",
+        "Benchmark": "4,588"
+    },
+    {
+        "CPU": "Mediatek Dimensity 7200-Pro (MT6886)",
+        "Benchmark": "4,729"
+    },
+    {
+        "CPU": "Mediatek Dimensity 7300-Ultra (MT6878)",
+        "Benchmark": "6,147"
+    },
+    {
+        "CPU": "Mediatek Dimensity 8200-Ultimate (MT6896)",
+        "Benchmark": "7,396"
+    },
+    {
+        "CPU": "Mediatek Dimensity 8350 (MT6897)",
+        "Benchmark": "7,391"
+    },
+    {
+        "CPU": "Mediatek Dimensity 8400-Turbo (MT6899)",
+        "Benchmark": "8,907"
+    },
+    {
+        "CPU": "MediaTek Dimensity 900 (MT6877)",
+        "Benchmark": "4,854"
+    },
+    {
+        "CPU": "Mediatek Dimensity 9200 (MT6985)",
+        "Benchmark": "7,976"
+    },
+    {
+        "CPU": "Mediatek Dimensity 9400 (MT6991)",
+        "Benchmark": "12,506"
+    },
+    {
+        "CPU": "Mediatek DM700",
+        "Benchmark": "4,471"
+    },
+    {
+        "CPU": "MediaTek G70 (MT6769V/CB)",
+        "Benchmark": "2,441"
+    },
+    {
+        "CPU": "MediaTek G70 (MT6769V/WB)",
+        "Benchmark": "2,192"
+    },
+    {
+        "CPU": "MediaTek G80 (MT6769T)",
+        "Benchmark": "2,585"
+    },
+    {
+        "CPU": "MediaTek G80 (MT6769V/CT)",
+        "Benchmark": "2,495"
+    },
+    {
+        "CPU": "MediaTek G80 (MT6769V/CU)",
+        "Benchmark": "2,724"
+    },
+    {
+        "CPU": "MediaTek G85 (MT6769Z)",
+        "Benchmark": "2,765"
+    },
+    {
+        "CPU": "MediaTek G88 (MT6769H)",
+        "Benchmark": "2,739"
+    },
+    {
+        "CPU": "MediaTek G99 Ultimate (MT6789)",
+        "Benchmark": "4,212"
+    },
+    {
+        "CPU": "MediaTek Kompanio 520/528 (MT8186/MT8186T)",
+        "Benchmark": "3,691"
+    },
+    {
+        "CPU": "MediaTek MT6735",
+        "Benchmark": "584"
+    },
+    {
+        "CPU": "MediaTek MT6737",
+        "Benchmark": "469"
+    },
+    {
+        "CPU": "MediaTek MT6737M",
+        "Benchmark": "427"
+    },
+    {
+        "CPU": "MediaTek MT6737T",
+        "Benchmark": "697"
+    },
+    {
+        "CPU": "Mediatek MT6739",
+        "Benchmark": "680"
+    },
+    {
+        "CPU": "Mediatek MT6739W",
+        "Benchmark": "251"
+    },
+    {
+        "CPU": "MediaTek MT6739WA",
+        "Benchmark": "402"
+    },
+    {
+        "CPU": "MediaTek MT6739WW",
+        "Benchmark": "445"
+    },
+    {
+        "CPU": "MediaTek MT6750",
+        "Benchmark": "1,052"
+    },
+    {
+        "CPU": "MediaTek MT6750T",
+        "Benchmark": "1,187"
+    },
+    {
+        "CPU": "MediaTek MT6750V/WT",
+        "Benchmark": "1,153"
+    },
+    {
+        "CPU": "MediaTek MT6753",
+        "Benchmark": "955"
+    },
+    {
+        "CPU": "MediaTek MT6753T",
+        "Benchmark": "1,149"
+    },
+    {
+        "CPU": "MediaTek MT6757CD",
+        "Benchmark": "1,782"
+    },
+    {
+        "CPU": "MediaTek MT6757V",
+        "Benchmark": "1,846"
+    },
+    {
+        "CPU": "Mediatek MT6761",
+        "Benchmark": "1,163"
+    },
+    {
+        "CPU": "Mediatek MT6761V/CAB",
+        "Benchmark": "1,074"
+    },
+    {
+        "CPU": "MediaTek MT6761V/WBB",
+        "Benchmark": "799"
+    },
+    {
+        "CPU": "Mediatek MT6761V/WD",
+        "Benchmark": "762"
+    },
+    {
+        "CPU": "MediaTek MT6761V/WE",
+        "Benchmark": "757"
+    },
+    {
+        "CPU": "Mediatek MT6762",
+        "Benchmark": "1,784"
+    },
+    {
+        "CPU": "MediaTek MT6762G",
+        "Benchmark": "1,239"
+    },
+    {
+        "CPU": "MediaTek MT6762V/CA",
+        "Benchmark": "1,289"
+    },
+    {
+        "CPU": "MediaTek MT6762V/CB",
+        "Benchmark": "1,639"
+    },
+    {
+        "CPU": "MediaTek MT6762V/CN",
+        "Benchmark": "637"
+    },
+    {
+        "CPU": "MediaTek MT6762V/WA",
+        "Benchmark": "1,476"
+    },
+    {
+        "CPU": "MediaTek MT6762V/WB",
+        "Benchmark": "1,471"
+    },
+    {
+        "CPU": "MediaTek MT6762V/WD",
+        "Benchmark": "1,582"
+    },
+    {
+        "CPU": "MediaTek MT6762V/WR",
+        "Benchmark": "1,546"
+    },
+    {
+        "CPU": "MediaTek MT6763V/CE",
+        "Benchmark": "2,13"
+    },
+    {
+        "CPU": "MediaTek MT6763V/V",
+        "Benchmark": "1,578"
+    },
+    {
+        "CPU": "Mediatek MT6765",
+        "Benchmark": "1,707"
+    },
+    {
+        "CPU": "MediaTek MT6765G",
+        "Benchmark": "1,668"
+    },
+    {
+        "CPU": "Mediatek MT6765H",
+        "Benchmark": "2,061"
+    },
+    {
+        "CPU": "MediaTek MT6765V/CA",
+        "Benchmark": "1,844"
+    },
+    {
+        "CPU": "MediaTek MT6765V/CB",
+        "Benchmark": "1,898"
+    },
+    {
+        "CPU": "Mediatek MT6765V/WA",
+        "Benchmark": "2,186"
+    },
+    {
+        "CPU": "Mediatek MT6765V/WB",
+        "Benchmark": "1,801"
+    },
+    {
+        "CPU": "Mediatek MT6765V/XBA",
+        "Benchmark": "1,732"
+    },
+    {
+        "CPU": "Mediatek MT6768",
+        "Benchmark": "2,709"
+    },
+    {
+        "CPU": "Mediatek MT6768G",
+        "Benchmark": "3,232"
+    },
+    {
+        "CPU": "MediaTek MT6768V/CA",
+        "Benchmark": "2,346"
+    },
+    {
+        "CPU": "Mediatek MT6769",
+        "Benchmark": "2,885"
+    },
+    {
+        "CPU": "Mediatek MT6769V/CB",
+        "Benchmark": "2,713"
+    },
+    {
+        "CPU": "MediaTek MT6771V/C",
+        "Benchmark": "2,673"
+    },
+    {
+        "CPU": "MediaTek MT6771V/CT",
+        "Benchmark": "2,682"
+    },
+    {
+        "CPU": "MediaTek MT6771V/W",
+        "Benchmark": "2,452"
+    },
+    {
+        "CPU": "MediaTek MT6771V/WM",
+        "Benchmark": "2,258"
+    },
+    {
+        "CPU": "MediaTek MT6771V/WT",
+        "Benchmark": "2,387"
+    },
+    {
+        "CPU": "Mediatek MT6779",
+        "Benchmark": "3,43"
+    },
+    {
+        "CPU": "MediaTek MT6779V/CE",
+        "Benchmark": "3,112"
+    },
+    {
+        "CPU": "MediaTek MT6779V/CU",
+        "Benchmark": "2,683"
+    },
+    {
+        "CPU": "MediaTek MT6779V/CV",
+        "Benchmark": "2,712"
+    },
+    {
+        "CPU": "Mediatek MT6781",
+        "Benchmark": "3,877"
+    },
+    {
+        "CPU": "Mediatek MT6781V/CD",
+        "Benchmark": "4,04"
+    },
+    {
+        "CPU": "Mediatek MT6781V/CDZAMB-H",
+        "Benchmark": "4,16"
+    },
+    {
+        "CPU": "Mediatek MT6785",
+        "Benchmark": "3,824"
+    },
+    {
+        "CPU": "MediaTek MT6785V/CC",
+        "Benchmark": "3,415"
+    },
+    {
+        "CPU": "MediaTek MT6785V/CD",
+        "Benchmark": "3,649"
+    },
+    {
+        "CPU": "Mediatek MT6789V/CD",
+        "Benchmark": "4,272"
+    },
+    {
+        "CPU": "MediaTek MT6797",
+        "Benchmark": "1,903"
+    },
+    {
+        "CPU": "MediaTek MT6797T",
+        "Benchmark": "1,605"
+    },
+    {
+        "CPU": "MediaTek MT6797X",
+        "Benchmark": "2,212"
+    },
+    {
+        "CPU": "Mediatek MT6833",
+        "Benchmark": "4,083"
+    },
+    {
+        "CPU": "Mediatek MT6833G",
+        "Benchmark": "4,532"
+    },
+    {
+        "CPU": "Mediatek MT6833GP",
+        "Benchmark": "4,426"
+    },
+    {
+        "CPU": "Mediatek MT6833P",
+        "Benchmark": "3,7"
+    },
+    {
+        "CPU": "Mediatek MT6833V/NZA",
+        "Benchmark": "3,615"
+    },
+    {
+        "CPU": "Mediatek MT6833V/PNZA",
+        "Benchmark": "4,106"
+    },
+    {
+        "CPU": "Mediatek MT6833V/ZA",
+        "Benchmark": "4,229"
+    },
+    {
+        "CPU": "MediaTek MT6853T",
+        "Benchmark": "3,508"
+    },
+    {
+        "CPU": "Mediatek MT6853V/NZA",
+        "Benchmark": "3,995"
+    },
+    {
+        "CPU": "Mediatek MT6853V/TNZA",
+        "Benchmark": "4,161"
+    },
+    {
+        "CPU": "MediaTek MT6873",
+        "Benchmark": "4,074"
+    },
+    {
+        "CPU": "Mediatek MT6875",
+        "Benchmark": "5,258"
+    },
+    {
+        "CPU": "Mediatek MT6877V/TTZA",
+        "Benchmark": "4,965"
+    },
+    {
+        "CPU": "Mediatek MT6877V/TZA",
+        "Benchmark": "4,708"
+    },
+    {
+        "CPU": "Mediatek MT6879V/ZA",
+        "Benchmark": "4,632"
+    },
+    {
+        "CPU": "Mediatek MT6879V_T/ZA",
+        "Benchmark": "5,218"
+    },
+    {
+        "CPU": "Mediatek MT6883Z/CZA",
+        "Benchmark": "5,914"
+    },
+    {
+        "CPU": "Mediatek MT6891",
+        "Benchmark": "5,3"
+    },
+    {
+        "CPU": "Mediatek MT6891Z/CZA",
+        "Benchmark": "6,644"
+    },
+    {
+        "CPU": "Mediatek MT6891Z_T/CZA",
+        "Benchmark": "7,16"
+    },
+    {
+        "CPU": "Mediatek MT6891Z_Z/CZA",
+        "Benchmark": "6,545"
+    },
+    {
+        "CPU": "Mediatek MT6893",
+        "Benchmark": "6,334"
+    },
+    {
+        "CPU": "Mediatek MT6893Z_T/CZA",
+        "Benchmark": "6,397"
+    },
+    {
+        "CPU": "MediaTek MT6895",
+        "Benchmark": "7,615"
+    },
+    {
+        "CPU": "Mediatek MT6895Z/TCZA",
+        "Benchmark": "6,744"
+    },
+    {
+        "CPU": "Mediatek MT6895Z_A/TCZA",
+        "Benchmark": "7,618"
+    },
+    {
+        "CPU": "Mediatek MT6895Z_B/TCZA",
+        "Benchmark": "7,044"
+    },
+    {
+        "CPU": "MediaTek MT6983",
+        "Benchmark": "6,776"
+    },
+    {
+        "CPU": "Mediatek MT6983W/CZA",
+        "Benchmark": "9,136"
+    },
+    {
+        "CPU": "Mediatek MT6983Z/CZA",
+        "Benchmark": "7,726"
+    },
+    {
+        "CPU": "Mediatek MT6989",
+        "Benchmark": "10,792"
+    },
+    {
+        "CPU": "MediaTek MT8163",
+        "Benchmark": "619"
+    },
+    {
+        "CPU": "MediaTek MT8166B",
+        "Benchmark": "971"
+    },
+    {
+        "CPU": "MediaTek MT8167B",
+        "Benchmark": "403"
+    },
+    {
+        "CPU": "MediaTek MT8168",
+        "Benchmark": "1,029"
+    },
+    {
+        "CPU": "MediaTek MT8168A",
+        "Benchmark": "712"
+    },
+    {
+        "CPU": "Mediatek MT8168B",
+        "Benchmark": "795"
+    },
+    {
+        "CPU": "Mediatek MT8173",
+        "Benchmark": "1,366"
+    },
+    {
+        "CPU": "Mediatek MT8175B",
+        "Benchmark": "592"
+    },
+    {
+        "CPU": "MediaTek MT8183",
+        "Benchmark": "2,587"
+    },
+    {
+        "CPU": "MediaTek MT8188",
+        "Benchmark": "3,144"
+    },
+    {
+        "CPU": "Mediatek MT8192",
+        "Benchmark": "5,172"
+    },
+    {
+        "CPU": "Mediatek MT8195",
+        "Benchmark": "8,419"
+    },
+    {
+        "CPU": "Mediatek MT8195AV",
+        "Benchmark": "6,251"
+    },
+    {
+        "CPU": "Mediatek MT8365",
+        "Benchmark": "1,156"
+    },
+    {
+        "CPU": "Mediatek MT8370AV/A",
+        "Benchmark": "4,107"
+    },
+    {
+        "CPU": "Mediatek MT8390AV/A",
+        "Benchmark": "4,92"
+    },
+    {
+        "CPU": "Mediatek MT8696",
+        "Benchmark": "740"
+    },
+    {
+        "CPU": "MediaTek MT8735B",
+        "Benchmark": "418"
+    },
+    {
+        "CPU": "Mediatek MT8765WA",
+        "Benchmark": "564"
+    },
+    {
+        "CPU": "Mediatek MT8766A",
+        "Benchmark": "979"
+    },
+    {
+        "CPU": "Mediatek MT8766B",
+        "Benchmark": "1,174"
+    },
+    {
+        "CPU": "Mediatek MT8768A",
+        "Benchmark": "1,524"
+    },
+    {
+        "CPU": "MediaTek MT8768CT",
+        "Benchmark": "2,037"
+    },
+    {
+        "CPU": "Mediatek MT8768CX",
+        "Benchmark": "2,274"
+    },
+    {
+        "CPU": "Mediatek MT8768N",
+        "Benchmark": "2,382"
+    },
+    {
+        "CPU": "MediaTek MT8768WA",
+        "Benchmark": "1,706"
+    },
+    {
+        "CPU": "Mediatek MT8768WE",
+        "Benchmark": "1,667"
+    },
+    {
+        "CPU": "MediaTek MT8768WT",
+        "Benchmark": "1,998"
+    },
+    {
+        "CPU": "Mediatek MT8771V/PZA",
+        "Benchmark": "4,414"
+    },
+    {
+        "CPU": "Mediatek MT8781V/CA",
+        "Benchmark": "4,117"
+    },
+    {
+        "CPU": "Mediatek MT8781V/NA",
+        "Benchmark": "4,316"
+    },
+    {
+        "CPU": "Mediatek MT8786",
+        "Benchmark": "2,56"
+    },
+    {
+        "CPU": "Mediatek MT8786V/CT",
+        "Benchmark": "3,301"
+    },
+    {
+        "CPU": "Mediatek MT8786V/N",
+        "Benchmark": "3,171"
+    },
+    {
+        "CPU": "Mediatek MT8788",
+        "Benchmark": "3,322"
+    },
+    {
+        "CPU": "Mediatek MT8789",
+        "Benchmark": "6,64"
+    },
+    {
+        "CPU": "Mediatek MT8789V/CT",
+        "Benchmark": "3,946"
+    },
+    {
+        "CPU": "Mediatek MT8789V/T",
+        "Benchmark": "4,222"
+    },
+    {
+        "CPU": "Mediatek MT8791V/TN",
+        "Benchmark": "4,809"
+    },
+    {
+        "CPU": "Mediatek MT8792",
+        "Benchmark": "8,258"
+    },
+    {
+        "CPU": "Mediatek MT8797Z/CNZA",
+        "Benchmark": "7,264"
+    },
+    {
+        "CPU": "Mediatek MT8798Z/CNZA",
+        "Benchmark": "9,11"
+    },
+    {
+        "CPU": "Mediatek t50",
+        "Benchmark": "948"
+    },
+    {
+        "CPU": "Microsoft SQ1 @ 3.0 GHz",
+        "Benchmark": "5,971"
+    },
+    {
+        "CPU": "Microsoft SQ2 @ 3.15 GHz",
+        "Benchmark": "6,534"
+    },
+    {
+        "CPU": "Microsoft SQ3 @ 3.0 GHz",
+        "Benchmark": "11,813"
+    },
+    {
+        "CPU": "Mobile AMD Athlon 2500+",
+        "Benchmark": "241"
+    },
+    {
+        "CPU": "Mobile AMD Athlon 4 2400+",
+        "Benchmark": "233"
+    },
+    {
+        "CPU": "Mobile AMD Athlon 64 3200+",
+        "Benchmark": "326"
+    },
+    {
+        "CPU": "Mobile AMD Athlon 64 3400+",
+        "Benchmark": "333"
+    },
+    {
+        "CPU": "Mobile AMD Athlon 64 3700+",
+        "Benchmark": "356"
+    },
+    {
+        "CPU": "Mobile AMD Athlon 64 4000+",
+        "Benchmark": "313"
+    },
+    {
+        "CPU": "Mobile AMD Athlon MP-M 1800+",
+        "Benchmark": "173"
+    },
+    {
+        "CPU": "Mobile AMD Athlon MP-M 2400+",
+        "Benchmark": "192"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 1600+",
+        "Benchmark": "169"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 1800+",
+        "Benchmark": "193"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 2000+",
+        "Benchmark": "196"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 2200+",
+        "Benchmark": "237"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 2400+",
+        "Benchmark": "225"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 2500+",
+        "Benchmark": "226"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 2600+",
+        "Benchmark": "241"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 2800+",
+        "Benchmark": "238"
+    },
+    {
+        "CPU": "Mobile AMD Athlon XP-M 3000+",
+        "Benchmark": "238"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 2100+",
+        "Benchmark": "164"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 2600+",
+        "Benchmark": "256"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 2800+",
+        "Benchmark": "237"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3000+",
+        "Benchmark": "269"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3100+",
+        "Benchmark": "277"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3200+",
+        "Benchmark": "245"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3300+",
+        "Benchmark": "294"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3400+",
+        "Benchmark": "269"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3500+",
+        "Benchmark": "269"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3600+",
+        "Benchmark": "284"
+    },
+    {
+        "CPU": "Mobile AMD Sempron 3800+",
+        "Benchmark": "335"
+    },
+    {
+        "CPU": "Mobile Intel Celeron 1.70GHz",
+        "Benchmark": "118"
+    },
+    {
+        "CPU": "Mobile Intel Celeron 1.80GHz",
+        "Benchmark": "121"
+    },
+    {
+        "CPU": "Mobile Intel Celeron 1333MHz",
+        "Benchmark": "183"
+    },
+    {
+        "CPU": "Mobile Intel Celeron 2.00GHz",
+        "Benchmark": "133"
+    },
+    {
+        "CPU": "Mobile Intel Celeron 2.20GHz",
+        "Benchmark": "147"
+    },
+    {
+        "CPU": "Mobile Intel Celeron 2.40GHz",
+        "Benchmark": "154"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 - M 1.70GHz",
+        "Benchmark": "121"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 - M 1.80GHz",
+        "Benchmark": "119"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 - M 2.00GHz",
+        "Benchmark": "138"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 - M 2.20GHz",
+        "Benchmark": "143"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 - M 2.40GHz",
+        "Benchmark": "139"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 2.66GHz",
+        "Benchmark": "182"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 2.80GHz",
+        "Benchmark": "205"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 3.06GHz",
+        "Benchmark": "220"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 3.20GHz",
+        "Benchmark": "232"
+    },
+    {
+        "CPU": "Mobile Intel Pentium 4 3.33GHz",
+        "Benchmark": "344"
+    },
+    {
+        "CPU": "Mobile Intel Pentium III - M 1200MHz",
+        "Benchmark": "146"
+    },
+    {
+        "CPU": "Mobile Intel Pentium III - M 933MHz",
+        "Benchmark": "130"
+    },
+    {
+        "CPU": "mocha",
+        "Benchmark": "1,125"
+    },
+    {
+        "CPU": "Montage Jintide C4215R",
+        "Benchmark": "14,672"
+    },
+    {
+        "CPU": "Montage Jintide C5418Y",
+        "Benchmark": "49,045"
+    },
+    {
+        "CPU": "[Dual CPU] Montage Jintide C6348",
+        "Benchmark": "66,555"
+    },
+    {
+        "CPU": "msm8960dt",
+        "Benchmark": "306"
+    },
+    {
+        "CPU": "MT3561S",
+        "Benchmark": "723"
+    },
+    {
+        "CPU": "MT5893",
+        "Benchmark": "702"
+    },
+    {
+        "CPU": "MT6580",
+        "Benchmark": "394"
+    },
+    {
+        "CPU": "MT6592",
+        "Benchmark": "521"
+    },
+    {
+        "CPU": "MT6592T",
+        "Benchmark": "1,056"
+    },
+    {
+        "CPU": "MT6735M",
+        "Benchmark": "308"
+    },
+    {
+        "CPU": "MT6735P",
+        "Benchmark": "384"
+    },
+    {
+        "CPU": "MT6737H",
+        "Benchmark": "528"
+    },
+    {
+        "CPU": "MT6738",
+        "Benchmark": "692"
+    },
+    {
+        "CPU": "MT6739CH",
+        "Benchmark": "533"
+    },
+    {
+        "CPU": "MT6739CW",
+        "Benchmark": "545"
+    },
+    {
+        "CPU": "MT6739WM",
+        "Benchmark": "338"
+    },
+    {
+        "CPU": "MT6750V/C",
+        "Benchmark": "1,383"
+    },
+    {
+        "CPU": "MT6750V/CS",
+        "Benchmark": "955"
+    },
+    {
+        "CPU": "MT6750V/CT",
+        "Benchmark": "1,544"
+    },
+    {
+        "CPU": "MT6750V/DN",
+        "Benchmark": "1,271"
+    },
+    {
+        "CPU": "MT6750V/W",
+        "Benchmark": "845"
+    },
+    {
+        "CPU": "MT6750V/WS",
+        "Benchmark": "934"
+    },
+    {
+        "CPU": "MT6752",
+        "Benchmark": "1,728"
+    },
+    {
+        "CPU": "MT6752M",
+        "Benchmark": "1,735"
+    },
+    {
+        "CPU": "MT6755",
+        "Benchmark": "1,278"
+    },
+    {
+        "CPU": "MT6755BM",
+        "Benchmark": "1,07"
+    },
+    {
+        "CPU": "MT6755M",
+        "Benchmark": "1,229"
+    },
+    {
+        "CPU": "MT6755V/BM",
+        "Benchmark": "1,336"
+    },
+    {
+        "CPU": "MT6755V/C",
+        "Benchmark": "1,554"
+    },
+    {
+        "CPU": "MT6755V/W",
+        "Benchmark": "1,608"
+    },
+    {
+        "CPU": "MT6755V/WM",
+        "Benchmark": "1,09"
+    },
+    {
+        "CPU": "MT6755V/WS",
+        "Benchmark": "1,389"
+    },
+    {
+        "CPU": "MT6757W",
+        "Benchmark": "1,941"
+    },
+    {
+        "CPU": "MT6757WD",
+        "Benchmark": "1,771"
+    },
+    {
+        "CPU": "MT6757WH",
+        "Benchmark": "1,161"
+    },
+    {
+        "CPU": "MT6761V/CAB",
+        "Benchmark": "818"
+    },
+    {
+        "CPU": "MT6761V/CBB",
+        "Benchmark": "910"
+    },
+    {
+        "CPU": "MT6761V/CD",
+        "Benchmark": "784"
+    },
+    {
+        "CPU": "MT6761V/WAB",
+        "Benchmark": "816"
+    },
+    {
+        "CPU": "MT6761V/WD",
+        "Benchmark": "580"
+    },
+    {
+        "CPU": "MT6762",
+        "Benchmark": "1,735"
+    },
+    {
+        "CPU": "mt6762m",
+        "Benchmark": "538"
+    },
+    {
+        "CPU": "MT6762V/CR",
+        "Benchmark": "1,022"
+    },
+    {
+        "CPU": "MT6763V/B",
+        "Benchmark": "1,633"
+    },
+    {
+        "CPU": "MT6763V/CT",
+        "Benchmark": "1,817"
+    },
+    {
+        "CPU": "MT6763V/WT",
+        "Benchmark": "1,375"
+    },
+    {
+        "CPU": "MT6765",
+        "Benchmark": "1,844"
+    },
+    {
+        "CPU": "MT6765H",
+        "Benchmark": "2,132"
+    },
+    {
+        "CPU": "MT6765V/WA",
+        "Benchmark": "1,824"
+    },
+    {
+        "CPU": "MT6765V/WB",
+        "Benchmark": "1,913"
+    },
+    {
+        "CPU": "MT6768G",
+        "Benchmark": "2,838"
+    },
+    {
+        "CPU": "MT6769V",
+        "Benchmark": "2,229"
+    },
+    {
+        "CPU": "MT6771V/CL",
+        "Benchmark": "3,079"
+    },
+    {
+        "CPU": "MT6771V/WL",
+        "Benchmark": "2,299"
+    },
+    {
+        "CPU": "mt6779",
+        "Benchmark": "2,251"
+    },
+    {
+        "CPU": "MT6781",
+        "Benchmark": "3,875"
+    },
+    {
+        "CPU": "MT6781V/CD",
+        "Benchmark": "3,969"
+    },
+    {
+        "CPU": "MT6785",
+        "Benchmark": "3,558"
+    },
+    {
+        "CPU": "MT6795",
+        "Benchmark": "1,197"
+    },
+    {
+        "CPU": "MT6795M",
+        "Benchmark": "968"
+    },
+    {
+        "CPU": "MT6795MM",
+        "Benchmark": "618"
+    },
+    {
+        "CPU": "MT6797D",
+        "Benchmark": "758"
+    },
+    {
+        "CPU": "MT6797M",
+        "Benchmark": "2,162"
+    },
+    {
+        "CPU": "MT6833",
+        "Benchmark": "3,784"
+    },
+    {
+        "CPU": "MT6833GP",
+        "Benchmark": "3,238"
+    },
+    {
+        "CPU": "MT6833P",
+        "Benchmark": "4,158"
+    },
+    {
+        "CPU": "MT6833V/NZA",
+        "Benchmark": "3,644"
+    },
+    {
+        "CPU": "MT6833V/PNZA",
+        "Benchmark": "4,178"
+    },
+    {
+        "CPU": "MT6833V/ZA",
+        "Benchmark": "4,113"
+    },
+    {
+        "CPU": "MT6853V/NZA",
+        "Benchmark": "3,33"
+    },
+    {
+        "CPU": "MT6853V/TNZA",
+        "Benchmark": "3,616"
+    },
+    {
+        "CPU": "MT6853V/ZA",
+        "Benchmark": "3,505"
+    },
+    {
+        "CPU": "MT6875",
+        "Benchmark": "4,393"
+    },
+    {
+        "CPU": "MT6877T",
+        "Benchmark": "4,548"
+    },
+    {
+        "CPU": "MT6877V/TTZA",
+        "Benchmark": "5,253"
+    },
+    {
+        "CPU": "MT6877V/TZA",
+        "Benchmark": "4,824"
+    },
+    {
+        "CPU": "MT6883Z/CZA",
+        "Benchmark": "5,665"
+    },
+    {
+        "CPU": "MT6891",
+        "Benchmark": "5,817"
+    },
+    {
+        "CPU": "MT6891Z/CZA",
+        "Benchmark": "6,025"
+    },
+    {
+        "CPU": "MT6893",
+        "Benchmark": "5,102"
+    },
+    {
+        "CPU": "MT6893Z/CZA",
+        "Benchmark": "6,467"
+    },
+    {
+        "CPU": "MT6893Z_A/CZA",
+        "Benchmark": "6,05"
+    },
+    {
+        "CPU": "MT6893Z_B/CZA",
+        "Benchmark": "6,371"
+    },
+    {
+        "CPU": "MT6893Z_C/CZA",
+        "Benchmark": "6,139"
+    },
+    {
+        "CPU": "MT6893Z_D/CZA",
+        "Benchmark": "5,701"
+    },
+    {
+        "CPU": "MT6893Z_Z/CZA",
+        "Benchmark": "6,485"
+    },
+    {
+        "CPU": "MT6969T",
+        "Benchmark": "2,228"
+    },
+    {
+        "CPU": "MT8127",
+        "Benchmark": "429"
+    },
+    {
+        "CPU": "MT8161A",
+        "Benchmark": "818"
+    },
+    {
+        "CPU": "MT8161AA",
+        "Benchmark": "857"
+    },
+    {
+        "CPU": "MT8161AB",
+        "Benchmark": "700"
+    },
+    {
+        "CPU": "MT8161P",
+        "Benchmark": "542"
+    },
+    {
+        "CPU": "MT8165",
+        "Benchmark": "962"
+    },
+    {
+        "CPU": "MT8167A",
+        "Benchmark": "478"
+    },
+    {
+        "CPU": "MT8167D",
+        "Benchmark": "532"
+    },
+    {
+        "CPU": "MT8168B",
+        "Benchmark": "1,05"
+    },
+    {
+        "CPU": "MT8168M",
+        "Benchmark": "881"
+    },
+    {
+        "CPU": "MT8169A",
+        "Benchmark": "2"
+    },
+    {
+        "CPU": "MT8173",
+        "Benchmark": "804"
+    },
+    {
+        "CPU": "MT8175B",
+        "Benchmark": "1,199"
+    },
+    {
+        "CPU": "MT8176",
+        "Benchmark": "1,406"
+    },
+    {
+        "CPU": "MT8188JV/A",
+        "Benchmark": "5,13"
+    },
+    {
+        "CPU": "MT8195AV/ZA",
+        "Benchmark": "5,735"
+    },
+    {
+        "CPU": "MT8365",
+        "Benchmark": "889"
+    },
+    {
+        "CPU": "MT8395AV/ZA",
+        "Benchmark": "2,41"
+    },
+    {
+        "CPU": "MT8667",
+        "Benchmark": "3,235"
+    },
+    {
+        "CPU": "MT8696",
+        "Benchmark": "738"
+    },
+    {
+        "CPU": "MT8732T",
+        "Benchmark": "1,081"
+    },
+    {
+        "CPU": "MT8735",
+        "Benchmark": "662"
+    },
+    {
+        "CPU": "MT8735A",
+        "Benchmark": "655"
+    },
+    {
+        "CPU": "MT8735M",
+        "Benchmark": "388"
+    },
+    {
+        "CPU": "MT8735P",
+        "Benchmark": "572"
+    },
+    {
+        "CPU": "MT8735T",
+        "Benchmark": "704"
+    },
+    {
+        "CPU": "MT8765WA",
+        "Benchmark": "567"
+    },
+    {
+        "CPU": "MT8765WB",
+        "Benchmark": "454"
+    },
+    {
+        "CPU": "MT8766A",
+        "Benchmark": "956"
+    },
+    {
+        "CPU": "MT8766B",
+        "Benchmark": "832"
+    },
+    {
+        "CPU": "MT8768CA",
+        "Benchmark": "1,912"
+    },
+    {
+        "CPU": "MT8768WB",
+        "Benchmark": "1,074"
+    },
+    {
+        "CPU": "MT8768WD",
+        "Benchmark": "1,122"
+    },
+    {
+        "CPU": "MT8768WE",
+        "Benchmark": "1,35"
+    },
+    {
+        "CPU": "MT8771V/PZA",
+        "Benchmark": "4,723"
+    },
+    {
+        "CPU": "MT8783",
+        "Benchmark": "1,039"
+    },
+    {
+        "CPU": "MT8786V/CA",
+        "Benchmark": "3,128"
+    },
+    {
+        "CPU": "MT8786V/N",
+        "Benchmark": "2,992"
+    },
+    {
+        "CPU": "MT8788",
+        "Benchmark": "2,756"
+    },
+    {
+        "CPU": "MT8789V/CT",
+        "Benchmark": "4,119"
+    },
+    {
+        "CPU": "MT8789V/T",
+        "Benchmark": "4,104"
+    },
+    {
+        "CPU": "MT8797Z/CNZA",
+        "Benchmark": "6,55"
+    },
+    {
+        "CPU": "MT9950",
+        "Benchmark": "845"
+    },
+    {
+        "CPU": "MTK6757",
+        "Benchmark": "1,158"
+    },
+    {
+        "CPU": "MTK8257",
+        "Benchmark": "842"
+    },
+    {
+        "CPU": "Nakamichi",
+        "Benchmark": "353"
+    },
+    {
+        "CPU": "Nvidia Tegra T132",
+        "Benchmark": "1,242"
+    },
+    {
+        "CPU": "Nvidia Tegra T210",
+        "Benchmark": "1,746"
+    },
+    {
+        "CPU": "nxp IMX8MP",
+        "Benchmark": "868"
+    },
+    {
+        "CPU": "nxp IMX8MQ",
+        "Benchmark": "831"
+    },
+    {
+        "CPU": "Odin based on Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "6,455"
+    },
+    {
+        "CPU": "OMAP4 Espresso board",
+        "Benchmark": "98"
+    },
+    {
+        "CPU": "P22",
+        "Benchmark": "1,908"
+    },
+    {
+        "CPU": "Pentium Dual-Core E6000 @ 3.46GHz",
+        "Benchmark": "1,472"
+    },
+    {
+        "CPU": "Pentium Dual-Core T4200 @ 2.00GHz",
+        "Benchmark": "775"
+    },
+    {
+        "CPU": "Pentium Dual-Core T4300 @ 2.10GHz",
+        "Benchmark": "903"
+    },
+    {
+        "CPU": "Pentium Dual-Core T4500 @ 2.30GHz",
+        "Benchmark": "955"
+    },
+    {
+        "CPU": "PXA1908",
+        "Benchmark": "486"
+    },
+    {
+        "CPU": "QCT APQ8064 AWIFI",
+        "Benchmark": "382"
+    },
+    {
+        "CPU": "QCT APQ8064 DEB",
+        "Benchmark": "453"
+    },
+    {
+        "CPU": "QCT APQ8064 FLO",
+        "Benchmark": "553"
+    },
+    {
+        "CPU": "QCT APQ8064 MAKO",
+        "Benchmark": "399"
+    },
+    {
+        "CPU": "QCT APQ8064 MTP",
+        "Benchmark": "389"
+    },
+    {
+        "CPU": "QTI MSM8937",
+        "Benchmark": "2,142"
+    },
+    {
+        "CPU": "QTI MSM8953",
+        "Benchmark": "2,065"
+    },
+    {
+        "CPU": "QTI QCM2290",
+        "Benchmark": "1,078"
+    },
+    {
+        "CPU": "QTI QCM4290",
+        "Benchmark": "2,512"
+    },
+    {
+        "CPU": "QTI QCM4325",
+        "Benchmark": "2,526"
+    },
+    {
+        "CPU": "QTI QCM4490",
+        "Benchmark": "5,12"
+    },
+    {
+        "CPU": "QTI QCM5430",
+        "Benchmark": "4,006"
+    },
+    {
+        "CPU": "QTI QCS4490",
+        "Benchmark": "5,179"
+    },
+    {
+        "CPU": "QTI QCS5430",
+        "Benchmark": "3,76"
+    },
+    {
+        "CPU": "QTI QCS8550",
+        "Benchmark": "10,487"
+    },
+    {
+        "CPU": "QTI QM215",
+        "Benchmark": "563"
+    },
+    {
+        "CPU": "QTI SDM439",
+        "Benchmark": "1,56"
+    },
+    {
+        "CPU": "QTI SDM450",
+        "Benchmark": "1,633"
+    },
+    {
+        "CPU": "QTI SDM660",
+        "Benchmark": "2,61"
+    },
+    {
+        "CPU": "QTI SDM845",
+        "Benchmark": "3,684"
+    },
+    {
+        "CPU": "QTI SG8175P",
+        "Benchmark": "6,713"
+    },
+    {
+        "CPU": "QTI SM4250",
+        "Benchmark": "2,631"
+    },
+    {
+        "CPU": "QTI SM4350",
+        "Benchmark": "3,701"
+    },
+    {
+        "CPU": "QTI SM4375",
+        "Benchmark": "3,936"
+    },
+    {
+        "CPU": "QTI SM4450",
+        "Benchmark": "4,19"
+    },
+    {
+        "CPU": "QTI SM4635",
+        "Benchmark": "3,618"
+    },
+    {
+        "CPU": "QTI SM611",
+        "Benchmark": "3,18"
+    },
+    {
+        "CPU": "QTI SM6115",
+        "Benchmark": "2,875"
+    },
+    {
+        "CPU": "QTI SM6125",
+        "Benchmark": "2,855"
+    },
+    {
+        "CPU": "QTI SM6150",
+        "Benchmark": "3,328"
+    },
+    {
+        "CPU": "QTI SM6225",
+        "Benchmark": "3,486"
+    },
+    {
+        "CPU": "QTI SM6350",
+        "Benchmark": "4,09"
+    },
+    {
+        "CPU": "QTI SM6375",
+        "Benchmark": "4,181"
+    },
+    {
+        "CPU": "QTI SM6450",
+        "Benchmark": "5,88"
+    },
+    {
+        "CPU": "QTI SM6450P",
+        "Benchmark": "6,321"
+    },
+    {
+        "CPU": "QTI SM6475",
+        "Benchmark": "5,755"
+    },
+    {
+        "CPU": "QTI SM6650",
+        "Benchmark": "5,972"
+    },
+    {
+        "CPU": "QTI SM7125",
+        "Benchmark": "3,885"
+    },
+    {
+        "CPU": "QTI SM7150",
+        "Benchmark": "3,742"
+    },
+    {
+        "CPU": "QTI SM7225",
+        "Benchmark": "4,277"
+    },
+    {
+        "CPU": "QTI SM7250",
+        "Benchmark": "4,277"
+    },
+    {
+        "CPU": "QTI SM7325",
+        "Benchmark": "5,937"
+    },
+    {
+        "CPU": "QTI SM7350",
+        "Benchmark": "5,634"
+    },
+    {
+        "CPU": "QTI SM7435",
+        "Benchmark": "5,746"
+    },
+    {
+        "CPU": "QTI SM7450",
+        "Benchmark": "5,587"
+    },
+    {
+        "CPU": "QTI SM7475",
+        "Benchmark": "7,263"
+    },
+    {
+        "CPU": "QTI SM7550",
+        "Benchmark": "6,764"
+    },
+    {
+        "CPU": "QTI SM7635",
+        "Benchmark": "6,103"
+    },
+    {
+        "CPU": "QTI SM7675",
+        "Benchmark": "8,603"
+    },
+    {
+        "CPU": "QTI SM8150",
+        "Benchmark": "5,363"
+    },
+    {
+        "CPU": "QTI SM8250",
+        "Benchmark": "6,586"
+    },
+    {
+        "CPU": "QTI SM8350",
+        "Benchmark": "6,505"
+    },
+    {
+        "CPU": "QTI SM8450",
+        "Benchmark": "6,411"
+    },
+    {
+        "CPU": "QTI SM8475",
+        "Benchmark": "7,333"
+    },
+    {
+        "CPU": "QTI SM8550",
+        "Benchmark": "9,091"
+    },
+    {
+        "CPU": "QTI SM8635",
+        "Benchmark": "8,395"
+    },
+    {
+        "CPU": "QTI SM8650",
+        "Benchmark": "11,437"
+    },
+    {
+        "CPU": "QTI SM8750",
+        "Benchmark": "12,104"
+    },
+    {
+        "CPU": "Qualcomm",
+        "Benchmark": "1,354"
+    },
+    {
+        "CPU": "Qualcomm APQ 8084 (Flattened Device Tree)",
+        "Benchmark": "720"
+    },
+    {
+        "CPU": "Qualcomm APQ8026",
+        "Benchmark": "330"
+    },
+    {
+        "CPU": "Qualcomm APQ8084",
+        "Benchmark": "605"
+    },
+    {
+        "CPU": "Qualcomm MSM 8939 HUAWEI KIW-L21",
+        "Benchmark": "1,088"
+    },
+    {
+        "CPU": "Qualcomm MSM 8939 HUAWEI KIW-L24",
+        "Benchmark": "1,065"
+    },
+    {
+        "CPU": "Qualcomm MSM 8939 HUAWEI TEXAS-A1",
+        "Benchmark": "1,085"
+    },
+    {
+        "CPU": "Qualcomm MSM 8974 HAMMERHEAD (Flattened Device Tre",
+        "Benchmark": "566"
+    },
+    {
+        "CPU": "Qualcomm MSM8212",
+        "Benchmark": "378"
+    },
+    {
+        "CPU": "Qualcomm MSM8226",
+        "Benchmark": "344"
+    },
+    {
+        "CPU": "Qualcomm MSM8228",
+        "Benchmark": "332"
+    },
+    {
+        "CPU": "Qualcomm MSM8626",
+        "Benchmark": "294"
+    },
+    {
+        "CPU": "Qualcomm MSM8916",
+        "Benchmark": "424"
+    },
+    {
+        "CPU": "Qualcomm MSM8917",
+        "Benchmark": "656"
+    },
+    {
+        "CPU": "Qualcomm MSM8926",
+        "Benchmark": "310"
+    },
+    {
+        "CPU": "Qualcomm MSM8928",
+        "Benchmark": "367"
+    },
+    {
+        "CPU": "Qualcomm MSM8937",
+        "Benchmark": "1,047"
+    },
+    {
+        "CPU": "Qualcomm MSM8939",
+        "Benchmark": "1,18"
+    },
+    {
+        "CPU": "Qualcomm MSM8953",
+        "Benchmark": "1,589"
+    },
+    {
+        "CPU": "Qualcomm MSM8956",
+        "Benchmark": "2,127"
+    },
+    {
+        "CPU": "Qualcomm MSM8974",
+        "Benchmark": "732"
+    },
+    {
+        "CPU": "Qualcomm MSM8974PRO-AA",
+        "Benchmark": "721"
+    },
+    {
+        "CPU": "Qualcomm MSM8974PRO-AB",
+        "Benchmark": "692"
+    },
+    {
+        "CPU": "Qualcomm MSM8974PRO-AC",
+        "Benchmark": "658"
+    },
+    {
+        "CPU": "Qualcomm MSM8976",
+        "Benchmark": "1,749"
+    },
+    {
+        "CPU": "Qualcomm MSM8992",
+        "Benchmark": "1,268"
+    },
+    {
+        "CPU": "Qualcomm MSM8994",
+        "Benchmark": "785"
+    },
+    {
+        "CPU": "Qualcomm MSM8996",
+        "Benchmark": "1,455"
+    },
+    {
+        "CPU": "Qualcomm MSM8996PRO-AB",
+        "Benchmark": "1,667"
+    },
+    {
+        "CPU": "Qualcomm MSM8998",
+        "Benchmark": "3,532"
+    },
+    {
+        "CPU": "Qualcomm QCM6490",
+        "Benchmark": "6,068"
+    },
+    {
+        "CPU": "Qualcomm QCS6490",
+        "Benchmark": "6,237"
+    },
+    {
+        "CPU": "Qualcomm SA8155P",
+        "Benchmark": "4,257"
+    },
+    {
+        "CPU": "Qualcomm SA8195P",
+        "Benchmark": "5,168"
+    },
+    {
+        "CPU": "Qualcomm SC7180",
+        "Benchmark": "3,239"
+    },
+    {
+        "CPU": "Qualcomm SC7180P",
+        "Benchmark": "4,583"
+    },
+    {
+        "CPU": "Qualcomm SDM439",
+        "Benchmark": "2,195"
+    },
+    {
+        "CPU": "Qualcomm SDM450",
+        "Benchmark": "2,808"
+    },
+    {
+        "CPU": "Qualcomm SDM630",
+        "Benchmark": "2,429"
+    },
+    {
+        "CPU": "Qualcomm SDM660",
+        "Benchmark": "2,444"
+    },
+    {
+        "CPU": "Qualcomm SDM670",
+        "Benchmark": "3,241"
+    },
+    {
+        "CPU": "Qualcomm SDM845",
+        "Benchmark": "4,413"
+    },
+    {
+        "CPU": "Qualcomm SM4250",
+        "Benchmark": "2,55"
+    },
+    {
+        "CPU": "Qualcomm SM4350",
+        "Benchmark": "3,603"
+    },
+    {
+        "CPU": "Qualcomm SM6115",
+        "Benchmark": "3,107"
+    },
+    {
+        "CPU": "Qualcomm SM6125",
+        "Benchmark": "2,938"
+    },
+    {
+        "CPU": "Qualcomm SM6150",
+        "Benchmark": "3,414"
+    },
+    {
+        "CPU": "Qualcomm SM6225",
+        "Benchmark": "3,781"
+    },
+    {
+        "CPU": "Qualcomm SM6375",
+        "Benchmark": "4,85"
+    },
+    {
+        "CPU": "Qualcomm SM7125",
+        "Benchmark": "3,788"
+    },
+    {
+        "CPU": "Qualcomm SM7150",
+        "Benchmark": "4,085"
+    },
+    {
+        "CPU": "Qualcomm SM7250",
+        "Benchmark": "3,953"
+    },
+    {
+        "CPU": "Qualcomm SM7325",
+        "Benchmark": "6,071"
+    },
+    {
+        "CPU": "Qualcomm SM8150",
+        "Benchmark": "5,718"
+    },
+    {
+        "CPU": "Qualcomm SM8250",
+        "Benchmark": "6,7"
+    },
+    {
+        "CPU": "Qualcomm SM8350",
+        "Benchmark": "6,558"
+    },
+    {
+        "CPU": "Qualcomm Snapdragon 810",
+        "Benchmark": "1,316"
+    },
+    {
+        "CPU": "Qualcomm Snapdragon X Elite - X1E-78-100",
+        "Benchmark": "22,813"
+    },
+    {
+        "CPU": "Qualcomm Snapdragon X Elite - X1E-80-100",
+        "Benchmark": "23,068"
+    },
+    {
+        "CPU": "Qualcomm Snapdragon X Elite - X1E-84-100",
+        "Benchmark": "25,035"
+    },
+    {
+        "CPU": "Qualcomm Snapdragon X Elite - X1E001DE",
+        "Benchmark": "31,863"
+    },
+    {
+        "CPU": "Qualcomm Snapdragon X Plus X1P-64-100",
+        "Benchmark": "21,62"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc",
+        "Benchmark": "3,865"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc 450",
+        "Benchmark": "1,978"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8009",
+        "Benchmark": "346"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8016",
+        "Benchmark": "406"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8017",
+        "Benchmark": "546"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8053",
+        "Benchmark": "2,123"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8076",
+        "Benchmark": "1,673"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8094",
+        "Benchmark": "1,564"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8096",
+        "Benchmark": "1,734"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc APQ8096pro",
+        "Benchmark": "730"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc ATOLL-AB",
+        "Benchmark": "3,475"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc BENGAL",
+        "Benchmark": "2,451"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc BENGAL-IOT",
+        "Benchmark": "2,175"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc BENGALP",
+        "Benchmark": "2,636"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc BENGALP-IOT",
+        "Benchmark": "3,127"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc KHAJE",
+        "Benchmark": "3,405"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc KONA",
+        "Benchmark": "5,666"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc KONA-IOT",
+        "Benchmark": "6,752"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc LAGOON",
+        "Benchmark": "3,435"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc LITO",
+        "Benchmark": "3,357"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8216",
+        "Benchmark": "292"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8909",
+        "Benchmark": "293"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8916",
+        "Benchmark": "411"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8917",
+        "Benchmark": "536"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8920",
+        "Benchmark": "487"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8929",
+        "Benchmark": "560"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8937",
+        "Benchmark": "1,103"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8939",
+        "Benchmark": "959"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8952",
+        "Benchmark": "912"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8953",
+        "Benchmark": "1,833"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8956",
+        "Benchmark": "1,536"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8976",
+        "Benchmark": "1,818"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8976SG",
+        "Benchmark": "2,139"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8992",
+        "Benchmark": "878"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8994",
+        "Benchmark": "1,073"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8996",
+        "Benchmark": "1,427"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8996pro",
+        "Benchmark": "1,58"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc MSM8998",
+        "Benchmark": "2,844"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc QCM2150",
+        "Benchmark": "409"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc QCM6125",
+        "Benchmark": "2,775"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc QCS610",
+        "Benchmark": "1,949"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc QM215",
+        "Benchmark": "461"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SA8195P",
+        "Benchmark": "6,554"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SCUBAIIOT",
+        "Benchmark": "926"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SCUBAPIIOT",
+        "Benchmark": "1,123"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDA429W",
+        "Benchmark": "715"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDA450",
+        "Benchmark": "1,507"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDA660",
+        "Benchmark": "2,853"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM429",
+        "Benchmark": "1,027"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM439",
+        "Benchmark": "1,495"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM450",
+        "Benchmark": "1,351"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM460",
+        "Benchmark": "2,041"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM630",
+        "Benchmark": "1,938"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM632",
+        "Benchmark": "2,091"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM636",
+        "Benchmark": "2,199"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM660",
+        "Benchmark": "2,436"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM662",
+        "Benchmark": "2,237"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM665",
+        "Benchmark": "2,396"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM670",
+        "Benchmark": "2,572"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM710",
+        "Benchmark": "2,709"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM712",
+        "Benchmark": "2,614"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM720G",
+        "Benchmark": "3,289"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM730G AIE",
+        "Benchmark": "3,421"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM750G",
+        "Benchmark": "4,35"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM765G 5G",
+        "Benchmark": "3,425"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM778G",
+        "Benchmark": "5,553"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDM845",
+        "Benchmark": "3,391"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDMMAGPIE",
+        "Benchmark": "3,16"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SDMMAGPIEP",
+        "Benchmark": "3,523"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM4250",
+        "Benchmark": "2,139"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM4350",
+        "Benchmark": "3,087"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM6125",
+        "Benchmark": "2,277"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM6150",
+        "Benchmark": "2,942"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM6225",
+        "Benchmark": "2,692"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM6375",
+        "Benchmark": "4,266"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM7125",
+        "Benchmark": "3,377"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM7150",
+        "Benchmark": "3,271"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM7225",
+        "Benchmark": "3,39"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM7250",
+        "Benchmark": "3,459"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM7325",
+        "Benchmark": "6,431"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8150",
+        "Benchmark": "4,6"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8150_Plus",
+        "Benchmark": "4,212"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8150P",
+        "Benchmark": "4,495"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8250",
+        "Benchmark": "5,861"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8250_AC",
+        "Benchmark": "6,416"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "6,117"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc SM8350AC",
+        "Benchmark": "6,588"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc TRINKET",
+        "Benchmark": "2,463"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc TRINKET-IOT",
+        "Benchmark": "2,559"
+    },
+    {
+        "CPU": "Qualcomm Technologies, Inc. MSM8940-PMI8940 MTP",
+        "Benchmark": "1,426"
+    },
+    {
+        "CPU": "redwood based Qualcomm Technologies, Inc. SM7325",
+        "Benchmark": "6,448"
+    },
+    {
+        "CPU": "Renoir based on Qualcomm Technologies, Inc SM7350",
+        "Benchmark": "4,886"
+    },
+    {
+        "CPU": "RK30board",
+        "Benchmark": "198"
+    },
+    {
+        "CPU": "rk3399",
+        "Benchmark": "2,046"
+    },
+    {
+        "CPU": "rk3566",
+        "Benchmark": "595"
+    },
+    {
+        "CPU": "RK3568 AIoT3568 Board V2.1-AD52068, LVDS(8775), HD",
+        "Benchmark": "1,178"
+    },
+    {
+        "CPU": "ROC-RK3568-PC HDMI (Android)",
+        "Benchmark": "1,197"
+    },
+    {
+        "CPU": "Rockchip (Device Tree)",
+        "Benchmark": "666"
+    },
+    {
+        "CPU": "Rockchip RK",
+        "Benchmark": "1,246"
+    },
+    {
+        "CPU": "Rockchip RK3228A",
+        "Benchmark": "314"
+    },
+    {
+        "CPU": "Rockchip RK3229",
+        "Benchmark": "285"
+    },
+    {
+        "CPU": "Rockchip RK3288",
+        "Benchmark": "708"
+    },
+    {
+        "CPU": "Rockchip RK3288 (Flattened Device Tree)",
+        "Benchmark": "515"
+    },
+    {
+        "CPU": "Rockchip RK3326",
+        "Benchmark": "431"
+    },
+    {
+        "CPU": "Rockchip rk3326 863 rkisp1 board",
+        "Benchmark": "365"
+    },
+    {
+        "CPU": "Rockchip rk3326 evb board",
+        "Benchmark": "463"
+    },
+    {
+        "CPU": "Rockchip RK3328",
+        "Benchmark": "319"
+    },
+    {
+        "CPU": "Rockchip RK3328 box liantong avb",
+        "Benchmark": "491"
+    },
+    {
+        "CPU": "Rockchip RK3368",
+        "Benchmark": "827"
+    },
+    {
+        "CPU": "Rockchip RK3399",
+        "Benchmark": "2,925"
+    },
+    {
+        "CPU": "Rockchip RK3399 Board (Android)",
+        "Benchmark": "1,456"
+    },
+    {
+        "CPU": "Rockchip RK3399 EVB IND LPDDR4 Board lvds (Android",
+        "Benchmark": "1,862"
+    },
+    {
+        "CPU": "Rockchip RK3399 Excavator Board edp avb (Android)",
+        "Benchmark": "1,533"
+    },
+    {
+        "CPU": "Rockchip RK3399 Generic Board edp (Android)",
+        "Benchmark": "391"
+    },
+    {
+        "CPU": "Rockchip RK3528 DEMO4 DDR4 V10 Board",
+        "Benchmark": "888"
+    },
+    {
+        "CPU": "Rockchip RK3562",
+        "Benchmark": "1,058"
+    },
+    {
+        "CPU": "Rockchip RK3566",
+        "Benchmark": "922"
+    },
+    {
+        "CPU": "Rockchip RK3566 BOX DEMO V10 ANDROID Board",
+        "Benchmark": "1,093"
+    },
+    {
+        "CPU": "Rockchip RK3566 EVB1 DDR4 V10 Board",
+        "Benchmark": "751"
+    },
+    {
+        "CPU": "Rockchip RK3566 EVB2 LP4X V10 Board",
+        "Benchmark": "933"
+    },
+    {
+        "CPU": "Rockchip RK3566 EVB2 LP4X V10 Board PDM Mic Array",
+        "Benchmark": "337"
+    },
+    {
+        "CPU": "Rockchip RK3566 EVB3 DDR3 V10 Board",
+        "Benchmark": "994"
+    },
+    {
+        "CPU": "Rockchip RK3566 HD15 Board",
+        "Benchmark": "1,16"
+    },
+    {
+        "CPU": "Rockchip RK3566 RK817 EINK LP4X Board",
+        "Benchmark": "667"
+    },
+    {
+        "CPU": "Rockchip RK3566 RK817 TABLET LP4X Board",
+        "Benchmark": "1,021"
+    },
+    {
+        "CPU": "Rockchip RK3566 RK817 TABLET RKG11 LP4 Board",
+        "Benchmark": "686"
+    },
+    {
+        "CPU": "Rockchip RK3566 RK817 ZIDOO TABLET LP4X Board",
+        "Benchmark": "795"
+    },
+    {
+        "CPU": "Rockchip RK3568",
+        "Benchmark": "1,193"
+    },
+    {
+        "CPU": "Rockchip RK3568 EVB1 DDR4 V10 Board",
+        "Benchmark": "1,082"
+    },
+    {
+        "CPU": "Rockchip RK3568 EVB2 LP4X V10 Board",
+        "Benchmark": "915"
+    },
+    {
+        "CPU": "Rockchip RK3568 EVB7 DDR4 V10 Board",
+        "Benchmark": "1,106"
+    },
+    {
+        "CPU": "Rockchip RK3576",
+        "Benchmark": "3,675"
+    },
+    {
+        "CPU": "Rockchip RK3588",
+        "Benchmark": "4,53"
+    },
+    {
+        "CPU": "rockchip,rk3328",
+        "Benchmark": "453"
+    },
+    {
+        "CPU": "rockchip,rk3368",
+        "Benchmark": "870"
+    },
+    {
+        "CPU": "Samsung \"Exynos 9610\"",
+        "Benchmark": "3,168"
+    },
+    {
+        "CPU": "Samsung A04S EUR OPEN REV03C board based on EXYNOS",
+        "Benchmark": "2,452"
+    },
+    {
+        "CPU": "Samsung A13 EUR OPEN REV02B board based on EXYNOS8",
+        "Benchmark": "1,23"
+    },
+    {
+        "CPU": "Samsung A13 USA SINGLE REV02B board based on EXYNO",
+        "Benchmark": "1,528"
+    },
+    {
+        "CPU": "SAMSUNG EXPRESS2",
+        "Benchmark": "233"
+    },
+    {
+        "CPU": "Samsung Exynos",
+        "Benchmark": "2,423"
+    },
+    {
+        "CPU": "Samsung Exynos 2100",
+        "Benchmark": "5,509"
+    },
+    {
+        "CPU": "Samsung Exynos 7420",
+        "Benchmark": "2,164"
+    },
+    {
+        "CPU": "Samsung Exynos 7570",
+        "Benchmark": "474"
+    },
+    {
+        "CPU": "Samsung Exynos 7580",
+        "Benchmark": "878"
+    },
+    {
+        "CPU": "Samsung Exynos 7870",
+        "Benchmark": "1,041"
+    },
+    {
+        "CPU": "Samsung Exynos 7880",
+        "Benchmark": "1,818"
+    },
+    {
+        "CPU": "Samsung Exynos 7884",
+        "Benchmark": "1,576"
+    },
+    {
+        "CPU": "Samsung Exynos 7885",
+        "Benchmark": "1,836"
+    },
+    {
+        "CPU": "Samsung Exynos 7904",
+        "Benchmark": "1,841"
+    },
+    {
+        "CPU": "Samsung Exynos 850",
+        "Benchmark": "2,091"
+    },
+    {
+        "CPU": "Samsung Exynos 8890",
+        "Benchmark": "2,595"
+    },
+    {
+        "CPU": "Samsung Exynos 8895",
+        "Benchmark": "3,165"
+    },
+    {
+        "CPU": "Samsung Exynos 9610",
+        "Benchmark": "2,27"
+    },
+    {
+        "CPU": "Samsung Exynos 9611",
+        "Benchmark": "2,555"
+    },
+    {
+        "CPU": "Samsung Exynos 980",
+        "Benchmark": "4,584"
+    },
+    {
+        "CPU": "Samsung Exynos 9810",
+        "Benchmark": "3,772"
+    },
+    {
+        "CPU": "Samsung Exynos 9820",
+        "Benchmark": "3,974"
+    },
+    {
+        "CPU": "Samsung Exynos 9825",
+        "Benchmark": "3,792"
+    },
+    {
+        "CPU": "Samsung Exynos 990",
+        "Benchmark": "6,079"
+    },
+    {
+        "CPU": "Samsung EXYNOS5420",
+        "Benchmark": "704"
+    },
+    {
+        "CPU": "Samsung EXYNOS5430",
+        "Benchmark": "1,38"
+    },
+    {
+        "CPU": "Samsung EXYNOS5433",
+        "Benchmark": "1,178"
+    },
+    {
+        "CPU": "SAMSUNG Exynos7420",
+        "Benchmark": "2,05"
+    },
+    {
+        "CPU": "SAMSUNG Exynos7580",
+        "Benchmark": "910"
+    },
+    {
+        "CPU": "Samsung Exynos7870",
+        "Benchmark": "2,093"
+    },
+    {
+        "CPU": "samsung exynos7885",
+        "Benchmark": "2,496"
+    },
+    {
+        "CPU": "Samsung GrandPrimePlus LTE CIS rev04 board based o",
+        "Benchmark": "312"
+    },
+    {
+        "CPU": "Samsung GrandPrimePlus LTE LTN DTV rev04 board bas",
+        "Benchmark": "599"
+    },
+    {
+        "CPU": "Samsung GrandPrimePlus LTE LTN OPEN rev04 board ba",
+        "Benchmark": "415"
+    },
+    {
+        "CPU": "Samsung J7 Max LTE SWA board based on MT6757V/WL",
+        "Benchmark": "928"
+    },
+    {
+        "CPU": "SAMSUNG JF",
+        "Benchmark": "540"
+    },
+    {
+        "CPU": "Samsung M13 EUR OPEN REV02 board based on EXYNOS85",
+        "Benchmark": "1,425"
+    },
+    {
+        "CPU": "Samsung M13 SWA INS 00 board based on EXYNOS850",
+        "Benchmark": "1,269"
+    },
+    {
+        "CPU": "Samsung s5e8535",
+        "Benchmark": "4,565"
+    },
+    {
+        "CPU": "Samsung s5e8825",
+        "Benchmark": "4,474"
+    },
+    {
+        "CPU": "Samsung s5e8835",
+        "Benchmark": "5,976"
+    },
+    {
+        "CPU": "Samsung s5e8845",
+        "Benchmark": "7,04"
+    },
+    {
+        "CPU": "Samsung s5e8855",
+        "Benchmark": "7,569"
+    },
+    {
+        "CPU": "Samsung s5e9925",
+        "Benchmark": "6,474"
+    },
+    {
+        "CPU": "Samsung s5e9945",
+        "Benchmark": "10,974"
+    },
+    {
+        "CPU": "SAMSUNG SERRANO",
+        "Benchmark": "266"
+    },
+    {
+        "CPU": "Samsung Technologies, Inc Exynos E1080",
+        "Benchmark": "4,846"
+    },
+    {
+        "CPU": "sc8830",
+        "Benchmark": "438"
+    },
+    {
+        "CPU": "SM6375",
+        "Benchmark": "4,441"
+    },
+    {
+        "CPU": "SM7325",
+        "Benchmark": "6,074"
+    },
+    {
+        "CPU": "SM8325",
+        "Benchmark": "5,629"
+    },
+    {
+        "CPU": "SM8350",
+        "Benchmark": "6,134"
+    },
+    {
+        "CPU": "SM8450",
+        "Benchmark": "4,896"
+    },
+    {
+        "CPU": "SMDK4x12",
+        "Benchmark": "3,006"
+    },
+    {
+        "CPU": "Snapdragon 435",
+        "Benchmark": "1,069"
+    },
+    {
+        "CPU": "Snapdragon 662",
+        "Benchmark": "2,431"
+    },
+    {
+        "CPU": "Snapdragon 7325",
+        "Benchmark": "5,561"
+    },
+    {
+        "CPU": "Snapdragon 7c @ 1.96 GHz",
+        "Benchmark": "3,712"
+    },
+    {
+        "CPU": "Snapdragon 7c @ 2.40 GHz",
+        "Benchmark": "3,423"
+    },
+    {
+        "CPU": "Snapdragon 7c Gen 2 @ 2.55 GHz",
+        "Benchmark": "3,857"
+    },
+    {
+        "CPU": "Snapdragon 7cPlus Gen 3 @ 2.40 GHz",
+        "Benchmark": "6,044"
+    },
+    {
+        "CPU": "Snapdragon 8 Gen2 Mobile Platform for Galaxy",
+        "Benchmark": "9,362"
+    },
+    {
+        "CPU": "Snapdragon 835",
+        "Benchmark": "2,45"
+    },
+    {
+        "CPU": "Snapdragon 835 @ 2.45 GHz",
+        "Benchmark": "3,524"
+    },
+    {
+        "CPU": "Snapdragon 8350",
+        "Benchmark": "4,613"
+    },
+    {
+        "CPU": "Snapdragon 845 @ 2.8 GHz",
+        "Benchmark": "3,446"
+    },
+    {
+        "CPU": "Snapdragon 850 @ 2.40 GHz",
+        "Benchmark": "2,946"
+    },
+    {
+        "CPU": "Snapdragon 850 @ 2.96 GHz",
+        "Benchmark": "3,326"
+    },
+    {
+        "CPU": "Snapdragon 855 @ 2.84 GHz",
+        "Benchmark": "5,07"
+    },
+    {
+        "CPU": "Snapdragon 860 @ 2.96 GHz",
+        "Benchmark": "4,804"
+    },
+    {
+        "CPU": "Snapdragon 8c @ 2.46 GHz",
+        "Benchmark": "5,23"
+    },
+    {
+        "CPU": "Snapdragon 8cx @ 2.84 GHz",
+        "Benchmark": "5,088"
+    },
+    {
+        "CPU": "Snapdragon 8cx Gen 2 @ 3.0 GHz",
+        "Benchmark": "6,796"
+    },
+    {
+        "CPU": "Snapdragon 8cx Gen 2 @ 3.15 GHz",
+        "Benchmark": "6,692"
+    },
+    {
+        "CPU": "Snapdragon 8cx Gen 3 @ 2.69 GHz",
+        "Benchmark": "10,11"
+    },
+    {
+        "CPU": "Snapdragon 8cx Gen 3 @ 3.0",
+        "Benchmark": "1,811"
+    },
+    {
+        "CPU": "Snapdragon 8cx Gen 3 @ 3.0 GHz",
+        "Benchmark": "11,817"
+    },
+    {
+        "CPU": "Snapdragon X - X126100 - Qualcomm Oryon",
+        "Benchmark": "17,356"
+    },
+    {
+        "CPU": "Snapdragon X Plus - X1P42100 - Qualcomm Ory",
+        "Benchmark": "18,221"
+    },
+    {
+        "CPU": "Sony Mobile fusion3",
+        "Benchmark": "428"
+    },
+    {
+        "CPU": "Spreadtrum SC7731e",
+        "Benchmark": "329"
+    },
+    {
+        "CPU": "Spreadtrum SC9832E",
+        "Benchmark": "520"
+    },
+    {
+        "CPU": "Spreadtrum SC9853I-IA",
+        "Benchmark": "748"
+    },
+    {
+        "CPU": "Spreadtrum SC9863A",
+        "Benchmark": "1,429"
+    },
+    {
+        "CPU": "Spreadtrum SC9863A Board",
+        "Benchmark": "1,671"
+    },
+    {
+        "CPU": "Spreadtrum T310",
+        "Benchmark": "1,586"
+    },
+    {
+        "CPU": "Spreadtrum T603",
+        "Benchmark": "1,765"
+    },
+    {
+        "CPU": "Spreadtrum T606",
+        "Benchmark": "2,747"
+    },
+    {
+        "CPU": "Spreadtrum T610",
+        "Benchmark": "2,747"
+    },
+    {
+        "CPU": "Spreadtrum T612",
+        "Benchmark": "3,007"
+    },
+    {
+        "CPU": "Spreadtrum T615",
+        "Benchmark": "2,954"
+    },
+    {
+        "CPU": "Spreadtrum T616",
+        "Benchmark": "2,92"
+    },
+    {
+        "CPU": "Spreadtrum T618",
+        "Benchmark": "2,933"
+    },
+    {
+        "CPU": "Spreadtrum T620",
+        "Benchmark": "2,906"
+    },
+    {
+        "CPU": "Spreadtrum T760",
+        "Benchmark": "5,165"
+    },
+    {
+        "CPU": "Spreadtrum T765",
+        "Benchmark": "3,804"
+    },
+    {
+        "CPU": "Spreadtrum T820",
+        "Benchmark": "5,455"
+    },
+    {
+        "CPU": "Spreadtrum UIS7885(prototype)",
+        "Benchmark": "5,668"
+    },
+    {
+        "CPU": "Star based on Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "5,241"
+    },
+    {
+        "CPU": "sun50iw1p1",
+        "Benchmark": "559"
+    },
+    {
+        "CPU": "sun50iw6",
+        "Benchmark": "498"
+    },
+    {
+        "CPU": "sun8iw11p1",
+        "Benchmark": "335"
+    },
+    {
+        "CPU": "sun8iw7",
+        "Benchmark": "237"
+    },
+    {
+        "CPU": "Synaptics VS640",
+        "Benchmark": "862"
+    },
+    {
+        "CPU": "T606",
+        "Benchmark": "2,824"
+    },
+    {
+        "CPU": "T610-Unisoc",
+        "Benchmark": "2,565"
+    },
+    {
+        "CPU": "T610S-Unisoc",
+        "Benchmark": "2,781"
+    },
+    {
+        "CPU": "T618",
+        "Benchmark": "2,772"
+    },
+    {
+        "CPU": "T700-Unisoc",
+        "Benchmark": "2,421"
+    },
+    {
+        "CPU": "taoyao based Qualcomm Technologies, Inc. Yupik IDP",
+        "Benchmark": "6,359"
+    },
+    {
+        "CPU": "Thor",
+        "Benchmark": "839"
+    },
+    {
+        "CPU": "tn8",
+        "Benchmark": "1,027"
+    },
+    {
+        "CPU": "UGOOS UT8 Board",
+        "Benchmark": "1,152"
+    },
+    {
+        "CPU": "UIS7862A",
+        "Benchmark": "2,638"
+    },
+    {
+        "CPU": "Unisoc SC7731e",
+        "Benchmark": "337"
+    },
+    {
+        "CPU": "Unisoc SC9832e",
+        "Benchmark": "501"
+    },
+    {
+        "CPU": "Unisoc SC9863a",
+        "Benchmark": "1,434"
+    },
+    {
+        "CPU": "Unisoc SC9863A1",
+        "Benchmark": "1,399"
+    },
+    {
+        "CPU": "Unisoc T310",
+        "Benchmark": "1,421"
+    },
+    {
+        "CPU": "Unisoc T606",
+        "Benchmark": "2,645"
+    },
+    {
+        "CPU": "Unisoc T610",
+        "Benchmark": "2,812"
+    },
+    {
+        "CPU": "Unisoc T612",
+        "Benchmark": "2,632"
+    },
+    {
+        "CPU": "Unisoc T616",
+        "Benchmark": "3,152"
+    },
+    {
+        "CPU": "Unisoc T618",
+        "Benchmark": "2,577"
+    },
+    {
+        "CPU": "Unisoc T700",
+        "Benchmark": "2,644"
+    },
+    {
+        "CPU": "Unisoc UIS7862S",
+        "Benchmark": "2,739"
+    },
+    {
+        "CPU": "Unisoc UIS8581A",
+        "Benchmark": "1,704"
+    },
+    {
+        "CPU": "Unisoc UIS8581E",
+        "Benchmark": "1,279"
+    },
+    {
+        "CPU": "Unisoc ums312",
+        "Benchmark": "972"
+    },
+    {
+        "CPU": "Unisoc ums512",
+        "Benchmark": "2,601"
+    },
+    {
+        "CPU": "Unisoc ums9230",
+        "Benchmark": "2,266"
+    },
+    {
+        "CPU": "Unisoc ums9230H",
+        "Benchmark": "2,924"
+    },
+    {
+        "CPU": "Unisoc ums9230T",
+        "Benchmark": "2,897"
+    },
+    {
+        "CPU": "UNIVERSAL3470",
+        "Benchmark": "391"
+    },
+    {
+        "CPU": "UNIVERSAL3475",
+        "Benchmark": "310"
+    },
+    {
+        "CPU": "vendor Kirin710",
+        "Benchmark": "2,825"
+    },
+    {
+        "CPU": "vendor Kirin810",
+        "Benchmark": "4,237"
+    },
+    {
+        "CPU": "vendor Kirin820",
+        "Benchmark": "4,947"
+    },
+    {
+        "CPU": "vendor Kirin9000",
+        "Benchmark": "6,914"
+    },
+    {
+        "CPU": "vendor Kirin9000E",
+        "Benchmark": "7,141"
+    },
+    {
+        "CPU": "vendor Kirin970",
+        "Benchmark": "3,042"
+    },
+    {
+        "CPU": "vendor Kirin980",
+        "Benchmark": "5,193"
+    },
+    {
+        "CPU": "vendor Kirin985",
+        "Benchmark": "5,481"
+    },
+    {
+        "CPU": "vendor Kirin990",
+        "Benchmark": "6,123"
+    },
+    {
+        "CPU": "Venus based on Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "5,398"
+    },
+    {
+        "CPU": "VIA C7-D 1800MHz",
+        "Benchmark": "150"
+    },
+    {
+        "CPU": "VIA C7-M 1200MHz",
+        "Benchmark": "112"
+    },
+    {
+        "CPU": "VIA C7-M 1600MHz",
+        "Benchmark": "116"
+    },
+    {
+        "CPU": "VIA C7-M 6300MHz",
+        "Benchmark": "145"
+    },
+    {
+        "CPU": "VIA Eden 1000MHz",
+        "Benchmark": "80"
+    },
+    {
+        "CPU": "VIA Eden 1200MHz",
+        "Benchmark": "93"
+    },
+    {
+        "CPU": "VIA Eden C1050@1.06GHz",
+        "Benchmark": "263"
+    },
+    {
+        "CPU": "VIA Eden X2 U4200 @ 1.0+ GHz",
+        "Benchmark": "327"
+    },
+    {
+        "CPU": "VIA Eden X4 C4250 @ 1.2+GHz",
+        "Benchmark": "904"
+    },
+    {
+        "CPU": "VIA Esther 1000MHz",
+        "Benchmark": "95"
+    },
+    {
+        "CPU": "VIA Esther 1500MHz",
+        "Benchmark": "135"
+    },
+    {
+        "CPU": "VIA Nano L2007@1600MHz",
+        "Benchmark": "238"
+    },
+    {
+        "CPU": "VIA Nano L2100@1800MHz",
+        "Benchmark": "279"
+    },
+    {
+        "CPU": "VIA Nano L2207@1600MHz",
+        "Benchmark": "165"
+    },
+    {
+        "CPU": "VIA Nano U2250 (1.6GHz Capable)",
+        "Benchmark": "187"
+    },
+    {
+        "CPU": "VIA Nano U2250@1300+MHz",
+        "Benchmark": "179"
+    },
+    {
+        "CPU": "VIA Nano U2500@1200MHz",
+        "Benchmark": "199"
+    },
+    {
+        "CPU": "VIA Nano U3500@1000MHz",
+        "Benchmark": "184"
+    },
+    {
+        "CPU": "VIA Nano X2 U4025 @ 1.2 GHz",
+        "Benchmark": "400"
+    },
+    {
+        "CPU": "VIA Nehemiah",
+        "Benchmark": "101"
+    },
+    {
+        "CPU": "VIA QuadCore C4650@2.0GHz",
+        "Benchmark": "1,352"
+    },
+    {
+        "CPU": "VIA QuadCore L4700 @ 1.2+ GHz",
+        "Benchmark": "773"
+    },
+    {
+        "CPU": "VIA QuadCore U4650 @ 1.0+ GHz",
+        "Benchmark": "666"
+    },
+    {
+        "CPU": "Vili based on Qualcomm Technologies, Inc SM8350",
+        "Benchmark": "5,296"
+    },
+    {
+        "CPU": "Virtual @ 2.32GHz",
+        "Benchmark": "1,826"
+    },
+    {
+        "CPU": "Virtual @ 2.56GHz",
+        "Benchmark": "3,778"
+    },
+    {
+        "CPU": "Virtual @ 2.70GHz",
+        "Benchmark": "3,503"
+    },
+    {
+        "CPU": "Virtual @ 2.95GHz",
+        "Benchmark": "9,196"
+    },
+    {
+        "CPU": "Virtual @ 3.24GHz",
+        "Benchmark": "11,638"
+    },
+    {
+        "CPU": "Virtual @ 3.41GHz",
+        "Benchmark": "13,635"
+    },
+    {
+        "CPU": "Virtual @ 3.80GHz",
+        "Benchmark": "17,386"
+    },
+    {
+        "CPU": "Welcome SC9863A",
+        "Benchmark": "1,868"
+    },
+    {
+        "CPU": "XTRONS_IX",
+        "Benchmark": "1,266"
+    },
+    {
+        "CPU": "Z3-6540M@2.1GHz",
+        "Benchmark": "1,599"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-6640A@2.6GHz",
+        "Benchmark": "1,617"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-6640MA@2.1+GHz",
+        "Benchmark": "1,597"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-6640MA@2.2+GHz",
+        "Benchmark": "1,566"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-7000",
+        "Benchmark": "7,006"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-U6580@2.5GHz",
+        "Benchmark": "3,227"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-U6780@2.7GHz",
+        "Benchmark": "3,693"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian KX-U6780A@2.7GHz",
+        "Benchmark": "3,376"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian ZX-C+ C4700@2.0GHz",
+        "Benchmark": "1,547"
+    },
+    {
+        "CPU": "ZHAOXIN KaiXian ZX-D D4600@2.0GHz",
+        "Benchmark": "1,492"
+    },
+    {
+        "CPU": "ZHAOXIN Z3-6540M@2.1+GHz",
+        "Benchmark": "1,378"
+    }
+]

--- a/src/renderer/src/pages/game-details/sidebar/gpu.json
+++ b/src/renderer/src/pages/game-details/sidebar/gpu.json
@@ -1,0 +1,11206 @@
+[
+    {
+        "Graphics": "6FDF:FF",
+        "Benchmark": "9528"
+    },
+    {
+        "Graphics": "256MB DDR Radeon 9800 XT",
+        "Benchmark": "37"
+    },
+    {
+        "Graphics": "7900 MOD - Radeon HD 6520G",
+        "Benchmark": "610"
+    },
+    {
+        "Graphics": "7900 MOD - Radeon HD 6550D",
+        "Benchmark": "892"
+    },
+    {
+        "Graphics": "A6 Micro-6500T Quad-Core APU with RadeonR4",
+        "Benchmark": "220"
+    },
+    {
+        "Graphics": "A10-8Q",
+        "Benchmark": "7038"
+    },
+    {
+        "Graphics": "A10-12Q",
+        "Benchmark": "9493"
+    },
+    {
+        "Graphics": "A16",
+        "Benchmark": "5280"
+    },
+    {
+        "Graphics": "A16-1Q",
+        "Benchmark": "3275"
+    },
+    {
+        "Graphics": "A16-2B",
+        "Benchmark": "2317"
+    },
+    {
+        "Graphics": "A16-2Q",
+        "Benchmark": "4747"
+    },
+    {
+        "Graphics": "A16-4Q",
+        "Benchmark": "4493"
+    },
+    {
+        "Graphics": "A40-24Q",
+        "Benchmark": "3317"
+    },
+    {
+        "Graphics": "A40-48Q",
+        "Benchmark": "10436"
+    },
+    {
+        "Graphics": "ABIT Siluro T400",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "ALL-IN-WONDER 9000",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "ALL-IN-WONDER 9800",
+        "Benchmark": "23"
+    },
+    {
+        "Graphics": "ALL-IN-WONDER RADEON 8500DV",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "ALL-IN-WONDER X800 GT",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "All-in-Wonder X1800XL",
+        "Benchmark": "30"
+    },
+    {
+        "Graphics": "All-in-Wonder X1900",
+        "Benchmark": "127"
+    },
+    {
+        "Graphics": "AMD Ryzen Z1 Extreme",
+        "Benchmark": "6519"
+    },
+    {
+        "Graphics": "AMIGAMERLIN 3.1-R1 For Voodoo 4 4500 PCI",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "ASUS A7000",
+        "Benchmark": "9"
+    },
+    {
+        "Graphics": "ASUS AGP-V3800PRO v31.40H",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "ASUS EAH4870x2",
+        "Benchmark": "496"
+    },
+    {
+        "Graphics": "Asus GTX 650 FML II EC-EGPU",
+        "Benchmark": "720"
+    },
+    {
+        "Graphics": "ASUS V9520-X V62.11",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "B8DKMDAP",
+        "Benchmark": "4557"
+    },
+    {
+        "Graphics": "Barco MXRT 1450",
+        "Benchmark": "205"
+    },
+    {
+        "Graphics": "Barco MXRT 2600",
+        "Benchmark": "900"
+    },
+    {
+        "Graphics": "Barco MXRT 5400",
+        "Benchmark": "1161"
+    },
+    {
+        "Graphics": "Barco MXRT 5450",
+        "Benchmark": "1079"
+    },
+    {
+        "Graphics": "Barco MXRT 5500",
+        "Benchmark": "2701"
+    },
+    {
+        "Graphics": "Barco MXRT 5600",
+        "Benchmark": "2465"
+    },
+    {
+        "Graphics": "Barco MXRT 7100",
+        "Benchmark": "180"
+    },
+    {
+        "Graphics": "Barco MXRT 7400",
+        "Benchmark": "900"
+    },
+    {
+        "Graphics": "Barco MXRT 7500",
+        "Benchmark": "3753"
+    },
+    {
+        "Graphics": "Barco MXRT 7600",
+        "Benchmark": "4943"
+    },
+    {
+        "Graphics": "BASICDISPLAY",
+        "Benchmark": "69"
+    },
+    {
+        "Graphics": "Beijing Fantasy Technology Fantasy II-M",
+        "Benchmark": "259"
+    },
+    {
+        "Graphics": "CARRIZO 9874",
+        "Benchmark": "226"
+    },
+    {
+        "Graphics": "Citrix Indirect Display Adapter",
+        "Benchmark": "1888"
+    },
+    {
+        "Graphics": "CMP 30HX",
+        "Benchmark": "6806"
+    },
+    {
+        "Graphics": "CMP 40HX",
+        "Benchmark": "9136"
+    },
+    {
+        "Graphics": "CONNECT 3D RADEON X300",
+        "Benchmark": "36"
+    },
+    {
+        "Graphics": "Custom GPU 0405",
+        "Benchmark": "2921"
+    },
+    {
+        "Graphics": "Custom GPU 0932",
+        "Benchmark": "3249"
+    },
+    {
+        "Graphics": "Dell 8100",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Dell 8200",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Diamond X1300-PCIE 256MB",
+        "Benchmark": "70"
+    },
+    {
+        "Graphics": "EAH5450",
+        "Benchmark": "134"
+    },
+    {
+        "Graphics": "EIZO Quadro MED-XN51LP",
+        "Benchmark": "4951"
+    },
+    {
+        "Graphics": "Embedded Radeon E9173",
+        "Benchmark": "1773"
+    },
+    {
+        "Graphics": "Eng Sample: 100-000000560-40_Y",
+        "Benchmark": "5655"
+    },
+    {
+        "Graphics": "Eng Sample: 100-000000561-40_Y",
+        "Benchmark": "4206"
+    },
+    {
+        "Graphics": "Extreme AX850 PRO",
+        "Benchmark": "120"
+    },
+    {
+        "Graphics": "FireGL T2-128",
+        "Benchmark": "30"
+    },
+    {
+        "Graphics": "FireGL V3100",
+        "Benchmark": "52"
+    },
+    {
+        "Graphics": "FireGL V3200",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "FireGL V3300",
+        "Benchmark": "70"
+    },
+    {
+        "Graphics": "FireGL V3350",
+        "Benchmark": "68"
+    },
+    {
+        "Graphics": "FireGL V3400",
+        "Benchmark": "103"
+    },
+    {
+        "Graphics": "FireGL V3600",
+        "Benchmark": "179"
+    },
+    {
+        "Graphics": "FireGL V5100",
+        "Benchmark": "92"
+    },
+    {
+        "Graphics": "FireGL V5200",
+        "Benchmark": "114"
+    },
+    {
+        "Graphics": "FireGL V5600",
+        "Benchmark": "341"
+    },
+    {
+        "Graphics": "FireGL V7100",
+        "Benchmark": "71"
+    },
+    {
+        "Graphics": "FireGL V7200",
+        "Benchmark": "116"
+    },
+    {
+        "Graphics": "FireGL V7300",
+        "Benchmark": "128"
+    },
+    {
+        "Graphics": "FireGL V7350",
+        "Benchmark": "110"
+    },
+    {
+        "Graphics": "FireGL V7600",
+        "Benchmark": "615"
+    },
+    {
+        "Graphics": "FireGL V7700",
+        "Benchmark": "660"
+    },
+    {
+        "Graphics": "FireGL V8600",
+        "Benchmark": "838"
+    },
+    {
+        "Graphics": "FireGL V8650",
+        "Benchmark": "550"
+    },
+    {
+        "Graphics": "FireGL X1",
+        "Benchmark": "59"
+    },
+    {
+        "Graphics": "FireMV 2200 PCI",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "FireMV 2200 PCIe",
+        "Benchmark": "36"
+    },
+    {
+        "Graphics": "FireMV 2250",
+        "Benchmark": "45"
+    },
+    {
+        "Graphics": "FireMV 2260",
+        "Benchmark": "117"
+    },
+    {
+        "Graphics": "FireMV 2400 PCIe",
+        "Benchmark": "11"
+    },
+    {
+        "Graphics": "FireMV 2450",
+        "Benchmark": "73"
+    },
+    {
+        "Graphics": "FirePro 3D V3700",
+        "Benchmark": "178"
+    },
+    {
+        "Graphics": "FirePro 3D V3750",
+        "Benchmark": "341"
+    },
+    {
+        "Graphics": "FirePro 3D V3800",
+        "Benchmark": "472"
+    },
+    {
+        "Graphics": "FirePro 3D V4800",
+        "Benchmark": "853"
+    },
+    {
+        "Graphics": "FirePro 3D V5700",
+        "Benchmark": "546"
+    },
+    {
+        "Graphics": "FirePro 3D V5800",
+        "Benchmark": "1231"
+    },
+    {
+        "Graphics": "FirePro 3D V7750",
+        "Benchmark": "545"
+    },
+    {
+        "Graphics": "FirePro 3D V7800",
+        "Benchmark": "1867"
+    },
+    {
+        "Graphics": "FirePro 3D V8700",
+        "Benchmark": "1206"
+    },
+    {
+        "Graphics": "FirePro 3D V8750",
+        "Benchmark": "1271"
+    },
+    {
+        "Graphics": "FirePro 3D V8800",
+        "Benchmark": "2437"
+    },
+    {
+        "Graphics": "FirePro 3D V9800",
+        "Benchmark": "2811"
+    },
+    {
+        "Graphics": "FirePro 2260",
+        "Benchmark": "112"
+    },
+    {
+        "Graphics": "FirePro 2270",
+        "Benchmark": "142"
+    },
+    {
+        "Graphics": "FirePro 2450",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "FirePro 2460",
+        "Benchmark": "170"
+    },
+    {
+        "Graphics": "FirePro M2000",
+        "Benchmark": "425"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "FirePro M4000",
+        "Benchmark": "1595"
+    },
+    {
+        "Graphics": "FirePro M4000 Mobility Pro",
+        "Benchmark": "1629"
+    },
+    {
+        "Graphics": "Firepro M4100",
+        "Benchmark": "1059"
+    },
+    {
+        "Graphics": "FirePro M4150",
+        "Benchmark": "994"
+    },
+    {
+        "Graphics": "FirePro M4170",
+        "Benchmark": "1188"
+    },
+    {
+        "Graphics": "FirePro M5100",
+        "Benchmark": "2102"
+    },
+    {
+        "Graphics": "FirePro M5100 FireGL V",
+        "Benchmark": "1839"
+    },
+    {
+        "Graphics": "FirePro M5950",
+        "Benchmark": "1314"
+    },
+    {
+        "Graphics": "FirePro M6000",
+        "Benchmark": "1820"
+    },
+    {
+        "Graphics": "FirePro M6000 Mobility Pro",
+        "Benchmark": "1712"
+    },
+    {
+        "Graphics": "FirePro M6100",
+        "Benchmark": "2374"
+    },
+    {
+        "Graphics": "FirePro M6100 FireGL V",
+        "Benchmark": "2875"
+    },
+    {
+        "Graphics": "FirePro M7740",
+        "Benchmark": "665"
+    },
+    {
+        "Graphics": "FirePro M40003",
+        "Benchmark": "1364"
+    },
+    {
+        "Graphics": "FirePro R5000",
+        "Benchmark": "2646"
+    },
+    {
+        "Graphics": "FirePro RG220",
+        "Benchmark": "335"
+    },
+    {
+        "Graphics": "FirePro S7000",
+        "Benchmark": "4523"
+    },
+    {
+        "Graphics": "FirePro S7150",
+        "Benchmark": "3770"
+    },
+    {
+        "Graphics": "FirePro S9000",
+        "Benchmark": "5059"
+    },
+    {
+        "Graphics": "FirePro S9050",
+        "Benchmark": "4901"
+    },
+    {
+        "Graphics": "FirePro S10000",
+        "Benchmark": "4768"
+    },
+    {
+        "Graphics": "FirePro V3800",
+        "Benchmark": "320"
+    },
+    {
+        "Graphics": "FirePro V3900",
+        "Benchmark": "637"
+    },
+    {
+        "Graphics": "FirePro V4900",
+        "Benchmark": "1005"
+    },
+    {
+        "Graphics": "FirePro V5700",
+        "Benchmark": "464"
+    },
+    {
+        "Graphics": "FirePro V5800",
+        "Benchmark": "1180"
+    },
+    {
+        "Graphics": "FirePro V5900",
+        "Benchmark": "1232"
+    },
+    {
+        "Graphics": "FirePro V7000",
+        "Benchmark": "3161"
+    },
+    {
+        "Graphics": "FirePro V7800",
+        "Benchmark": "2028"
+    },
+    {
+        "Graphics": "FirePro V7900",
+        "Benchmark": "2260"
+    },
+    {
+        "Graphics": "FirePro V8700",
+        "Benchmark": "1538"
+    },
+    {
+        "Graphics": "FirePro V8800",
+        "Benchmark": "2280"
+    },
+    {
+        "Graphics": "FirePro V9800",
+        "Benchmark": "2726"
+    },
+    {
+        "Graphics": "FirePro W600",
+        "Benchmark": "1685"
+    },
+    {
+        "Graphics": "FirePro W2100",
+        "Benchmark": "852"
+    },
+    {
+        "Graphics": "FirePro W4100",
+        "Benchmark": "1500"
+    },
+    {
+        "Graphics": "FirePro W4170M",
+        "Benchmark": "1065"
+    },
+    {
+        "Graphics": "Firepro W4190M",
+        "Benchmark": "1166"
+    },
+    {
+        "Graphics": "FirePro W4300",
+        "Benchmark": "2749"
+    },
+    {
+        "Graphics": "FirePro W5000",
+        "Benchmark": "2955"
+    },
+    {
+        "Graphics": "FirePro W5100",
+        "Benchmark": "2979"
+    },
+    {
+        "Graphics": "FirePro W5130M",
+        "Benchmark": "1343"
+    },
+    {
+        "Graphics": "Firepro W5170M",
+        "Benchmark": "1814"
+    },
+    {
+        "Graphics": "FirePro W6150M",
+        "Benchmark": "2358"
+    },
+    {
+        "Graphics": "FirePro W7000",
+        "Benchmark": "4255"
+    },
+    {
+        "Graphics": "FirePro W7000 Adapter",
+        "Benchmark": "4359"
+    },
+    {
+        "Graphics": "FirePro W7100",
+        "Benchmark": "5191"
+    },
+    {
+        "Graphics": "FirePro W7170M",
+        "Benchmark": "3161"
+    },
+    {
+        "Graphics": "FirePro W8000",
+        "Benchmark": "4259"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "FirePro W8100",
+        "Benchmark": "6671"
+    },
+    {
+        "Graphics": "FirePro W9000",
+        "Benchmark": "6157"
+    },
+    {
+        "Graphics": "FirePro W9100",
+        "Benchmark": "7747"
+    },
+    {
+        "Graphics": "FireStream 9170",
+        "Benchmark": "647"
+    },
+    {
+        "Graphics": "FireStream 9250",
+        "Benchmark": "1164"
+    },
+    {
+        "Graphics": "FireStream 9270",
+        "Benchmark": "1341"
+    },
+    {
+        "Graphics": "FireStream 9370",
+        "Benchmark": "2528"
+    },
+    {
+        "Graphics": "GeCube RADEON 7000",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "GeForce2 Go",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce2 GTS/GeForce2 Pro",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce2 Integrated GPU",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce2 MX",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "GeForce2 MX 100/200",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce2 MX with DVI-D and TV-out",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce2 MX with TV Out",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "GeForce2 MX/MX 400",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce2 Ti",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce2 Ultra",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "GeForce3",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce3 Ti 200",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce3 Ti 500",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "GeForce4 420 Go",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce4 420 Go 32M",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce4 440",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 440 Go",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce4 440 Go 64M",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce4 448 Go",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce4 4200 Go",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce4 MX 420",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 MX 440",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 MX 440 with AGP8X",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 MX 440SE",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 MX 460",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 MX 4000",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "GeForce4 MX Integrated GPU",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "GeForce4 Ti 4200",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce4 Ti 4400",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "GeForce4 Ti 4600",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce4 Ti 4800",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce4 Ti 4800 SE",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "GeForce9400M",
+        "Benchmark": "105"
+    },
+    {
+        "Graphics": "GeForce 205",
+        "Benchmark": "126"
+    },
+    {
+        "Graphics": "GeForce 210",
+        "Benchmark": "128"
+    },
+    {
+        "Graphics": "GeForce 240M GT",
+        "Benchmark": "319"
+    },
+    {
+        "Graphics": "GeForce 256",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "GeForce 305M",
+        "Benchmark": "150"
+    },
+    {
+        "Graphics": "GeForce 310",
+        "Benchmark": "143"
+    },
+    {
+        "Graphics": "GeForce 310M",
+        "Benchmark": "126"
+    },
+    {
+        "Graphics": "GeForce 315",
+        "Benchmark": "198"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce 315M",
+        "Benchmark": "114"
+    },
+    {
+        "Graphics": "GeForce 320M",
+        "Benchmark": "209"
+    },
+    {
+        "Graphics": "GeForce 405",
+        "Benchmark": "118"
+    },
+    {
+        "Graphics": "GeForce 410M",
+        "Benchmark": "267"
+    },
+    {
+        "Graphics": "GeForce 505",
+        "Benchmark": "143"
+    },
+    {
+        "Graphics": "GeForce 510",
+        "Benchmark": "290"
+    },
+    {
+        "Graphics": "GeForce 605",
+        "Benchmark": "321"
+    },
+    {
+        "Graphics": "GeForce 610M",
+        "Benchmark": "292"
+    },
+    {
+        "Graphics": "GeForce 615",
+        "Benchmark": "507"
+    },
+    {
+        "Graphics": "GeForce 705M",
+        "Benchmark": "455"
+    },
+    {
+        "Graphics": "GeForce 710A",
+        "Benchmark": "472"
+    },
+    {
+        "Graphics": "GeForce 710M",
+        "Benchmark": "452"
+    },
+    {
+        "Graphics": "GeForce 720A",
+        "Benchmark": "577"
+    },
+    {
+        "Graphics": "GeForce 730A",
+        "Benchmark": "770"
+    },
+    {
+        "Graphics": "GeForce 770M",
+        "Benchmark": "3245"
+    },
+    {
+        "Graphics": "GeForce 800A",
+        "Benchmark": "476"
+    },
+    {
+        "Graphics": "GeForce 800M",
+        "Benchmark": "477"
+    },
+    {
+        "Graphics": "GeForce 810A",
+        "Benchmark": "655"
+    },
+    {
+        "Graphics": "GeForce 810M",
+        "Benchmark": "419"
+    },
+    {
+        "Graphics": "GeForce 820A",
+        "Benchmark": "555"
+    },
+    {
+        "Graphics": "GeForce 820M",
+        "Benchmark": "488"
+    },
+    {
+        "Graphics": "GeForce 825M",
+        "Benchmark": "770"
+    },
+    {
+        "Graphics": "GeForce 830A",
+        "Benchmark": "1156"
+    },
+    {
+        "Graphics": "GeForce 830M",
+        "Benchmark": "1009"
+    },
+    {
+        "Graphics": "GeForce 840A",
+        "Benchmark": "1123"
+    },
+    {
+        "Graphics": "GeForce 840M",
+        "Benchmark": "1097"
+    },
+    {
+        "Graphics": "GeForce 845M",
+        "Benchmark": "1488"
+    },
+    {
+        "Graphics": "GeForce 910M",
+        "Benchmark": "588"
+    },
+    {
+        "Graphics": "GeForce 920A",
+        "Benchmark": "833"
+    },
+    {
+        "Graphics": "GeForce 920M",
+        "Benchmark": "716"
+    },
+    {
+        "Graphics": "GeForce 920MX",
+        "Benchmark": "1068"
+    },
+    {
+        "Graphics": "GeForce 930A",
+        "Benchmark": "1263"
+    },
+    {
+        "Graphics": "GeForce 930M",
+        "Benchmark": "1011"
+    },
+    {
+        "Graphics": "GeForce 930MX",
+        "Benchmark": "1286"
+    },
+    {
+        "Graphics": "GeForce 940A",
+        "Benchmark": "1106"
+    },
+    {
+        "Graphics": "GeForce 940M",
+        "Benchmark": "1128"
+    },
+    {
+        "Graphics": "GeForce 940MX",
+        "Benchmark": "1514"
+    },
+    {
+        "Graphics": "GeForce 945A",
+        "Benchmark": "1852"
+    },
+    {
+        "Graphics": "GeForce 945M",
+        "Benchmark": "2108"
+    },
+    {
+        "Graphics": "GeForce 999 GTX",
+        "Benchmark": "83"
+    },
+    {
+        "Graphics": "GeForce 6100",
+        "Benchmark": "27"
+    },
+    {
+        "Graphics": "GeForce 6100 nForce 400",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "GeForce 6100 nForce 405",
+        "Benchmark": "26"
+    },
+    {
+        "Graphics": "GeForce 6100 nForce 420",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "GeForce 6100 nForce 430",
+        "Benchmark": "23"
+    },
+    {
+        "Graphics": "GeForce 6150",
+        "Benchmark": "21"
+    },
+    {
+        "Graphics": "GeForce 6150 LE",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "GeForce 6150SE",
+        "Benchmark": "24"
+    },
+    {
+        "Graphics": "GeForce 6150SE nForce 430",
+        "Benchmark": "30"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce 6200",
+        "Benchmark": "37"
+    },
+    {
+        "Graphics": "GeForce 6200 A-LE",
+        "Benchmark": "32"
+    },
+    {
+        "Graphics": "GeForce 6200 LE",
+        "Benchmark": "32"
+    },
+    {
+        "Graphics": "GeForce 6200 TurboCache",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "GeForce 6200A",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "GeForce 6200SE TurboCache",
+        "Benchmark": "37"
+    },
+    {
+        "Graphics": "GeForce 6500",
+        "Benchmark": "38"
+    },
+    {
+        "Graphics": "GeForce 6600",
+        "Benchmark": "86"
+    },
+    {
+        "Graphics": "GeForce 6600 GT",
+        "Benchmark": "142"
+    },
+    {
+        "Graphics": "GeForce 6600 LE",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "GeForce 6610 XL",
+        "Benchmark": "88"
+    },
+    {
+        "Graphics": "GeForce 6700 XL",
+        "Benchmark": "95"
+    },
+    {
+        "Graphics": "GeForce 6800",
+        "Benchmark": "112"
+    },
+    {
+        "Graphics": "GeForce 6800 GS",
+        "Benchmark": "191"
+    },
+    {
+        "Graphics": "GeForce 6800 GS/XT",
+        "Benchmark": "102"
+    },
+    {
+        "Graphics": "GeForce 6800 GT",
+        "Benchmark": "142"
+    },
+    {
+        "Graphics": "GeForce 6800 LE",
+        "Benchmark": "109"
+    },
+    {
+        "Graphics": "GeForce 6800 Ultra",
+        "Benchmark": "138"
+    },
+    {
+        "Graphics": "GeForce 6800 XE",
+        "Benchmark": "58"
+    },
+    {
+        "Graphics": "GeForce 6800 XT",
+        "Benchmark": "120"
+    },
+    {
+        "Graphics": "GeForce 7000M",
+        "Benchmark": "13"
+    },
+    {
+        "Graphics": "GeForce 7000M / nForce 610M",
+        "Benchmark": "12"
+    },
+    {
+        "Graphics": "GeForce 7025 / nForce 630a",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "GeForce 7050 / nForce 610i",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "GeForce 7050 / nForce 620i",
+        "Benchmark": "41"
+    },
+    {
+        "Graphics": "GeForce 7050 / nForce 630i",
+        "Benchmark": "37"
+    },
+    {
+        "Graphics": "GeForce 7050 PV / nForce 630a",
+        "Benchmark": "31"
+    },
+    {
+        "Graphics": "GeForce 7100 / nForce 620i",
+        "Benchmark": "26"
+    },
+    {
+        "Graphics": "GeForce 7100 / nForce 630i",
+        "Benchmark": "41"
+    },
+    {
+        "Graphics": "GeForce 7100 GS",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "GeForce 7150 / nForce 630i",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "GeForce 7150M / nForce 630M",
+        "Benchmark": "18"
+    },
+    {
+        "Graphics": "GeForce 7200 GS",
+        "Benchmark": "23"
+    },
+    {
+        "Graphics": "GeForce 7300 GS",
+        "Benchmark": "78"
+    },
+    {
+        "Graphics": "GeForce 7300 GT",
+        "Benchmark": "121"
+    },
+    {
+        "Graphics": "GeForce 7300 LE",
+        "Benchmark": "80"
+    },
+    {
+        "Graphics": "GeForce 7300 SE",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "GeForce 7300 SE/7200 GS",
+        "Benchmark": "48"
+    },
+    {
+        "Graphics": "GeForce 7350 LE",
+        "Benchmark": "74"
+    },
+    {
+        "Graphics": "GeForce 7500 LE",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "GeForce 7600 GS",
+        "Benchmark": "158"
+    },
+    {
+        "Graphics": "GeForce 7600 GT",
+        "Benchmark": "237"
+    },
+    {
+        "Graphics": "GeForce 7650 GS",
+        "Benchmark": "134"
+    },
+    {
+        "Graphics": "GeForce 7800 GS",
+        "Benchmark": "177"
+    },
+    {
+        "Graphics": "GeForce 7800 GT",
+        "Benchmark": "244"
+    },
+    {
+        "Graphics": "GeForce 7800 GTX",
+        "Benchmark": "290"
+    },
+    {
+        "Graphics": "GeForce 7900 GS",
+        "Benchmark": "253"
+    },
+    {
+        "Graphics": "GeForce 7900 GT",
+        "Benchmark": "258"
+    },
+    {
+        "Graphics": "GeForce 7900 GT/GTO",
+        "Benchmark": "247"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce 7900 GTX",
+        "Benchmark": "387"
+    },
+    {
+        "Graphics": "GeForce 7950 GT",
+        "Benchmark": "346"
+    },
+    {
+        "Graphics": "GeForce 7950 GX2",
+        "Benchmark": "201"
+    },
+    {
+        "Graphics": "GeForce 7950 Xtreme",
+        "Benchmark": "287"
+    },
+    {
+        "Graphics": "GeForce 8100 / nForce 720a",
+        "Benchmark": "79"
+    },
+    {
+        "Graphics": "GeForce 8200",
+        "Benchmark": "163"
+    },
+    {
+        "Graphics": "GeForce 8200M G",
+        "Benchmark": "65"
+    },
+    {
+        "Graphics": "GeForce 8300",
+        "Benchmark": "101"
+    },
+    {
+        "Graphics": "GeForce 8300 GS",
+        "Benchmark": "115"
+    },
+    {
+        "Graphics": "GeForce 8400",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "GeForce 8400 GS",
+        "Benchmark": "155"
+    },
+    {
+        "Graphics": "GeForce 8400 SE",
+        "Benchmark": "68"
+    },
+    {
+        "Graphics": "GeForce 8400M G",
+        "Benchmark": "105"
+    },
+    {
+        "Graphics": "GeForce 8400M GS",
+        "Benchmark": "100"
+    },
+    {
+        "Graphics": "GeForce 8400M GT",
+        "Benchmark": "66"
+    },
+    {
+        "Graphics": "GeForce 8500 GT",
+        "Benchmark": "155"
+    },
+    {
+        "Graphics": "GeForce 8600 GS",
+        "Benchmark": "91"
+    },
+    {
+        "Graphics": "GeForce 8600 GT",
+        "Benchmark": "131"
+    },
+    {
+        "Graphics": "GeForce 8600 GTS",
+        "Benchmark": "169"
+    },
+    {
+        "Graphics": "GeForce 8600M GS",
+        "Benchmark": "88"
+    },
+    {
+        "Graphics": "GeForce 8600M GT",
+        "Benchmark": "156"
+    },
+    {
+        "Graphics": "GeForce 8700M GT",
+        "Benchmark": "124"
+    },
+    {
+        "Graphics": "GeForce 8800 GS",
+        "Benchmark": "330"
+    },
+    {
+        "Graphics": "GeForce 8800 GT",
+        "Benchmark": "462"
+    },
+    {
+        "Graphics": "GeForce 8800 GTS",
+        "Benchmark": "407"
+    },
+    {
+        "Graphics": "GeForce 8800 GTS 512",
+        "Benchmark": "549"
+    },
+    {
+        "Graphics": "GeForce 8800 GTX",
+        "Benchmark": "572"
+    },
+    {
+        "Graphics": "GeForce 8800 Ultra",
+        "Benchmark": "642"
+    },
+    {
+        "Graphics": "GeForce 8800M GTS",
+        "Benchmark": "382"
+    },
+    {
+        "Graphics": "GeForce 8800M GTX",
+        "Benchmark": "462"
+    },
+    {
+        "Graphics": "GeForce 9100",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "GeForce 9100M G",
+        "Benchmark": "68"
+    },
+    {
+        "Graphics": "GeForce 9200",
+        "Benchmark": "169"
+    },
+    {
+        "Graphics": "GeForce 9200M GE",
+        "Benchmark": "143"
+    },
+    {
+        "Graphics": "GeForce 9200M GS",
+        "Benchmark": "129"
+    },
+    {
+        "Graphics": "GeForce 9300",
+        "Benchmark": "126"
+    },
+    {
+        "Graphics": "GeForce 9300 / nForce 730i",
+        "Benchmark": "128"
+    },
+    {
+        "Graphics": "GeForce 9300 GE",
+        "Benchmark": "95"
+    },
+    {
+        "Graphics": "GeForce 9300 GS",
+        "Benchmark": "102"
+    },
+    {
+        "Graphics": "GeForce 9300 SE",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "GeForce 9300GE",
+        "Benchmark": "97"
+    },
+    {
+        "Graphics": "GeForce 9300M G",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "GeForce 9300M GS",
+        "Benchmark": "118"
+    },
+    {
+        "Graphics": "GeForce 9400",
+        "Benchmark": "143"
+    },
+    {
+        "Graphics": "GeForce 9400 GT",
+        "Benchmark": "168"
+    },
+    {
+        "Graphics": "GeForce 9400M",
+        "Benchmark": "101"
+    },
+    {
+        "Graphics": "GeForce 9400M G",
+        "Benchmark": "67"
+    },
+    {
+        "Graphics": "GeForce 9450",
+        "Benchmark": "104"
+    },
+    {
+        "Graphics": "GeForce 9500 GS",
+        "Benchmark": "215"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce 9500 GT",
+        "Benchmark": "177"
+    },
+    {
+        "Graphics": "GeForce 9500M",
+        "Benchmark": "103"
+    },
+    {
+        "Graphics": "GeForce 9500M G",
+        "Benchmark": "121"
+    },
+    {
+        "Graphics": "GeForce 9500M GS",
+        "Benchmark": "134"
+    },
+    {
+        "Graphics": "GeForce 9600 GS",
+        "Benchmark": "281"
+    },
+    {
+        "Graphics": "GeForce 9600 GSO",
+        "Benchmark": "323"
+    },
+    {
+        "Graphics": "GeForce 9600 GSO 512",
+        "Benchmark": "329"
+    },
+    {
+        "Graphics": "GeForce 9600 GT",
+        "Benchmark": "475"
+    },
+    {
+        "Graphics": "GeForce 9600M GS",
+        "Benchmark": "130"
+    },
+    {
+        "Graphics": "GeForce 9600M GT",
+        "Benchmark": "149"
+    },
+    {
+        "Graphics": "GeForce 9600M GT / GeForce GT 220M",
+        "Benchmark": "293"
+    },
+    {
+        "Graphics": "GeForce 9650M GS",
+        "Benchmark": "270"
+    },
+    {
+        "Graphics": "GeForce 9650M GT",
+        "Benchmark": "137"
+    },
+    {
+        "Graphics": "GeForce 9700M GT",
+        "Benchmark": "208"
+    },
+    {
+        "Graphics": "GeForce 9700M GTS",
+        "Benchmark": "278"
+    },
+    {
+        "Graphics": "GeForce 9800 GT",
+        "Benchmark": "453"
+    },
+    {
+        "Graphics": "GeForce 9800 GT 1024MB",
+        "Benchmark": "134"
+    },
+    {
+        "Graphics": "GeForce 9800 GTX",
+        "Benchmark": "769"
+    },
+    {
+        "Graphics": "GeForce 9800 GTX+",
+        "Benchmark": "494"
+    },
+    {
+        "Graphics": "GeForce 9800 GTX/9800 GTX+",
+        "Benchmark": "593"
+    },
+    {
+        "Graphics": "GeForce 9800 GX2",
+        "Benchmark": "612"
+    },
+    {
+        "Graphics": "GeForce 9800 S",
+        "Benchmark": "635"
+    },
+    {
+        "Graphics": "GeForce 9800M GS",
+        "Benchmark": "534"
+    },
+    {
+        "Graphics": "GeForce 9800M GT",
+        "Benchmark": "381"
+    },
+    {
+        "Graphics": "GeForce 9800M GTS",
+        "Benchmark": "356"
+    },
+    {
+        "Graphics": "GeForce 9800M GTX",
+        "Benchmark": "454"
+    },
+    {
+        "Graphics": "GeForce FX 5100",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "GeForce FX 5200",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "GeForce FX 5200 Ultra",
+        "Benchmark": "12"
+    },
+    {
+        "Graphics": "GeForce FX 5200LE",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "GeForce FX 5200SE",
+        "Benchmark": "11"
+    },
+    {
+        "Graphics": "GeForce FX 5500",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "GeForce FX 5600",
+        "Benchmark": "12"
+    },
+    {
+        "Graphics": "GeForce FX 5600 Ultra",
+        "Benchmark": "17"
+    },
+    {
+        "Graphics": "GeForce FX 5600XT",
+        "Benchmark": "9"
+    },
+    {
+        "Graphics": "GeForce FX 5700",
+        "Benchmark": "40"
+    },
+    {
+        "Graphics": "GeForce FX 5700 Ultra",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "GeForce FX 5700LE",
+        "Benchmark": "24"
+    },
+    {
+        "Graphics": "GeForce FX 5700VE",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "GeForce FX 5900",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "GeForce FX 5900 Ultra",
+        "Benchmark": "41"
+    },
+    {
+        "Graphics": "GeForce FX 5900XT",
+        "Benchmark": "40"
+    },
+    {
+        "Graphics": "GeForce FX 5900ZT",
+        "Benchmark": "32"
+    },
+    {
+        "Graphics": "GeForce FX 5950 Ultra",
+        "Benchmark": "59"
+    },
+    {
+        "Graphics": "GeForce FX Go5300",
+        "Benchmark": "12"
+    },
+    {
+        "Graphics": "GeForce FX Go5650",
+        "Benchmark": "16"
+    },
+    {
+        "Graphics": "GeForce FX Go5700",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "GeForce FX Go 5200",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "GeForce FX Go 5600",
+        "Benchmark": "17"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce G100",
+        "Benchmark": "176"
+    },
+    {
+        "Graphics": "GeForce G102M",
+        "Benchmark": "167"
+    },
+    {
+        "Graphics": "GeForce G105M",
+        "Benchmark": "133"
+    },
+    {
+        "Graphics": "GeForce G200",
+        "Benchmark": "136"
+    },
+    {
+        "Graphics": "GeForce G205M",
+        "Benchmark": "91"
+    },
+    {
+        "Graphics": "GeForce G210",
+        "Benchmark": "124"
+    },
+    {
+        "Graphics": "GeForce G210M",
+        "Benchmark": "129"
+    },
+    {
+        "Graphics": "GeForce G 103M",
+        "Benchmark": "62"
+    },
+    {
+        "Graphics": "GeForce G 105M",
+        "Benchmark": "62"
+    },
+    {
+        "Graphics": "GeForce Go 6100",
+        "Benchmark": "17"
+    },
+    {
+        "Graphics": "GeForce Go 6150",
+        "Benchmark": "19"
+    },
+    {
+        "Graphics": "GeForce Go 6200",
+        "Benchmark": "15"
+    },
+    {
+        "Graphics": "GeForce Go 6400",
+        "Benchmark": "24"
+    },
+    {
+        "Graphics": "GeForce Go 6600",
+        "Benchmark": "69"
+    },
+    {
+        "Graphics": "GeForce Go 6600 TE/6200 TE",
+        "Benchmark": "44"
+    },
+    {
+        "Graphics": "GeForce Go 6800",
+        "Benchmark": "106"
+    },
+    {
+        "Graphics": "GeForce Go 6800 Ultra",
+        "Benchmark": "137"
+    },
+    {
+        "Graphics": "GeForce Go 7200",
+        "Benchmark": "45"
+    },
+    {
+        "Graphics": "GeForce Go 7300",
+        "Benchmark": "52"
+    },
+    {
+        "Graphics": "GeForce Go 7400",
+        "Benchmark": "65"
+    },
+    {
+        "Graphics": "GeForce Go 7600",
+        "Benchmark": "127"
+    },
+    {
+        "Graphics": "GeForce Go 7600 GT",
+        "Benchmark": "210"
+    },
+    {
+        "Graphics": "GeForce Go 7700",
+        "Benchmark": "147"
+    },
+    {
+        "Graphics": "GeForce Go 7800",
+        "Benchmark": "114"
+    },
+    {
+        "Graphics": "GeForce Go 7800 GTX",
+        "Benchmark": "209"
+    },
+    {
+        "Graphics": "GeForce Go 7900 GS",
+        "Benchmark": "177"
+    },
+    {
+        "Graphics": "GeForce Go 7900 GTX",
+        "Benchmark": "270"
+    },
+    {
+        "Graphics": "GeForce Go 7950 GTX",
+        "Benchmark": "263"
+    },
+    {
+        "Graphics": "GeForce GPU",
+        "Benchmark": "1161"
+    },
+    {
+        "Graphics": "GeForce GT625M",
+        "Benchmark": "451"
+    },
+    {
+        "Graphics": "GeForce GT 120",
+        "Benchmark": "165"
+    },
+    {
+        "Graphics": "GeForce GT 120 / 9500 GT",
+        "Benchmark": "324"
+    },
+    {
+        "Graphics": "GeForce GT 120M",
+        "Benchmark": "150"
+    },
+    {
+        "Graphics": "GeForce GT 130",
+        "Benchmark": "381"
+    },
+    {
+        "Graphics": "GeForce GT 130M",
+        "Benchmark": "145"
+    },
+    {
+        "Graphics": "GeForce GT 140",
+        "Benchmark": "657"
+    },
+    {
+        "Graphics": "GeForce GT 220",
+        "Benchmark": "221"
+    },
+    {
+        "Graphics": "GeForce GT 220M",
+        "Benchmark": "121"
+    },
+    {
+        "Graphics": "GeForce GT 230",
+        "Benchmark": "323"
+    },
+    {
+        "Graphics": "GeForce GT 230M",
+        "Benchmark": "215"
+    },
+    {
+        "Graphics": "GeForce GT 240",
+        "Benchmark": "500"
+    },
+    {
+        "Graphics": "GeForce GT 240M",
+        "Benchmark": "213"
+    },
+    {
+        "Graphics": "GeForce GT 320",
+        "Benchmark": "470"
+    },
+    {
+        "Graphics": "GeForce GT 320M",
+        "Benchmark": "106"
+    },
+    {
+        "Graphics": "GeForce GT 325M",
+        "Benchmark": "169"
+    },
+    {
+        "Graphics": "GeForce GT 330",
+        "Benchmark": "396"
+    },
+    {
+        "Graphics": "GeForce GT 330M",
+        "Benchmark": "220"
+    },
+    {
+        "Graphics": "GeForce GT 335M",
+        "Benchmark": "374"
+    },
+    {
+        "Graphics": "GeForce GT 340",
+        "Benchmark": "738"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce GT 415",
+        "Benchmark": "251"
+    },
+    {
+        "Graphics": "GeForce GT 415M",
+        "Benchmark": "286"
+    },
+    {
+        "Graphics": "GeForce GT 420",
+        "Benchmark": "425"
+    },
+    {
+        "Graphics": "GeForce GT 420M",
+        "Benchmark": "393"
+    },
+    {
+        "Graphics": "GeForce GT 425M",
+        "Benchmark": "514"
+    },
+    {
+        "Graphics": "GeForce GT 430",
+        "Benchmark": "602"
+    },
+    {
+        "Graphics": "GeForce GT 435M",
+        "Benchmark": "535"
+    },
+    {
+        "Graphics": "GeForce GT 440",
+        "Benchmark": "773"
+    },
+    {
+        "Graphics": "GeForce GT 445M",
+        "Benchmark": "811"
+    },
+    {
+        "Graphics": "GeForce GT 520",
+        "Benchmark": "320"
+    },
+    {
+        "Graphics": "GeForce GT 520M",
+        "Benchmark": "284"
+    },
+    {
+        "Graphics": "GeForce GT 520MX",
+        "Benchmark": "284"
+    },
+    {
+        "Graphics": "GeForce GT 525M",
+        "Benchmark": "453"
+    },
+    {
+        "Graphics": "GeForce GT 530",
+        "Benchmark": "666"
+    },
+    {
+        "Graphics": "GeForce GT 540M",
+        "Benchmark": "478"
+    },
+    {
+        "Graphics": "GeForce GT 545",
+        "Benchmark": "1109"
+    },
+    {
+        "Graphics": "GeForce GT 550M",
+        "Benchmark": "569"
+    },
+    {
+        "Graphics": "GeForce GT 555M",
+        "Benchmark": "650"
+    },
+    {
+        "Graphics": "GeForce GT 610",
+        "Benchmark": "324"
+    },
+    {
+        "Graphics": "GeForce GT 610M / GT 620M / GT 710M / GT 720M / GT",
+        "Benchmark": "368"
+    },
+    {
+        "Graphics": "GeForce GT 620",
+        "Benchmark": "382"
+    },
+    {
+        "Graphics": "GeForce GT 620M",
+        "Benchmark": "430"
+    },
+    {
+        "Graphics": "GeForce GT 625",
+        "Benchmark": "368"
+    },
+    {
+        "Graphics": "GeForce GT 625M",
+        "Benchmark": "484"
+    },
+    {
+        "Graphics": "GeForce GT 630",
+        "Benchmark": "683"
+    },
+    {
+        "Graphics": "GeForce GT 630M",
+        "Benchmark": "531"
+    },
+    {
+        "Graphics": "GeForce GT 635",
+        "Benchmark": "815"
+    },
+    {
+        "Graphics": "GeForce GT 635M",
+        "Benchmark": "550"
+    },
+    {
+        "Graphics": "GeForce GT 640",
+        "Benchmark": "1167"
+    },
+    {
+        "Graphics": "GeForce GT 640M",
+        "Benchmark": "930"
+    },
+    {
+        "Graphics": "GeForce GT 640M LE",
+        "Benchmark": "704"
+    },
+    {
+        "Graphics": "GeForce GT 645",
+        "Benchmark": "2005"
+    },
+    {
+        "Graphics": "GeForce GT 645M",
+        "Benchmark": "939"
+    },
+    {
+        "Graphics": "GeForce GT 650M",
+        "Benchmark": "1200"
+    },
+    {
+        "Graphics": "GeForce GT 705",
+        "Benchmark": "350"
+    },
+    {
+        "Graphics": "GeForce GT 710",
+        "Benchmark": "622"
+    },
+    {
+        "Graphics": "GeForce GT 710M",
+        "Benchmark": "437"
+    },
+    {
+        "Graphics": "GeForce GT 720",
+        "Benchmark": "644"
+    },
+    {
+        "Graphics": "GeForce GT 720A",
+        "Benchmark": "573"
+    },
+    {
+        "Graphics": "GeForce GT 720M",
+        "Benchmark": "448"
+    },
+    {
+        "Graphics": "GeForce GT 730",
+        "Benchmark": "825"
+    },
+    {
+        "Graphics": "GeForce GT 730A",
+        "Benchmark": "742"
+    },
+    {
+        "Graphics": "GeForce GT 730M",
+        "Benchmark": "812"
+    },
+    {
+        "Graphics": "GeForce GT 735M",
+        "Benchmark": "654"
+    },
+    {
+        "Graphics": "GeForce GT 740",
+        "Benchmark": "1464"
+    },
+    {
+        "Graphics": "GeForce GT 740A",
+        "Benchmark": "667"
+    },
+    {
+        "Graphics": "GeForce GT 740M",
+        "Benchmark": "792"
+    },
+    {
+        "Graphics": "GeForce GT 745A",
+        "Benchmark": "1237"
+    },
+    {
+        "Graphics": "GeForce GT 745M",
+        "Benchmark": "1097"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce GT 750M",
+        "Benchmark": "1329"
+    },
+    {
+        "Graphics": "GeForce GT 755M",
+        "Benchmark": "1713"
+    },
+    {
+        "Graphics": "GeForce GT 820M",
+        "Benchmark": "550"
+    },
+    {
+        "Graphics": "GeForce GT 1030",
+        "Benchmark": "2428"
+    },
+    {
+        "Graphics": "GeForce GTS 150M",
+        "Benchmark": "504"
+    },
+    {
+        "Graphics": "GeForce GTS 160M",
+        "Benchmark": "678"
+    },
+    {
+        "Graphics": "GeForce GTS 240",
+        "Benchmark": "556"
+    },
+    {
+        "Graphics": "GeForce GTS 250",
+        "Benchmark": "588"
+    },
+    {
+        "Graphics": "GeForce GTS 250M",
+        "Benchmark": "553"
+    },
+    {
+        "Graphics": "GeForce GTS 350M",
+        "Benchmark": "380"
+    },
+    {
+        "Graphics": "GeForce GTS 360M",
+        "Benchmark": "644"
+    },
+    {
+        "Graphics": "GeForce GTS 450",
+        "Benchmark": "1318"
+    },
+    {
+        "Graphics": "GeForce GTX 260",
+        "Benchmark": "1208"
+    },
+    {
+        "Graphics": "GeForce GTX 260M",
+        "Benchmark": "380"
+    },
+    {
+        "Graphics": "GeForce GTX 275",
+        "Benchmark": "1379"
+    },
+    {
+        "Graphics": "GeForce GTX 280",
+        "Benchmark": "1277"
+    },
+    {
+        "Graphics": "GeForce GTX 280M",
+        "Benchmark": "575"
+    },
+    {
+        "Graphics": "GeForce GTX 285",
+        "Benchmark": "1500"
+    },
+    {
+        "Graphics": "GeForce GTX 285M",
+        "Benchmark": "636"
+    },
+    {
+        "Graphics": "GeForce GTX 295",
+        "Benchmark": "1200"
+    },
+    {
+        "Graphics": "GeForce GTX 460",
+        "Benchmark": "2273"
+    },
+    {
+        "Graphics": "GeForce GTX 460 SE",
+        "Benchmark": "1990"
+    },
+    {
+        "Graphics": "GeForce GTX 460 v2",
+        "Benchmark": "1865"
+    },
+    {
+        "Graphics": "GeForce GTX 460M",
+        "Benchmark": "1214"
+    },
+    {
+        "Graphics": "GeForce GTX 465",
+        "Benchmark": "2653"
+    },
+    {
+        "Graphics": "GeForce GTX 470",
+        "Benchmark": "3140"
+    },
+    {
+        "Graphics": "GeForce GTX 470M",
+        "Benchmark": "1953"
+    },
+    {
+        "Graphics": "GeForce GTX 480",
+        "Benchmark": "4121"
+    },
+    {
+        "Graphics": "GeForce GTX 480M",
+        "Benchmark": "1617"
+    },
+    {
+        "Graphics": "GeForce GTX 485M",
+        "Benchmark": "2359"
+    },
+    {
+        "Graphics": "GeForce GTX 550 Ti",
+        "Benchmark": "1559"
+    },
+    {
+        "Graphics": "GeForce GTX 555",
+        "Benchmark": "1603"
+    },
+    {
+        "Graphics": "GeForce GTX 560",
+        "Benchmark": "2770"
+    },
+    {
+        "Graphics": "GeForce GTX 560 SE",
+        "Benchmark": "1847"
+    },
+    {
+        "Graphics": "GeForce GTX 560 Ti",
+        "Benchmark": "3068"
+    },
+    {
+        "Graphics": "GeForce GTX 560M",
+        "Benchmark": "1274"
+    },
+    {
+        "Graphics": "GeForce GTX 570",
+        "Benchmark": "3921"
+    },
+    {
+        "Graphics": "GeForce GTX 570M",
+        "Benchmark": "1877"
+    },
+    {
+        "Graphics": "GeForce GTX 580",
+        "Benchmark": "4633"
+    },
+    {
+        "Graphics": "GeForce GTX 580M",
+        "Benchmark": "2074"
+    },
+    {
+        "Graphics": "GeForce GTX 590",
+        "Benchmark": "3341"
+    },
+    {
+        "Graphics": "GeForce GTX 645",
+        "Benchmark": "1881"
+    },
+    {
+        "Graphics": "GeForce GTX 650",
+        "Benchmark": "1749"
+    },
+    {
+        "Graphics": "GeForce GTX 650 Ti",
+        "Benchmark": "2528"
+    },
+    {
+        "Graphics": "GeForce GTX 650 Ti BOOST",
+        "Benchmark": "3389"
+    },
+    {
+        "Graphics": "GeForce GTX 660",
+        "Benchmark": "4023"
+    },
+    {
+        "Graphics": "GeForce GTX 660 Ti",
+        "Benchmark": "4408"
+    },
+    {
+        "Graphics": "GeForce GTX 660M",
+        "Benchmark": "1444"
+    },
+    {
+        "Graphics": "GeForce GTX 670",
+        "Benchmark": "5343"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce GTX 670M",
+        "Benchmark": "1742"
+    },
+    {
+        "Graphics": "GeForce GTX 670MX",
+        "Benchmark": "1971"
+    },
+    {
+        "Graphics": "GeForce GTX 675M",
+        "Benchmark": "1925"
+    },
+    {
+        "Graphics": "GeForce GTX 675MX",
+        "Benchmark": "2969"
+    },
+    {
+        "Graphics": "GeForce GTX 680",
+        "Benchmark": "5600"
+    },
+    {
+        "Graphics": "GeForce GTX 680M",
+        "Benchmark": "3277"
+    },
+    {
+        "Graphics": "GeForce GTX 680M KY_Bullet Edition",
+        "Benchmark": "3568"
+    },
+    {
+        "Graphics": "GeForce GTX 680MX",
+        "Benchmark": "3686"
+    },
+    {
+        "Graphics": "GeForce GTX 690",
+        "Benchmark": "5500"
+    },
+    {
+        "Graphics": "GeForce GTX 745",
+        "Benchmark": "2132"
+    },
+    {
+        "Graphics": "GeForce GTX 750",
+        "Benchmark": "3333"
+    },
+    {
+        "Graphics": "GeForce GTX 750 Ti",
+        "Benchmark": "3899"
+    },
+    {
+        "Graphics": "GeForce GTX 760",
+        "Benchmark": "4807"
+    },
+    {
+        "Graphics": "GeForce GTX 760 Ti",
+        "Benchmark": "5317"
+    },
+    {
+        "Graphics": "GeForce GTX 760 Ti OEM",
+        "Benchmark": "5427"
+    },
+    {
+        "Graphics": "GeForce GTX 760A",
+        "Benchmark": "1226"
+    },
+    {
+        "Graphics": "GeForce GTX 760M",
+        "Benchmark": "1711"
+    },
+    {
+        "Graphics": "GeForce GTX 765M",
+        "Benchmark": "2009"
+    },
+    {
+        "Graphics": "GeForce GTX 770",
+        "Benchmark": "5941"
+    },
+    {
+        "Graphics": "GeForce GTX 770M",
+        "Benchmark": "2798"
+    },
+    {
+        "Graphics": "GeForce GTX 775M",
+        "Benchmark": "3688"
+    },
+    {
+        "Graphics": "GeForce GTX 780",
+        "Benchmark": "7990"
+    },
+    {
+        "Graphics": "GeForce GTX 780 Ti",
+        "Benchmark": "9459"
+    },
+    {
+        "Graphics": "GeForce GTX 780M",
+        "Benchmark": "3807"
+    },
+    {
+        "Graphics": "GeForce GTX 850A",
+        "Benchmark": "1049"
+    },
+    {
+        "Graphics": "GeForce GTX 850M",
+        "Benchmark": "2522"
+    },
+    {
+        "Graphics": "GeForce GTX 850M - MODDED",
+        "Benchmark": "1091"
+    },
+    {
+        "Graphics": "GeForce GTX 860M",
+        "Benchmark": "3081"
+    },
+    {
+        "Graphics": "GeForce GTX 870M",
+        "Benchmark": "3503"
+    },
+    {
+        "Graphics": "GeForce GTX 880M",
+        "Benchmark": "3817"
+    },
+    {
+        "Graphics": "GeForce GTX 950",
+        "Benchmark": "5344"
+    },
+    {
+        "Graphics": "GeForce GTX 950A",
+        "Benchmark": "2593"
+    },
+    {
+        "Graphics": "GeForce GTX 950M",
+        "Benchmark": "2574"
+    },
+    {
+        "Graphics": "GeForce GTX 960",
+        "Benchmark": "6115"
+    },
+    {
+        "Graphics": "GeForce GTX 960A",
+        "Benchmark": "3464"
+    },
+    {
+        "Graphics": "GeForce GTX 960M",
+        "Benchmark": "3364"
+    },
+    {
+        "Graphics": "GeForce GTX 965M",
+        "Benchmark": "3829"
+    },
+    {
+        "Graphics": "GeForce GTX 970",
+        "Benchmark": "9641"
+    },
+    {
+        "Graphics": "GeForce GTX 970M",
+        "Benchmark": "5689"
+    },
+    {
+        "Graphics": "GeForce GTX 970XM FORCE",
+        "Benchmark": "6706"
+    },
+    {
+        "Graphics": "GeForce GTX 980",
+        "Benchmark": "11112"
+    },
+    {
+        "Graphics": "GeForce GTX 980 Ti",
+        "Benchmark": "13743"
+    },
+    {
+        "Graphics": "GeForce GTX 980M",
+        "Benchmark": "7351"
+    },
+    {
+        "Graphics": "GeForce GTX 1050",
+        "Benchmark": "5031"
+    },
+    {
+        "Graphics": "GeForce GTX 1050 3GB",
+        "Benchmark": "5118"
+    },
+    {
+        "Graphics": "GeForce GTX 1050 (Mobile)",
+        "Benchmark": "4462"
+    },
+    {
+        "Graphics": "GeForce GTX 1050 Ti",
+        "Benchmark": "6340"
+    },
+    {
+        "Graphics": "GeForce GTX 1050 Ti (Mobile)",
+        "Benchmark": "5917"
+    },
+    {
+        "Graphics": "GeForce GTX 1050 Ti with Max-Q Design",
+        "Benchmark": "5309"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce GTX 1050 with Max-Q Design",
+        "Benchmark": "4007"
+    },
+    {
+        "Graphics": "GeForce GTX 1060",
+        "Benchmark": "10081"
+    },
+    {
+        "Graphics": "GeForce GTX 1060 3GB",
+        "Benchmark": "9800"
+    },
+    {
+        "Graphics": "GeForce GTX 1060 5GB",
+        "Benchmark": "9087"
+    },
+    {
+        "Graphics": "GeForce GTX 1060 (Mobile)",
+        "Benchmark": "8160"
+    },
+    {
+        "Graphics": "GeForce GTX 1060 with Max-Q Design",
+        "Benchmark": "7854"
+    },
+    {
+        "Graphics": "GeForce GTX 1070",
+        "Benchmark": "13498"
+    },
+    {
+        "Graphics": "GeForce GTX 1070 (Mobile)",
+        "Benchmark": "10465"
+    },
+    {
+        "Graphics": "GeForce GTX 1070 Ti",
+        "Benchmark": "14677"
+    },
+    {
+        "Graphics": "GeForce GTX 1070 with Max-Q Design",
+        "Benchmark": "9856"
+    },
+    {
+        "Graphics": "GeForce GTX 1080",
+        "Benchmark": "15583"
+    },
+    {
+        "Graphics": "GeForce GTX 1080 Ti",
+        "Benchmark": "18598"
+    },
+    {
+        "Graphics": "GeForce GTX 1080 with Max-Q Design",
+        "Benchmark": "11422"
+    },
+    {
+        "Graphics": "GeForce GTX 1630",
+        "Benchmark": "4979"
+    },
+    {
+        "Graphics": "GeForce GTX 1650",
+        "Benchmark": "7879"
+    },
+    {
+        "Graphics": "GeForce GTX 1650 (Mobile)",
+        "Benchmark": "6968"
+    },
+    {
+        "Graphics": "GeForce GTX 1650 SUPER",
+        "Benchmark": "10181"
+    },
+    {
+        "Graphics": "GeForce GTX 1650 Ti",
+        "Benchmark": "7539"
+    },
+    {
+        "Graphics": "GeForce GTX 1650 Ti with Max-Q Design",
+        "Benchmark": "6503"
+    },
+    {
+        "Graphics": "GeForce GTX 1650 with Max-Q Design",
+        "Benchmark": "6230"
+    },
+    {
+        "Graphics": "GeForce GTX 1660",
+        "Benchmark": "11657"
+    },
+    {
+        "Graphics": "GeForce GTX 1660 SUPER",
+        "Benchmark": "12708"
+    },
+    {
+        "Graphics": "GeForce GTX 1660 Ti",
+        "Benchmark": "12906"
+    },
+    {
+        "Graphics": "GeForce GTX 1660 Ti (Mobile)",
+        "Benchmark": "10141"
+    },
+    {
+        "Graphics": "GeForce GTX 1660 Ti with Max-Q Design",
+        "Benchmark": "8595"
+    },
+    {
+        "Graphics": "GeForce GTX Titan",
+        "Benchmark": "8195"
+    },
+    {
+        "Graphics": "GeForce GTX TITAN Black",
+        "Benchmark": "9184"
+    },
+    {
+        "Graphics": "GeForce GTX TITAN X",
+        "Benchmark": "12776"
+    },
+    {
+        "Graphics": "GeForce GTX TITAN Z",
+        "Benchmark": "8904"
+    },
+    {
+        "Graphics": "GeForce MX110",
+        "Benchmark": "1417"
+    },
+    {
+        "Graphics": "GeForce MX130",
+        "Benchmark": "1818"
+    },
+    {
+        "Graphics": "GeForce MX150",
+        "Benchmark": "2260"
+    },
+    {
+        "Graphics": "GeForce MX230",
+        "Benchmark": "1829"
+    },
+    {
+        "Graphics": "GeForce MX250",
+        "Benchmark": "2389"
+    },
+    {
+        "Graphics": "GeForce MX330",
+        "Benchmark": "2386"
+    },
+    {
+        "Graphics": "GeForce MX350",
+        "Benchmark": "2810"
+    },
+    {
+        "Graphics": "GeForce MX450",
+        "Benchmark": "3739"
+    },
+    {
+        "Graphics": "GeForce MX550",
+        "Benchmark": "4544"
+    },
+    {
+        "Graphics": "GeForce MX570",
+        "Benchmark": "5795"
+    },
+    {
+        "Graphics": "GeForce MX570 A",
+        "Benchmark": "6192"
+    },
+    {
+        "Graphics": "GeForce PCX 5300",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "GeForce PCX 5750",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "GeForce PCX 5900",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "GeForce RTX 2050",
+        "Benchmark": "7759"
+    },
+    {
+        "Graphics": "GeForce RTX 2060",
+        "Benchmark": "14116"
+    },
+    {
+        "Graphics": "GeForce RTX 2060 12GB",
+        "Benchmark": "15927"
+    },
+    {
+        "Graphics": "GeForce RTX 2060 (Mobile)",
+        "Benchmark": "11352"
+    },
+    {
+        "Graphics": "GeForce RTX 2060 SUPER",
+        "Benchmark": "16464"
+    },
+    {
+        "Graphics": "GeForce RTX 2060 with Max-Q Design",
+        "Benchmark": "9744"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce RTX 2070",
+        "Benchmark": "16101"
+    },
+    {
+        "Graphics": "GeForce RTX 2070 (Mobile)",
+        "Benchmark": "12357"
+    },
+    {
+        "Graphics": "GeForce RTX 2070 SUPER",
+        "Benchmark": "18186"
+    },
+    {
+        "Graphics": "GeForce RTX 2070 Super with Max-Q Design",
+        "Benchmark": "13609"
+    },
+    {
+        "Graphics": "GeForce RTX 2070 with Max-Q Design",
+        "Benchmark": "11530"
+    },
+    {
+        "Graphics": "GeForce RTX 2080",
+        "Benchmark": "18750"
+    },
+    {
+        "Graphics": "GeForce RTX 2080 (Mobile)",
+        "Benchmark": "15013"
+    },
+    {
+        "Graphics": "GeForce RTX 2080 SUPER",
+        "Benchmark": "19498"
+    },
+    {
+        "Graphics": "GeForce RTX 2080 Super with Max-Q Design",
+        "Benchmark": "13592"
+    },
+    {
+        "Graphics": "GeForce RTX 2080 Ti",
+        "Benchmark": "21586"
+    },
+    {
+        "Graphics": "GeForce RTX 2080 with Max-Q Design",
+        "Benchmark": "12856"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 4GB Laptop GPU",
+        "Benchmark": "9467"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 6GB",
+        "Benchmark": "10732"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 6GB Laptop GPU",
+        "Benchmark": "10279"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 8GB",
+        "Benchmark": "12580"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 A Laptop GPU",
+        "Benchmark": "11939"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 OEM",
+        "Benchmark": "11858"
+    },
+    {
+        "Graphics": "GeForce RTX 3050 Ti Laptop GPU",
+        "Benchmark": "10121"
+    },
+    {
+        "Graphics": "GeForce RTX 3060 8GB",
+        "Benchmark": "15238"
+    },
+    {
+        "Graphics": "GeForce RTX 3060 12GB",
+        "Benchmark": "16840"
+    },
+    {
+        "Graphics": "GeForce RTX 3060 Laptop GPU",
+        "Benchmark": "13233"
+    },
+    {
+        "Graphics": "GeForce RTX 3060 Ti",
+        "Benchmark": "20374"
+    },
+    {
+        "Graphics": "GeForce RTX 3070",
+        "Benchmark": "22238"
+    },
+    {
+        "Graphics": "GeForce RTX 3070 Laptop GPU",
+        "Benchmark": "15347"
+    },
+    {
+        "Graphics": "GeForce RTX 3070 Ti",
+        "Benchmark": "23389"
+    },
+    {
+        "Graphics": "GeForce RTX 3070 Ti Laptop GPU",
+        "Benchmark": "17789"
+    },
+    {
+        "Graphics": "GeForce RTX 3080",
+        "Benchmark": "25129"
+    },
+    {
+        "Graphics": "GeForce RTX 3080 12GB",
+        "Benchmark": "26569"
+    },
+    {
+        "Graphics": "GeForce RTX 3080 Laptop GPU",
+        "Benchmark": "16405"
+    },
+    {
+        "Graphics": "GeForce RTX 3080 Ti",
+        "Benchmark": "26922"
+    },
+    {
+        "Graphics": "GeForce RTX 3080 Ti Laptop GPU",
+        "Benchmark": "19374"
+    },
+    {
+        "Graphics": "GeForce RTX 3090",
+        "Benchmark": "26653"
+    },
+    {
+        "Graphics": "GeForce RTX 3090 Ti",
+        "Benchmark": "29501"
+    },
+    {
+        "Graphics": "GeForce RTX 4050 Laptop GPU",
+        "Benchmark": "14436"
+    },
+    {
+        "Graphics": "GeForce RTX 4060",
+        "Benchmark": "19703"
+    },
+    {
+        "Graphics": "GeForce RTX 4060 Laptop GPU",
+        "Benchmark": "17520"
+    },
+    {
+        "Graphics": "GeForce RTX 4060 Ti",
+        "Benchmark": "22723"
+    },
+    {
+        "Graphics": "GeForce RTX 4060 Ti 16GB",
+        "Benchmark": "22751"
+    },
+    {
+        "Graphics": "GeForce RTX 4070",
+        "Benchmark": "26942"
+    },
+    {
+        "Graphics": "GeForce RTX 4070 Laptop GPU",
+        "Benchmark": "19581"
+    },
+    {
+        "Graphics": "GeForce RTX 4070 SUPER",
+        "Benchmark": "29985"
+    },
+    {
+        "Graphics": "GeForce RTX 4070 Ti",
+        "Benchmark": "31637"
+    },
+    {
+        "Graphics": "GeForce RTX 4070 Ti SUPER",
+        "Benchmark": "31754"
+    },
+    {
+        "Graphics": "GeForce RTX 4080",
+        "Benchmark": "34435"
+    },
+    {
+        "Graphics": "GeForce RTX 4080 Laptop GPU",
+        "Benchmark": "24987"
+    },
+    {
+        "Graphics": "GeForce RTX 4080 SUPER",
+        "Benchmark": "34243"
+    },
+    {
+        "Graphics": "GeForce RTX 4090",
+        "Benchmark": "38262"
+    },
+    {
+        "Graphics": "GeForce RTX 4090 D",
+        "Benchmark": "31935"
+    },
+    {
+        "Graphics": "GeForce RTX 4090 Laptop GPU",
+        "Benchmark": "27266"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GeForce RTX 5060",
+        "Benchmark": "21378"
+    },
+    {
+        "Graphics": "GeForce RTX 5060 Laptop GPU",
+        "Benchmark": "19206"
+    },
+    {
+        "Graphics": "GeForce RTX 5060 Ti",
+        "Benchmark": "22572"
+    },
+    {
+        "Graphics": "GeForce RTX 5070",
+        "Benchmark": "28925"
+    },
+    {
+        "Graphics": "GeForce RTX 5070 Laptop GPU",
+        "Benchmark": "20690"
+    },
+    {
+        "Graphics": "GeForce RTX 5070 Ti",
+        "Benchmark": "32819"
+    },
+    {
+        "Graphics": "GeForce RTX 5070 Ti Laptop GPU",
+        "Benchmark": "24444"
+    },
+    {
+        "Graphics": "GeForce RTX 5080",
+        "Benchmark": "36143"
+    },
+    {
+        "Graphics": "GeForce RTX 5080 Laptop GPU",
+        "Benchmark": "28033"
+    },
+    {
+        "Graphics": "GeForce RTX 5090",
+        "Benchmark": "39818"
+    },
+    {
+        "Graphics": "GeForce RTX 5090 D",
+        "Benchmark": "39850"
+    },
+    {
+        "Graphics": "GeForce RTX 5090 Laptop GPU",
+        "Benchmark": "30505"
+    },
+    {
+        "Graphics": "GF117",
+        "Benchmark": "554"
+    },
+    {
+        "Graphics": "Glenfly Arise-GT-10C0",
+        "Benchmark": "1007"
+    },
+    {
+        "Graphics": "GRID GTX P40-6",
+        "Benchmark": "4340"
+    },
+    {
+        "Graphics": "GRID K1",
+        "Benchmark": "650"
+    },
+    {
+        "Graphics": "GRID K2",
+        "Benchmark": "2736"
+    },
+    {
+        "Graphics": "GRID K120Q",
+        "Benchmark": "293"
+    },
+    {
+        "Graphics": "GRID K140Q",
+        "Benchmark": "727"
+    },
+    {
+        "Graphics": "GRID K160Q",
+        "Benchmark": "628"
+    },
+    {
+        "Graphics": "GRID K180Q",
+        "Benchmark": "533"
+    },
+    {
+        "Graphics": "GRID K220Q",
+        "Benchmark": "912"
+    },
+    {
+        "Graphics": "GRID K240Q",
+        "Benchmark": "2541"
+    },
+    {
+        "Graphics": "GRID K260Q",
+        "Benchmark": "2949"
+    },
+    {
+        "Graphics": "GRID K280Q",
+        "Benchmark": "2839"
+    },
+    {
+        "Graphics": "GRID K520",
+        "Benchmark": "3516"
+    },
+    {
+        "Graphics": "GRID M6-0B",
+        "Benchmark": "911"
+    },
+    {
+        "Graphics": "GRID M6-1Q",
+        "Benchmark": "2069"
+    },
+    {
+        "Graphics": "GRID M6-8Q",
+        "Benchmark": "3568"
+    },
+    {
+        "Graphics": "GRID M10-0B",
+        "Benchmark": "870"
+    },
+    {
+        "Graphics": "GRID M10-0Q",
+        "Benchmark": "795"
+    },
+    {
+        "Graphics": "GRID M10-1B",
+        "Benchmark": "1493"
+    },
+    {
+        "Graphics": "GRID M10-1Q",
+        "Benchmark": "2384"
+    },
+    {
+        "Graphics": "GRID M10-2B",
+        "Benchmark": "2063"
+    },
+    {
+        "Graphics": "GRID M10-2Q",
+        "Benchmark": "2691"
+    },
+    {
+        "Graphics": "GRID M10-4Q",
+        "Benchmark": "2976"
+    },
+    {
+        "Graphics": "GRID M10-8Q",
+        "Benchmark": "2068"
+    },
+    {
+        "Graphics": "GRID M60-0B",
+        "Benchmark": "1838"
+    },
+    {
+        "Graphics": "GRID M60-0Q",
+        "Benchmark": "827"
+    },
+    {
+        "Graphics": "GRID M60-1B",
+        "Benchmark": "4456"
+    },
+    {
+        "Graphics": "GRID M60-1Q",
+        "Benchmark": "3694"
+    },
+    {
+        "Graphics": "GRID M60-2Q",
+        "Benchmark": "5203"
+    },
+    {
+        "Graphics": "GRID M60-4Q",
+        "Benchmark": "3831"
+    },
+    {
+        "Graphics": "GRID M60-8A",
+        "Benchmark": "5523"
+    },
+    {
+        "Graphics": "GRID M60-8Q",
+        "Benchmark": "3883"
+    },
+    {
+        "Graphics": "GRID P4-1B",
+        "Benchmark": "2151"
+    },
+    {
+        "Graphics": "GRID P4-4Q",
+        "Benchmark": "6234"
+    },
+    {
+        "Graphics": "GRID P4-8A",
+        "Benchmark": "3206"
+    },
+    {
+        "Graphics": "GRID P4-8Q",
+        "Benchmark": "5355"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "GRID P6-2Q",
+        "Benchmark": "3925"
+    },
+    {
+        "Graphics": "GRID P6-4Q",
+        "Benchmark": "4429"
+    },
+    {
+        "Graphics": "GRID P40-2B",
+        "Benchmark": "9842"
+    },
+    {
+        "Graphics": "GRID P40-2B4",
+        "Benchmark": "8160"
+    },
+    {
+        "Graphics": "GRID P40-2Q",
+        "Benchmark": "4130"
+    },
+    {
+        "Graphics": "GRID P40-3Q",
+        "Benchmark": "681"
+    },
+    {
+        "Graphics": "GRID P40-4Q",
+        "Benchmark": "5145"
+    },
+    {
+        "Graphics": "GRID P40-8Q",
+        "Benchmark": "7507"
+    },
+    {
+        "Graphics": "GRID P40-12Q",
+        "Benchmark": "8053"
+    },
+    {
+        "Graphics": "GRID P40-24Q",
+        "Benchmark": "8719"
+    },
+    {
+        "Graphics": "GRID P100-1B",
+        "Benchmark": "2223"
+    },
+    {
+        "Graphics": "GRID P100-8Q",
+        "Benchmark": "3267"
+    },
+    {
+        "Graphics": "GRID P100-16Q",
+        "Benchmark": "5944"
+    },
+    {
+        "Graphics": "GRID RTX6000-1B",
+        "Benchmark": "8473"
+    },
+    {
+        "Graphics": "GRID RTX6000-6Q",
+        "Benchmark": "21986"
+    },
+    {
+        "Graphics": "GRID RTX6000P-6Q",
+        "Benchmark": "4777"
+    },
+    {
+        "Graphics": "GRID RTX8000P-1B",
+        "Benchmark": "1053"
+    },
+    {
+        "Graphics": "GRID T4-1B",
+        "Benchmark": "1731"
+    },
+    {
+        "Graphics": "GRID T4-1Q",
+        "Benchmark": "3302"
+    },
+    {
+        "Graphics": "GRID T4-2B",
+        "Benchmark": "2900"
+    },
+    {
+        "Graphics": "GRID T4-2Q",
+        "Benchmark": "3765"
+    },
+    {
+        "Graphics": "GRID T4-4Q",
+        "Benchmark": "3608"
+    },
+    {
+        "Graphics": "GRID T4-8Q",
+        "Benchmark": "5565"
+    },
+    {
+        "Graphics": "GRID T4-16Q",
+        "Benchmark": "4910"
+    },
+    {
+        "Graphics": "GRID V100-8Q",
+        "Benchmark": "16"
+    },
+    {
+        "Graphics": "GRID V100D-8Q",
+        "Benchmark": "4155"
+    },
+    {
+        "Graphics": "GT 430",
+        "Benchmark": "223"
+    },
+    {
+        "Graphics": "IncrediblE HD",
+        "Benchmark": "389"
+    },
+    {
+        "Graphics": "IncrediblE HD 4000",
+        "Benchmark": "517"
+    },
+    {
+        "Graphics": "IncrediblE HD 4600",
+        "Benchmark": "749"
+    },
+    {
+        "Graphics": "Intel 2nd Generation SandyBridge HD",
+        "Benchmark": "169"
+    },
+    {
+        "Graphics": "Intel 2nd Generation SandyBridge HD 3000",
+        "Benchmark": "205"
+    },
+    {
+        "Graphics": "Intel 4th Generation Haswell HD",
+        "Benchmark": "419"
+    },
+    {
+        "Graphics": "Intel 865 Embedded Controller",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Intel 915G,910G Express",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Intel 915G/915GV/910GL Embedded Controller Functio",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Intel 945G Embedded Chipset Function 0",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Intel 946GZ Embedded Chipset",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Intel 946GZ Express",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel 82845G Controller",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel 82845G/GL Controller",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel 82845G/GL/GE/PE/GV Controller",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel 82852/82855 GM/GME Controller",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "Intel 82865G Controller",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Intel 82915G Express",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Intel 82915G/915GV/910GL",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Intel 82915G/GV/910GL Advanced v3.5",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel 82915G/GV/910GL Express",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Intel 82945G Express",
+        "Benchmark": "10"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Intel 82945G Express-Chipsatzfamilie",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "Intel - Express Chipset G41",
+        "Benchmark": "56"
+    },
+    {
+        "Graphics": "Intel - Express Chipset Q45/Q43",
+        "Benchmark": "57"
+    },
+    {
+        "Graphics": "Intel Arc",
+        "Benchmark": "5500"
+    },
+    {
+        "Graphics": "Intel Arc 130T GPU",
+        "Benchmark": "6409"
+    },
+    {
+        "Graphics": "Intel Arc 130V GPU",
+        "Benchmark": "4631"
+    },
+    {
+        "Graphics": "Intel Arc 140T",
+        "Benchmark": "5634"
+    },
+    {
+        "Graphics": "Intel Arc 140T GPU",
+        "Benchmark": "6870"
+    },
+    {
+        "Graphics": "Intel Arc 140V GPU",
+        "Benchmark": "5230"
+    },
+    {
+        "Graphics": "Intel Arc A310",
+        "Benchmark": "5435"
+    },
+    {
+        "Graphics": "Intel Arc A310 LP",
+        "Benchmark": "4828"
+    },
+    {
+        "Graphics": "Intel Arc A370M",
+        "Benchmark": "5115"
+    },
+    {
+        "Graphics": "Intel Arc A380",
+        "Benchmark": "6258"
+    },
+    {
+        "Graphics": "Intel Arc A530M",
+        "Benchmark": "7673"
+    },
+    {
+        "Graphics": "Intel Arc A580",
+        "Benchmark": "11930"
+    },
+    {
+        "Graphics": "Intel Arc A730M",
+        "Benchmark": "9808"
+    },
+    {
+        "Graphics": "Intel Arc A750",
+        "Benchmark": "12447"
+    },
+    {
+        "Graphics": "Intel Arc A770",
+        "Benchmark": "13186"
+    },
+    {
+        "Graphics": "Intel Arc A770M",
+        "Benchmark": "11983"
+    },
+    {
+        "Graphics": "Intel Arc B570",
+        "Benchmark": "13864"
+    },
+    {
+        "Graphics": "Intel Arc B580",
+        "Benchmark": "15766"
+    },
+    {
+        "Graphics": "Intel Arc Pro",
+        "Benchmark": "5741"
+    },
+    {
+        "Graphics": "Intel Arc Pro 140T GPU",
+        "Benchmark": "6803"
+    },
+    {
+        "Graphics": "Intel Arc Pro A60",
+        "Benchmark": "9194"
+    },
+    {
+        "Graphics": "Intel B43 Express Chipset",
+        "Benchmark": "138"
+    },
+    {
+        "Graphics": "Intel Coffee Lake UHD",
+        "Benchmark": "1158"
+    },
+    {
+        "Graphics": "Intel Extreme Controller",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "Intel G33/G31 Express",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "Intel G35 Express",
+        "Benchmark": "2097"
+    },
+    {
+        "Graphics": "Intel G41 Express Chipset",
+        "Benchmark": "141"
+    },
+    {
+        "Graphics": "Intel G41 Express-Chipsatz",
+        "Benchmark": "57"
+    },
+    {
+        "Graphics": "Intel G45/G43 Express Chipset",
+        "Benchmark": "137"
+    },
+    {
+        "Graphics": "Intel G45/G43/G41 Express Chipset",
+        "Benchmark": "67"
+    },
+    {
+        "Graphics": "Intel G965 Express",
+        "Benchmark": "222"
+    },
+    {
+        "Graphics": "Intel GMA 3150 Express",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel Graphics",
+        "Benchmark": "3162"
+    },
+    {
+        "Graphics": "Intel Haswell HD - GT1",
+        "Benchmark": "123"
+    },
+    {
+        "Graphics": "Intel Haswell HD - GT2",
+        "Benchmark": "139"
+    },
+    {
+        "Graphics": "Intel HD 500",
+        "Benchmark": "299"
+    },
+    {
+        "Graphics": "Intel HD 505",
+        "Benchmark": "360"
+    },
+    {
+        "Graphics": "Intel HD 510",
+        "Benchmark": "622"
+    },
+    {
+        "Graphics": "Intel HD 515",
+        "Benchmark": "637"
+    },
+    {
+        "Graphics": "Intel HD 520",
+        "Benchmark": "863"
+    },
+    {
+        "Graphics": "Intel HD 530",
+        "Benchmark": "993"
+    },
+    {
+        "Graphics": "Intel HD 610",
+        "Benchmark": "691"
+    },
+    {
+        "Graphics": "Intel HD 615",
+        "Benchmark": "701"
+    },
+    {
+        "Graphics": "Intel HD 630",
+        "Benchmark": "1114"
+    },
+    {
+        "Graphics": "Intel HD 2000",
+        "Benchmark": "213"
+    },
+    {
+        "Graphics": "Intel HD 3000",
+        "Benchmark": "260"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Intel HD 4000",
+        "Benchmark": "345"
+    },
+    {
+        "Graphics": "Intel HD 4400",
+        "Benchmark": "523"
+    },
+    {
+        "Graphics": "Intel HD 4600",
+        "Benchmark": "629"
+    },
+    {
+        "Graphics": "Intel HD 4600 manual-gen9_2015-134121",
+        "Benchmark": "619"
+    },
+    {
+        "Graphics": "Intel HD 5000",
+        "Benchmark": "583"
+    },
+    {
+        "Graphics": "Intel HD 5200",
+        "Benchmark": "830"
+    },
+    {
+        "Graphics": "Intel HD 5300",
+        "Benchmark": "404"
+    },
+    {
+        "Graphics": "Intel HD 5500",
+        "Benchmark": "593"
+    },
+    {
+        "Graphics": "Intel HD 5600",
+        "Benchmark": "1868"
+    },
+    {
+        "Graphics": "Intel HD 6000",
+        "Benchmark": "873"
+    },
+    {
+        "Graphics": "Intel HD Family",
+        "Benchmark": "463"
+    },
+    {
+        "Graphics": "Intel HD Graphics 620",
+        "Benchmark": "921"
+    },
+    {
+        "Graphics": "Intel HD manual-15.28-1861",
+        "Benchmark": "62"
+    },
+    {
+        "Graphics": "Intel HD manual-gen9_2015-133271",
+        "Benchmark": "165"
+    },
+    {
+        "Graphics": "Intel HD Modded",
+        "Benchmark": "112"
+    },
+    {
+        "Graphics": "Intel HD P530",
+        "Benchmark": "1161"
+    },
+    {
+        "Graphics": "Intel HD P630",
+        "Benchmark": "1226"
+    },
+    {
+        "Graphics": "Intel HD P3000",
+        "Benchmark": "282"
+    },
+    {
+        "Graphics": "Intel HD P4000",
+        "Benchmark": "516"
+    },
+    {
+        "Graphics": "Intel HD P4600",
+        "Benchmark": "505"
+    },
+    {
+        "Graphics": "Intel HD P4600/P4700",
+        "Benchmark": "631"
+    },
+    {
+        "Graphics": "Intel Infoshock HD",
+        "Benchmark": "193"
+    },
+    {
+        "Graphics": "Intel Iris 540",
+        "Benchmark": "1260"
+    },
+    {
+        "Graphics": "Intel Iris 550",
+        "Benchmark": "1439"
+    },
+    {
+        "Graphics": "Intel Iris 650",
+        "Benchmark": "1432"
+    },
+    {
+        "Graphics": "Intel Iris 5100",
+        "Benchmark": "741"
+    },
+    {
+        "Graphics": "Intel Iris 6100",
+        "Benchmark": "901"
+    },
+    {
+        "Graphics": "Intel Iris Plus",
+        "Benchmark": "1807"
+    },
+    {
+        "Graphics": "Intel Iris Plus 640",
+        "Benchmark": "1358"
+    },
+    {
+        "Graphics": "Intel Iris Plus 645",
+        "Benchmark": "1749"
+    },
+    {
+        "Graphics": "Intel Iris Plus 650",
+        "Benchmark": "1611"
+    },
+    {
+        "Graphics": "Intel Iris Plus 655",
+        "Benchmark": "1718"
+    },
+    {
+        "Graphics": "Intel Iris Pro 580",
+        "Benchmark": "1997"
+    },
+    {
+        "Graphics": "Intel Iris Pro 5200",
+        "Benchmark": "1180"
+    },
+    {
+        "Graphics": "Intel Iris Pro 6100",
+        "Benchmark": "925"
+    },
+    {
+        "Graphics": "Intel Iris Pro Graphics 6200",
+        "Benchmark": "1525"
+    },
+    {
+        "Graphics": "Intel Iris Pro P580",
+        "Benchmark": "1845"
+    },
+    {
+        "Graphics": "Intel Iris Pro P6300",
+        "Benchmark": "1596"
+    },
+    {
+        "Graphics": "Intel Iris Xe",
+        "Benchmark": "2656"
+    },
+    {
+        "Graphics": "Intel Iris Xe MAX",
+        "Benchmark": "1971"
+    },
+    {
+        "Graphics": "Intel Iris Xe MAX 100",
+        "Benchmark": "1964"
+    },
+    {
+        "Graphics": "Intel Media Accelerator",
+        "Benchmark": "32"
+    },
+    {
+        "Graphics": "Intel Media Accelerator 500",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Intel Media Accelerator 600",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "Intel Media Accelerator 3150",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Intel Media Accelerator HD",
+        "Benchmark": "106"
+    },
+    {
+        "Graphics": "Intel Poison Ivy",
+        "Benchmark": "738"
+    },
+    {
+        "Graphics": "Intel Q33 Express",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "Intel Q35 Embedded",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Intel Q35 Express",
+        "Benchmark": "64"
+    },
+    {
+        "Graphics": "Intel Q45/Q43 Express Chipset",
+        "Benchmark": "202"
+    },
+    {
+        "Graphics": "Intel Q45/Q43 Express-Chipsatz",
+        "Benchmark": "57"
+    },
+    {
+        "Graphics": "Intel Q965/Q963 Express",
+        "Benchmark": "135"
+    },
+    {
+        "Graphics": "Intel Skylake HD DT GT2",
+        "Benchmark": "576"
+    },
+    {
+        "Graphics": "Intel UHD 630",
+        "Benchmark": "614"
+    },
+    {
+        "Graphics": "Intel UHD Graphics",
+        "Benchmark": "1495"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 600",
+        "Benchmark": "317"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 605",
+        "Benchmark": "368"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 610",
+        "Benchmark": "686"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 615",
+        "Benchmark": "722"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 617",
+        "Benchmark": "855"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 620",
+        "Benchmark": "1042"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 630",
+        "Benchmark": "1236"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 710",
+        "Benchmark": "1077"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 730",
+        "Benchmark": "1561"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 750",
+        "Benchmark": "1718"
+    },
+    {
+        "Graphics": "Intel UHD Graphics 770",
+        "Benchmark": "1905"
+    },
+    {
+        "Graphics": "Intel UHD Graphics P630",
+        "Benchmark": "2045"
+    },
+    {
+        "Graphics": "Intel UHD Graphics P750",
+        "Benchmark": "1662"
+    },
+    {
+        "Graphics": "Intel US15 Embedded Media and Controller",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "ION",
+        "Benchmark": "108"
+    },
+    {
+        "Graphics": "ION LE",
+        "Benchmark": "97"
+    },
+    {
+        "Graphics": "L4",
+        "Benchmark": "7582"
+    },
+    {
+        "Graphics": "L4-1Q",
+        "Benchmark": "258"
+    },
+    {
+        "Graphics": "L4-2A",
+        "Benchmark": "3063"
+    },
+    {
+        "Graphics": "L4-2Q",
+        "Benchmark": "4062"
+    },
+    {
+        "Graphics": "L4-4Q",
+        "Benchmark": "4926"
+    },
+    {
+        "Graphics": "L4-6Q",
+        "Benchmark": "4473"
+    },
+    {
+        "Graphics": "L40-8Q",
+        "Benchmark": "11670"
+    },
+    {
+        "Graphics": "L40S",
+        "Benchmark": "20022"
+    },
+    {
+        "Graphics": "L40S-12Q",
+        "Benchmark": "4500"
+    },
+    {
+        "Graphics": "M860G with Mobility Radeon 4100",
+        "Benchmark": "75"
+    },
+    {
+        "Graphics": "M880G with Mobility Radeon HD 4200",
+        "Benchmark": "92"
+    },
+    {
+        "Graphics": "M880G with Mobility Radeon HD 4225",
+        "Benchmark": "71"
+    },
+    {
+        "Graphics": "M880G with Mobility Radeon HD 4250",
+        "Benchmark": "104"
+    },
+    {
+        "Graphics": "Master X3100 Driver",
+        "Benchmark": "10"
+    },
+    {
+        "Graphics": "Matrox C420 LP PCIe x16",
+        "Benchmark": "597"
+    },
+    {
+        "Graphics": "Matrox C680 PCIe x16",
+        "Benchmark": "1903"
+    },
+    {
+        "Graphics": "Matrox C900 PCIe x16",
+        "Benchmark": "1812"
+    },
+    {
+        "Graphics": "Matrox G200e WDDM 1.2",
+        "Benchmark": "59"
+    },
+    {
+        "Graphics": "Matrox G200e WDDM 2.0",
+        "Benchmark": "100"
+    },
+    {
+        "Graphics": "Matrox G200eh",
+        "Benchmark": "40"
+    },
+    {
+        "Graphics": "Matrox G200eh WDDM 1.2",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "Matrox G200eh WDDM 2.0",
+        "Benchmark": "49"
+    },
+    {
+        "Graphics": "Matrox G200eR",
+        "Benchmark": "36"
+    },
+    {
+        "Graphics": "Matrox G200eR WDDM 1.2",
+        "Benchmark": "45"
+    },
+    {
+        "Graphics": "Matrox G200eR WDDM 2.0",
+        "Benchmark": "67"
+    },
+    {
+        "Graphics": "Matrox G200eW",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Matrox G200eW3 WDDM 2.0",
+        "Benchmark": "89"
+    },
+    {
+        "Graphics": "Matrox G200eW WDDM 1.2",
+        "Benchmark": "50"
+    },
+    {
+        "Graphics": "Matrox LUMA A310",
+        "Benchmark": "3690"
+    },
+    {
+        "Graphics": "Matrox LUMA A310F",
+        "Benchmark": "3873"
+    },
+    {
+        "Graphics": "Matrox LUMA A380P",
+        "Benchmark": "5811"
+    },
+    {
+        "Graphics": "Matrox M9120 PCIe x16",
+        "Benchmark": "19"
+    },
+    {
+        "Graphics": "Matrox M9120 Plus LP PCIe x16",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "Matrox M9125 PCIe x16",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "Matrox M9128 LP PCIe x16",
+        "Benchmark": "31"
+    },
+    {
+        "Graphics": "Matrox M9138 LP PCIe x16",
+        "Benchmark": "42"
+    },
+    {
+        "Graphics": "Matrox M9140 LP PCIe x16",
+        "Benchmark": "23"
+    },
+    {
+        "Graphics": "Matrox M9148 LP PCIe x16",
+        "Benchmark": "40"
+    },
+    {
+        "Graphics": "Matrox M9188 ATX PCIe x16",
+        "Benchmark": "45"
+    },
+    {
+        "Graphics": "Matrox Millennium P650 PCIe 128",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Matrox Millennium P690 PCIe x16",
+        "Benchmark": "366"
+    },
+    {
+        "Graphics": "Matrox Millennium P690 Plus LP PCIe x16",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "Matrox Parhelia 128MB",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Matrox Parhelia 256MB",
+        "Benchmark": "9"
+    },
+    {
+        "Graphics": "Matrox Parhelia APVe",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "MEDION RADEON 9800 XXL",
+        "Benchmark": "71"
+    },
+    {
+        "Graphics": "MEDION RADEON X740XL",
+        "Benchmark": "94"
+    },
+    {
+        "Graphics": "Meta Virtual Monitor",
+        "Benchmark": "7142"
+    },
+    {
+        "Graphics": "Mi Pad 5 Adreno 640 GPU",
+        "Benchmark": "657"
+    },
+    {
+        "Graphics": "Mirage Driver",
+        "Benchmark": "2038"
+    },
+    {
+        "Graphics": "MIRRORV3",
+        "Benchmark": "1080"
+    },
+    {
+        "Graphics": "Mobile Intel965 Express",
+        "Benchmark": "17"
+    },
+    {
+        "Graphics": "Mobile Intel 4 Express-Chipsatzfamilie",
+        "Benchmark": "44"
+    },
+    {
+        "Graphics": "Mobile Intel 45 Express",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "Mobile Intel 45 Express-Chipsatzfamilie",
+        "Benchmark": "117"
+    },
+    {
+        "Graphics": "Mobile Intel 915GM/GMS/910GML Express",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "Mobile Intel 945 Express",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "Mobile Intel 945GM Express",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Mobile Intel 945GM/GU Express",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Mobile Intel 965 Express",
+        "Benchmark": "46"
+    },
+    {
+        "Graphics": "Mobile Intel 965 Express - BR-0907-0461 v1839",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "Mobile Intel 965 Express-Chipsatzfamilie",
+        "Benchmark": "24"
+    },
+    {
+        "Graphics": "Mobile Intel - famiglia Express Chipset 45",
+        "Benchmark": "38"
+    },
+    {
+        "Graphics": "Mobile Intel HD",
+        "Benchmark": "244"
+    },
+    {
+        "Graphics": "Mobile Intel serie 4 Express",
+        "Benchmark": "44"
+    },
+    {
+        "Graphics": "MOBILITY FIREGL 7800",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "MOBILITY FIREGL T2",
+        "Benchmark": "40"
+    },
+    {
+        "Graphics": "MOBILITY FIREGL T2/T2e",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "MOBILITY FireGL V3200",
+        "Benchmark": "62"
+    },
+    {
+        "Graphics": "MOBILITY FireGL V5000",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "MOBILITY FireGL V5200",
+        "Benchmark": "44"
+    },
+    {
+        "Graphics": "MOBILITY FireGL V5250",
+        "Benchmark": "27"
+    },
+    {
+        "Graphics": "Mobility FireGL V5725",
+        "Benchmark": "219"
+    },
+    {
+        "Graphics": "MOBILITY IGP 9000/9100",
+        "Benchmark": "10"
+    },
+    {
+        "Graphics": "Mobility Radeon 4100",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 7000 IGP",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 7500",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9000",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9000 IGP",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9000/9100 IGP",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9100 IGP",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9200",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9550",
+        "Benchmark": "30"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9600",
+        "Benchmark": "36"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9600 PRO TURBO",
+        "Benchmark": "24"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9600/9700",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9700",
+        "Benchmark": "27"
+    },
+    {
+        "Graphics": "MOBILITY RADEON 9800",
+        "Benchmark": "46"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 530v",
+        "Benchmark": "174"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 540v",
+        "Benchmark": "188"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 545v",
+        "Benchmark": "199"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 550v",
+        "Benchmark": "266"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 560v",
+        "Benchmark": "318"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 565v",
+        "Benchmark": "353"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 2300",
+        "Benchmark": "50"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 2400",
+        "Benchmark": "89"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 2400 XT",
+        "Benchmark": "102"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 2600",
+        "Benchmark": "167"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 2600 XT",
+        "Benchmark": "191"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3400 Serisi",
+        "Benchmark": "111"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3410",
+        "Benchmark": "62"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3430",
+        "Benchmark": "98"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3450",
+        "Benchmark": "91"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3470",
+        "Benchmark": "93"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3470 Hybrid X2",
+        "Benchmark": "93"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3650",
+        "Benchmark": "141"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3670",
+        "Benchmark": "232"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3850",
+        "Benchmark": "365"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3870",
+        "Benchmark": "547"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 3870 X2",
+        "Benchmark": "477"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4200",
+        "Benchmark": "90"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4225",
+        "Benchmark": "66"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4250",
+        "Benchmark": "98"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4270",
+        "Benchmark": "92"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4300 Serisi",
+        "Benchmark": "73"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4330",
+        "Benchmark": "135"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4350",
+        "Benchmark": "148"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4550",
+        "Benchmark": "191"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4570",
+        "Benchmark": "149"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4650",
+        "Benchmark": "401"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4670",
+        "Benchmark": "463"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4830",
+        "Benchmark": "511"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4850",
+        "Benchmark": "866"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 4870",
+        "Benchmark": "719"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5000",
+        "Benchmark": "773"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5000 Serisi",
+        "Benchmark": "478"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5165",
+        "Benchmark": "284"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5430",
+        "Benchmark": "181"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5450",
+        "Benchmark": "214"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5470",
+        "Benchmark": "236"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5570",
+        "Benchmark": "525"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5650",
+        "Benchmark": "443"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5730",
+        "Benchmark": "508"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5850",
+        "Benchmark": "763"
+    },
+    {
+        "Graphics": "Mobility Radeon HD 5870",
+        "Benchmark": "1091"
+    },
+    {
+        "Graphics": "Mobility Radeon HD serie 4200",
+        "Benchmark": "96"
+    },
+    {
+        "Graphics": "MOBILITY RADEON X300",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "MOBILITY RADEON X600",
+        "Benchmark": "50"
+    },
+    {
+        "Graphics": "MOBILITY RADEON X600 SE",
+        "Benchmark": "49"
+    },
+    {
+        "Graphics": "MOBILITY RADEON X700",
+        "Benchmark": "66"
+    },
+    {
+        "Graphics": "MOBILITY RADEON X700 XL",
+        "Benchmark": "59"
+    },
+    {
+        "Graphics": "Mobility Radeon X1300",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "Mobility Radeon X1350",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "Mobility Radeon X1400",
+        "Benchmark": "42"
+    },
+    {
+        "Graphics": "Mobility Radeon X1450",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "Mobility Radeon X1600",
+        "Benchmark": "92"
+    },
+    {
+        "Graphics": "Mobility Radeon X1700",
+        "Benchmark": "104"
+    },
+    {
+        "Graphics": "MOBILITY RADEON X1800",
+        "Benchmark": "130"
+    },
+    {
+        "Graphics": "Mobility Radeon X1900",
+        "Benchmark": "134"
+    },
+    {
+        "Graphics": "Mobility Radeon X2300",
+        "Benchmark": "48"
+    },
+    {
+        "Graphics": "Mobility Radeon X2300 HD",
+        "Benchmark": "48"
+    },
+    {
+        "Graphics": "Mobility Radeon X2500",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "MOBILITY RADEON XPRESS 200",
+        "Benchmark": "27"
+    },
+    {
+        "Graphics": "Mobility Radeon. HD 5470",
+        "Benchmark": "215"
+    },
+    {
+        "Graphics": "MOBILITY/RADEON 9000",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "MONSTER GeForce GTX 675M",
+        "Benchmark": "2637"
+    },
+    {
+        "Graphics": "Moore Threads S3000 MTvGPU-1132",
+        "Benchmark": "1997"
+    },
+    {
+        "Graphics": "MxGPU",
+        "Benchmark": "1282"
+    },
+    {
+        "Graphics": "N16P-GX",
+        "Benchmark": "1204"
+    },
+    {
+        "Graphics": "N18E-Q1",
+        "Benchmark": "2525"
+    },
+    {
+        "Graphics": "nForce 750a SLI",
+        "Benchmark": "83"
+    },
+    {
+        "Graphics": "nForce 760i SLI",
+        "Benchmark": "140"
+    },
+    {
+        "Graphics": "nForce 780a SLI",
+        "Benchmark": "92"
+    },
+    {
+        "Graphics": "nForce 980a/780a SLI",
+        "Benchmark": "164"
+    },
+    {
+        "Graphics": "NV44",
+        "Benchmark": "15"
+    },
+    {
+        "Graphics": "NVIDIA A10",
+        "Benchmark": "22064"
+    },
+    {
+        "Graphics": "NVIDIA A10-4Q",
+        "Benchmark": "2756"
+    },
+    {
+        "Graphics": "NVIDIA A10G",
+        "Benchmark": "17660"
+    },
+    {
+        "Graphics": "NVIDIA A40",
+        "Benchmark": "13900"
+    },
+    {
+        "Graphics": "NVIDIA A40-4Q",
+        "Benchmark": "4727"
+    },
+    {
+        "Graphics": "NVIDIA A40-8Q",
+        "Benchmark": "4681"
+    },
+    {
+        "Graphics": "NVIDIA A40-12Q",
+        "Benchmark": "4335"
+    },
+    {
+        "Graphics": "NVIDIA GeForce3 Ti200",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "NVIDIA TITAN X",
+        "Benchmark": "13659"
+    },
+    {
+        "Graphics": "NVIDIA TITAN Xp",
+        "Benchmark": "18792"
+    },
+    {
+        "Graphics": "NVS 300",
+        "Benchmark": "121"
+    },
+    {
+        "Graphics": "NVS 310",
+        "Benchmark": "265"
+    },
+    {
+        "Graphics": "NVS 315",
+        "Benchmark": "320"
+    },
+    {
+        "Graphics": "NVS 510",
+        "Benchmark": "682"
+    },
+    {
+        "Graphics": "NVS 810",
+        "Benchmark": "1190"
+    },
+    {
+        "Graphics": "NVS 2100M",
+        "Benchmark": "139"
+    },
+    {
+        "Graphics": "NVS 3100M",
+        "Benchmark": "118"
+    },
+    {
+        "Graphics": "NVS 4200M",
+        "Benchmark": "297"
+    },
+    {
+        "Graphics": "NVS 5100M",
+        "Benchmark": "199"
+    },
+    {
+        "Graphics": "NVS 5200M",
+        "Benchmark": "505"
+    },
+    {
+        "Graphics": "NVS 5400M",
+        "Benchmark": "617"
+    },
+    {
+        "Graphics": "OPAL XT/GL",
+        "Benchmark": "1053"
+    },
+    {
+        "Graphics": "P102-100",
+        "Benchmark": "2911"
+    },
+    {
+        "Graphics": "P104-100",
+        "Benchmark": "3602"
+    },
+    {
+        "Graphics": "P106-090",
+        "Benchmark": "2404"
+    },
+    {
+        "Graphics": "P106-100",
+        "Benchmark": "6670"
+    },
+    {
+        "Graphics": "Parsec Virtual Display Adapter",
+        "Benchmark": "6220"
+    },
+    {
+        "Graphics": "PCI\\VEN_1002&DEV_164E&SUBSYS_D0001458&REV_C3 Ryzen",
+        "Benchmark": "1653"
+    },
+    {
+        "Graphics": "PCI\\VEN_1002&DEV_164E&SUBSYS_D0001458&REV_C7 Ryzen",
+        "Benchmark": "1642"
+    },
+    {
+        "Graphics": "PHDGD Ivy 4",
+        "Benchmark": "374"
+    },
+    {
+        "Graphics": "PHDGD Ivy 5",
+        "Benchmark": "445"
+    },
+    {
+        "Graphics": "PHDGD Quantic C3",
+        "Benchmark": "116"
+    },
+    {
+        "Graphics": "PHDGD Sapphire GR for Mobile Intel 965",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "PHDGD Solo 1.2.0 x86",
+        "Benchmark": "11"
+    },
+    {
+        "Graphics": "PHDGD Solo 2 x64",
+        "Benchmark": "20"
+    },
+    {
+        "Graphics": "Q12U-1",
+        "Benchmark": "5164"
+    },
+    {
+        "Graphics": "Quadro2 MXR/EX",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Quadro2 Pro",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "Quadro4 380 XGL",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "Quadro4 900 XGL",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Quadro4 980 XGL",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Quadro 280 NVS PCIe",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Quadro 400",
+        "Benchmark": "148"
+    },
+    {
+        "Graphics": "Quadro 410",
+        "Benchmark": "439"
+    },
+    {
+        "Graphics": "Quadro 500M",
+        "Benchmark": "570"
+    },
+    {
+        "Graphics": "Quadro 600",
+        "Benchmark": "525"
+    },
+    {
+        "Graphics": "Quadro 1000M",
+        "Benchmark": "559"
+    },
+    {
+        "Graphics": "Quadro 1100M",
+        "Benchmark": "755"
+    },
+    {
+        "Graphics": "Quadro 2000",
+        "Benchmark": "946"
+    },
+    {
+        "Graphics": "Quadro 2000 D",
+        "Benchmark": "1239"
+    },
+    {
+        "Graphics": "Quadro 2000D",
+        "Benchmark": "976"
+    },
+    {
+        "Graphics": "Quadro 2000M",
+        "Benchmark": "776"
+    },
+    {
+        "Graphics": "Quadro 2100M",
+        "Benchmark": "1100"
+    },
+    {
+        "Graphics": "Quadro 3000M",
+        "Benchmark": "999"
+    },
+    {
+        "Graphics": "Quadro 4000",
+        "Benchmark": "1475"
+    },
+    {
+        "Graphics": "Quadro 4000M",
+        "Benchmark": "1287"
+    },
+    {
+        "Graphics": "Quadro 5000",
+        "Benchmark": "1958"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Quadro 5000M",
+        "Benchmark": "2059"
+    },
+    {
+        "Graphics": "Quadro 5010M",
+        "Benchmark": "1691"
+    },
+    {
+        "Graphics": "Quadro 6000",
+        "Benchmark": "2687"
+    },
+    {
+        "Graphics": "Quadro 7000",
+        "Benchmark": "3505"
+    },
+    {
+        "Graphics": "Quadro CX",
+        "Benchmark": "947"
+    },
+    {
+        "Graphics": "Quadro FX 350",
+        "Benchmark": "85"
+    },
+    {
+        "Graphics": "Quadro FX 350M",
+        "Benchmark": "44"
+    },
+    {
+        "Graphics": "Quadro FX 360M",
+        "Benchmark": "86"
+    },
+    {
+        "Graphics": "Quadro FX 370",
+        "Benchmark": "83"
+    },
+    {
+        "Graphics": "Quadro FX 370 Low Profile",
+        "Benchmark": "102"
+    },
+    {
+        "Graphics": "Quadro FX 370 LP",
+        "Benchmark": "108"
+    },
+    {
+        "Graphics": "Quadro FX 370M",
+        "Benchmark": "93"
+    },
+    {
+        "Graphics": "Quadro FX 380",
+        "Benchmark": "173"
+    },
+    {
+        "Graphics": "Quadro FX 380 LP",
+        "Benchmark": "144"
+    },
+    {
+        "Graphics": "Quadro FX 380M",
+        "Benchmark": "120"
+    },
+    {
+        "Graphics": "Quadro FX 500/600 PCI",
+        "Benchmark": "14"
+    },
+    {
+        "Graphics": "Quadro FX 500/FX 600",
+        "Benchmark": "7"
+    },
+    {
+        "Graphics": "Quadro FX 540",
+        "Benchmark": "80"
+    },
+    {
+        "Graphics": "Quadro FX 550",
+        "Benchmark": "63"
+    },
+    {
+        "Graphics": "Quadro FX 560",
+        "Benchmark": "113"
+    },
+    {
+        "Graphics": "Quadro FX 570",
+        "Benchmark": "248"
+    },
+    {
+        "Graphics": "Quadro FX 570M",
+        "Benchmark": "99"
+    },
+    {
+        "Graphics": "Quadro FX 580",
+        "Benchmark": "173"
+    },
+    {
+        "Graphics": "Quadro FX 770M",
+        "Benchmark": "220"
+    },
+    {
+        "Graphics": "Quadro FX 880M",
+        "Benchmark": "230"
+    },
+    {
+        "Graphics": "Quadro FX 1000",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "Quadro FX 1100",
+        "Benchmark": "35"
+    },
+    {
+        "Graphics": "Quadro FX 1300",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "Quadro FX 1400",
+        "Benchmark": "124"
+    },
+    {
+        "Graphics": "Quadro FX 1500",
+        "Benchmark": "169"
+    },
+    {
+        "Graphics": "Quadro FX 1500M",
+        "Benchmark": "171"
+    },
+    {
+        "Graphics": "Quadro FX 1600M",
+        "Benchmark": "231"
+    },
+    {
+        "Graphics": "Quadro FX 1700",
+        "Benchmark": "207"
+    },
+    {
+        "Graphics": "Quadro FX 1700M",
+        "Benchmark": "172"
+    },
+    {
+        "Graphics": "Quadro FX 1800",
+        "Benchmark": "402"
+    },
+    {
+        "Graphics": "Quadro FX 1800M",
+        "Benchmark": "494"
+    },
+    {
+        "Graphics": "Quadro FX 2000",
+        "Benchmark": "18"
+    },
+    {
+        "Graphics": "Quadro FX 2500M",
+        "Benchmark": "217"
+    },
+    {
+        "Graphics": "Quadro FX 2700",
+        "Benchmark": "543"
+    },
+    {
+        "Graphics": "Quadro FX 2700M",
+        "Benchmark": "366"
+    },
+    {
+        "Graphics": "Quadro FX 2800M",
+        "Benchmark": "414"
+    },
+    {
+        "Graphics": "Quadro FX 3000",
+        "Benchmark": "69"
+    },
+    {
+        "Graphics": "Quadro FX 3400/4400",
+        "Benchmark": "104"
+    },
+    {
+        "Graphics": "Quadro FX 3450",
+        "Benchmark": "148"
+    },
+    {
+        "Graphics": "Quadro FX 3450/4000 SDI",
+        "Benchmark": "179"
+    },
+    {
+        "Graphics": "Quadro FX 3500",
+        "Benchmark": "259"
+    },
+    {
+        "Graphics": "Quadro FX 3500M",
+        "Benchmark": "306"
+    },
+    {
+        "Graphics": "Quadro FX 3600M",
+        "Benchmark": "466"
+    },
+    {
+        "Graphics": "Quadro FX 3700",
+        "Benchmark": "372"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Quadro FX 3700M",
+        "Benchmark": "452"
+    },
+    {
+        "Graphics": "Quadro FX 3800",
+        "Benchmark": "827"
+    },
+    {
+        "Graphics": "Quadro FX 3800M",
+        "Benchmark": "574"
+    },
+    {
+        "Graphics": "Quadro FX 4000",
+        "Benchmark": "101"
+    },
+    {
+        "Graphics": "Quadro FX 4500",
+        "Benchmark": "227"
+    },
+    {
+        "Graphics": "Quadro FX 4500 X2",
+        "Benchmark": "236"
+    },
+    {
+        "Graphics": "Quadro FX 4600",
+        "Benchmark": "413"
+    },
+    {
+        "Graphics": "Quadro FX 4700 X2",
+        "Benchmark": "676"
+    },
+    {
+        "Graphics": "Quadro FX 4800",
+        "Benchmark": "995"
+    },
+    {
+        "Graphics": "Quadro FX 5500",
+        "Benchmark": "242"
+    },
+    {
+        "Graphics": "Quadro FX 5600",
+        "Benchmark": "525"
+    },
+    {
+        "Graphics": "Quadro FX 5800",
+        "Benchmark": "1210"
+    },
+    {
+        "Graphics": "Quadro FX Go1400",
+        "Benchmark": "101"
+    },
+    {
+        "Graphics": "Quadro GP100",
+        "Benchmark": "14953"
+    },
+    {
+        "Graphics": "Quadro GV100",
+        "Benchmark": "19832"
+    },
+    {
+        "Graphics": "Quadro K420",
+        "Benchmark": "732"
+    },
+    {
+        "Graphics": "Quadro K510M",
+        "Benchmark": "641"
+    },
+    {
+        "Graphics": "Quadro K600",
+        "Benchmark": "725"
+    },
+    {
+        "Graphics": "Quadro K610M",
+        "Benchmark": "712"
+    },
+    {
+        "Graphics": "Quadro K620",
+        "Benchmark": "2219"
+    },
+    {
+        "Graphics": "Quadro K620M",
+        "Benchmark": "1163"
+    },
+    {
+        "Graphics": "Quadro K1000M",
+        "Benchmark": "770"
+    },
+    {
+        "Graphics": "Quadro K1100M",
+        "Benchmark": "1088"
+    },
+    {
+        "Graphics": "Quadro K1200",
+        "Benchmark": "2955"
+    },
+    {
+        "Graphics": "Quadro K2000",
+        "Benchmark": "1579"
+    },
+    {
+        "Graphics": "Quadro K2000D",
+        "Benchmark": "1590"
+    },
+    {
+        "Graphics": "Quadro K2000M",
+        "Benchmark": "1003"
+    },
+    {
+        "Graphics": "Quadro K2100M",
+        "Benchmark": "1366"
+    },
+    {
+        "Graphics": "Quadro K2200",
+        "Benchmark": "3576"
+    },
+    {
+        "Graphics": "Quadro K2200M",
+        "Benchmark": "3501"
+    },
+    {
+        "Graphics": "Quadro K3000M",
+        "Benchmark": "1645"
+    },
+    {
+        "Graphics": "Quadro K3100M",
+        "Benchmark": "2260"
+    },
+    {
+        "Graphics": "Quadro K4000",
+        "Benchmark": "2722"
+    },
+    {
+        "Graphics": "Quadro K4000M",
+        "Benchmark": "1977"
+    },
+    {
+        "Graphics": "Quadro K4100M",
+        "Benchmark": "2775"
+    },
+    {
+        "Graphics": "Quadro K4200",
+        "Benchmark": "4342"
+    },
+    {
+        "Graphics": "Quadro K5000",
+        "Benchmark": "3975"
+    },
+    {
+        "Graphics": "Quadro K5000M",
+        "Benchmark": "2804"
+    },
+    {
+        "Graphics": "Quadro K5100M",
+        "Benchmark": "3209"
+    },
+    {
+        "Graphics": "Quadro K5200",
+        "Benchmark": "6144"
+    },
+    {
+        "Graphics": "Quadro K6000",
+        "Benchmark": "8076"
+    },
+    {
+        "Graphics": "Quadro M500M",
+        "Benchmark": "1177"
+    },
+    {
+        "Graphics": "Quadro M520",
+        "Benchmark": "1898"
+    },
+    {
+        "Graphics": "Quadro M600M",
+        "Benchmark": "2190"
+    },
+    {
+        "Graphics": "Quadro M620",
+        "Benchmark": "2774"
+    },
+    {
+        "Graphics": "Quadro M1000M",
+        "Benchmark": "2837"
+    },
+    {
+        "Graphics": "Quadro M1200",
+        "Benchmark": "3209"
+    },
+    {
+        "Graphics": "Quadro M2000",
+        "Benchmark": "4008"
+    },
+    {
+        "Graphics": "Quadro M2000M",
+        "Benchmark": "3445"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Quadro M2200",
+        "Benchmark": "4276"
+    },
+    {
+        "Graphics": "Quadro M3000M",
+        "Benchmark": "5567"
+    },
+    {
+        "Graphics": "Quadro M4000",
+        "Benchmark": "6684"
+    },
+    {
+        "Graphics": "Quadro M4000M",
+        "Benchmark": "6144"
+    },
+    {
+        "Graphics": "Quadro M5000",
+        "Benchmark": "9459"
+    },
+    {
+        "Graphics": "Quadro M5000M",
+        "Benchmark": "7031"
+    },
+    {
+        "Graphics": "Quadro M5500",
+        "Benchmark": "7915"
+    },
+    {
+        "Graphics": "Quadro M6000",
+        "Benchmark": "11735"
+    },
+    {
+        "Graphics": "Quadro M6000 24GB",
+        "Benchmark": "11831"
+    },
+    {
+        "Graphics": "Quadro NVS 55/280 PCI",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "Quadro NVS 110M",
+        "Benchmark": "47"
+    },
+    {
+        "Graphics": "Quadro NVS 120M",
+        "Benchmark": "46"
+    },
+    {
+        "Graphics": "Quadro NVS 130M",
+        "Benchmark": "97"
+    },
+    {
+        "Graphics": "Quadro NVS 135M",
+        "Benchmark": "50"
+    },
+    {
+        "Graphics": "Quadro NVS 140M",
+        "Benchmark": "78"
+    },
+    {
+        "Graphics": "Quadro NVS 150M",
+        "Benchmark": "70"
+    },
+    {
+        "Graphics": "Quadro NVS 160M",
+        "Benchmark": "141"
+    },
+    {
+        "Graphics": "Quadro NVS 210S",
+        "Benchmark": "23"
+    },
+    {
+        "Graphics": "Quadro NVS 210S / GeForce 6150LE",
+        "Benchmark": "20"
+    },
+    {
+        "Graphics": "Quadro NVS 280 PCI",
+        "Benchmark": "8"
+    },
+    {
+        "Graphics": "Quadro NVS 280 SD",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Quadro NVS 285",
+        "Benchmark": "43"
+    },
+    {
+        "Graphics": "Quadro NVS 285 128MB",
+        "Benchmark": "38"
+    },
+    {
+        "Graphics": "Quadro NVS 290",
+        "Benchmark": "228"
+    },
+    {
+        "Graphics": "Quadro NVS 295",
+        "Benchmark": "110"
+    },
+    {
+        "Graphics": "Quadro NVS 320M",
+        "Benchmark": "208"
+    },
+    {
+        "Graphics": "Quadro NVS 420",
+        "Benchmark": "120"
+    },
+    {
+        "Graphics": "Quadro NVS 440",
+        "Benchmark": "37"
+    },
+    {
+        "Graphics": "Quadro NVS 450",
+        "Benchmark": "66"
+    },
+    {
+        "Graphics": "Quadro NVS 510M",
+        "Benchmark": "238"
+    },
+    {
+        "Graphics": "Quadro P400",
+        "Benchmark": "1653"
+    },
+    {
+        "Graphics": "Quadro P500",
+        "Benchmark": "1656"
+    },
+    {
+        "Graphics": "Quadro P520",
+        "Benchmark": "2074"
+    },
+    {
+        "Graphics": "Quadro P600",
+        "Benchmark": "3323"
+    },
+    {
+        "Graphics": "Quadro P620",
+        "Benchmark": "3667"
+    },
+    {
+        "Graphics": "Quadro P1000",
+        "Benchmark": "4504"
+    },
+    {
+        "Graphics": "Quadro P2000",
+        "Benchmark": "6956"
+    },
+    {
+        "Graphics": "Quadro P2000 with Max-Q Design",
+        "Benchmark": "5263"
+    },
+    {
+        "Graphics": "Quadro P2200",
+        "Benchmark": "9365"
+    },
+    {
+        "Graphics": "Quadro P3000",
+        "Benchmark": "6439"
+    },
+    {
+        "Graphics": "Quadro P3200",
+        "Benchmark": "8635"
+    },
+    {
+        "Graphics": "Quadro P3200 with Max-Q Design",
+        "Benchmark": "9013"
+    },
+    {
+        "Graphics": "Quadro P4000",
+        "Benchmark": "11514"
+    },
+    {
+        "Graphics": "Quadro P4000 with Max-Q Design",
+        "Benchmark": "9082"
+    },
+    {
+        "Graphics": "Quadro P4200",
+        "Benchmark": "10538"
+    },
+    {
+        "Graphics": "Quadro P4200 with Max-Q Design",
+        "Benchmark": "11703"
+    },
+    {
+        "Graphics": "Quadro P5000",
+        "Benchmark": "12651"
+    },
+    {
+        "Graphics": "Quadro P5200",
+        "Benchmark": "11844"
+    },
+    {
+        "Graphics": "Quadro P5200 with Max-Q Design",
+        "Benchmark": "12308"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Quadro P6000",
+        "Benchmark": "15435"
+    },
+    {
+        "Graphics": "Quadro RTX 3000",
+        "Benchmark": "10915"
+    },
+    {
+        "Graphics": "Quadro RTX 3000 with Max-Q Design",
+        "Benchmark": "8204"
+    },
+    {
+        "Graphics": "Quadro RTX 4000",
+        "Benchmark": "15180"
+    },
+    {
+        "Graphics": "Quadro RTX 4000 (Mobile)",
+        "Benchmark": "11675"
+    },
+    {
+        "Graphics": "Quadro RTX 4000 with Max-Q Design",
+        "Benchmark": "12289"
+    },
+    {
+        "Graphics": "Quadro RTX 5000",
+        "Benchmark": "15663"
+    },
+    {
+        "Graphics": "Quadro RTX 5000 (Mobile)",
+        "Benchmark": "14832"
+    },
+    {
+        "Graphics": "Quadro RTX 5000 with Max-Q Design",
+        "Benchmark": "12997"
+    },
+    {
+        "Graphics": "Quadro RTX 6000",
+        "Benchmark": "18511"
+    },
+    {
+        "Graphics": "Quadro RTX 8000",
+        "Benchmark": "19861"
+    },
+    {
+        "Graphics": "Quadro T1000",
+        "Benchmark": "6483"
+    },
+    {
+        "Graphics": "Quadro T1000 with Max-Q Design",
+        "Benchmark": "6767"
+    },
+    {
+        "Graphics": "Quadro T2000",
+        "Benchmark": "7228"
+    },
+    {
+        "Graphics": "Quadro T2000 with Max-Q Design",
+        "Benchmark": "6824"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 7c Gen 3 GPU",
+        "Benchmark": "763"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 7c+ Gen 3",
+        "Benchmark": "705"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 8cx Gen 3",
+        "Benchmark": "1962"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 540 GPU",
+        "Benchmark": "126"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 618 GPU",
+        "Benchmark": "127"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 630 GPU",
+        "Benchmark": "282"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 675 GPU",
+        "Benchmark": "539"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 680 GPU",
+        "Benchmark": "872"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 685 GPU",
+        "Benchmark": "975"
+    },
+    {
+        "Graphics": "Qualcomm Adreno 690 GPU",
+        "Benchmark": "1052"
+    },
+    {
+        "Graphics": "Qualcomm Adreno X1-45 GPU",
+        "Benchmark": "1785"
+    },
+    {
+        "Graphics": "Qualcomm Adreno X1-85 GPU",
+        "Benchmark": "2928"
+    },
+    {
+        "Graphics": "QXL KMDOD",
+        "Benchmark": "18"
+    },
+    {
+        "Graphics": "Radeon 520",
+        "Benchmark": "865"
+    },
+    {
+        "Graphics": "Radeon 530",
+        "Benchmark": "1029"
+    },
+    {
+        "Graphics": "Radeon 535",
+        "Benchmark": "1059"
+    },
+    {
+        "Graphics": "Radeon 535DX",
+        "Benchmark": "773"
+    },
+    {
+        "Graphics": "Radeon 540",
+        "Benchmark": "1412"
+    },
+    {
+        "Graphics": "Radeon 540X",
+        "Benchmark": "1483"
+    },
+    {
+        "Graphics": "Radeon 550",
+        "Benchmark": "2124"
+    },
+    {
+        "Graphics": "Radeon 550X",
+        "Benchmark": "1419"
+    },
+    {
+        "Graphics": "Radeon 610M",
+        "Benchmark": "1104"
+    },
+    {
+        "Graphics": "Radeon 610M Ryzen 9 7845HX",
+        "Benchmark": "11463"
+    },
+    {
+        "Graphics": "Radeon 610M Ryzen 9 7940HX",
+        "Benchmark": "1525"
+    },
+    {
+        "Graphics": "Radeon 610M Ryzen 9 7945HX",
+        "Benchmark": "1608"
+    },
+    {
+        "Graphics": "Radeon 610M Ryzen 9 7945HX3D",
+        "Benchmark": "1761"
+    },
+    {
+        "Graphics": "Radeon 620",
+        "Benchmark": "933"
+    },
+    {
+        "Graphics": "Radeon 625",
+        "Benchmark": "1073"
+    },
+    {
+        "Graphics": "Radeon 630",
+        "Benchmark": "1514"
+    },
+    {
+        "Graphics": "Radeon 660M",
+        "Benchmark": "3341"
+    },
+    {
+        "Graphics": "Radeon 660M Ryzen 3 7335U",
+        "Benchmark": "2112"
+    },
+    {
+        "Graphics": "Radeon 660M Ryzen 5 6600H",
+        "Benchmark": "4461"
+    },
+    {
+        "Graphics": "Radeon 660M Ryzen 5 7535HS",
+        "Benchmark": "2994"
+    },
+    {
+        "Graphics": "Radeon 680M Ryzen 7 7735HS",
+        "Benchmark": "4476"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon 680M Ryzen 9 6900HX",
+        "Benchmark": "5613"
+    },
+    {
+        "Graphics": "Radeon 740M",
+        "Benchmark": "3192"
+    },
+    {
+        "Graphics": "Radeon 760M",
+        "Benchmark": "5590"
+    },
+    {
+        "Graphics": "Radeon 780M",
+        "Benchmark": "6978"
+    },
+    {
+        "Graphics": "Radeon 840M",
+        "Benchmark": "3963"
+    },
+    {
+        "Graphics": "Radeon 860M",
+        "Benchmark": "4784"
+    },
+    {
+        "Graphics": "Radeon 880M",
+        "Benchmark": "7693"
+    },
+    {
+        "Graphics": "Radeon 890M",
+        "Benchmark": "8368"
+    },
+    {
+        "Graphics": "Radeon 2100",
+        "Benchmark": "59"
+    },
+    {
+        "Graphics": "Radeon 3000",
+        "Benchmark": "98"
+    },
+    {
+        "Graphics": "Radeon 3015e",
+        "Benchmark": "370"
+    },
+    {
+        "Graphics": "Radeon 3020e",
+        "Benchmark": "476"
+    },
+    {
+        "Graphics": "Radeon 3100",
+        "Benchmark": "73"
+    },
+    {
+        "Graphics": "Radeon 6600M",
+        "Benchmark": "532"
+    },
+    {
+        "Graphics": "Radeon 6750M",
+        "Benchmark": "911"
+    },
+    {
+        "Graphics": "Radeon 7000 / Radeon VE",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON 7000 / RADEON VE Family",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RADEON 7200",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON 7500",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RADEON 7500 Family",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Radeon 8050S",
+        "Benchmark": "15765"
+    },
+    {
+        "Graphics": "Radeon 8060S",
+        "Benchmark": "17348"
+    },
+    {
+        "Graphics": "RADEON 8500 Family",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "RADEON 9000",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "RADEON 9000 Family",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RADEON 9100 Family",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "RADEON 9100 IGP",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "RADEON 9200",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RADEON 9200 LE Family",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON 9200 PRO Family",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON 9200 SE",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON 9250",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON 9500",
+        "Benchmark": "36"
+    },
+    {
+        "Graphics": "RADEON 9500 PRO / 9700",
+        "Benchmark": "41"
+    },
+    {
+        "Graphics": "RADEON 9550",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "Radeon 9550 / X1050",
+        "Benchmark": "29"
+    },
+    {
+        "Graphics": "RADEON 9600 Family",
+        "Benchmark": "25"
+    },
+    {
+        "Graphics": "RADEON 9600 PRO",
+        "Benchmark": "42"
+    },
+    {
+        "Graphics": "RADEON 9600 PRO Family",
+        "Benchmark": "26"
+    },
+    {
+        "Graphics": "RADEON 9600 TX Family",
+        "Benchmark": "18"
+    },
+    {
+        "Graphics": "RADEON 9600 XT",
+        "Benchmark": "35"
+    },
+    {
+        "Graphics": "RADEON 9600SE",
+        "Benchmark": "27"
+    },
+    {
+        "Graphics": "RADEON 9700 PRO",
+        "Benchmark": "53"
+    },
+    {
+        "Graphics": "Radeon 9700 TX w/TV-Out",
+        "Benchmark": "44"
+    },
+    {
+        "Graphics": "RADEON 9800",
+        "Benchmark": "57"
+    },
+    {
+        "Graphics": "RADEON 9800 PRO",
+        "Benchmark": "59"
+    },
+    {
+        "Graphics": "RADEON 9800 SE",
+        "Benchmark": "23"
+    },
+    {
+        "Graphics": "RADEON 9800 XT",
+        "Benchmark": "56"
+    },
+    {
+        "Graphics": "RADEON A9800XT",
+        "Benchmark": "22"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon Athlon Gold 3150U",
+        "Benchmark": "781"
+    },
+    {
+        "Graphics": "Radeon Athlon Gold PRO 4150GE",
+        "Benchmark": "1573"
+    },
+    {
+        "Graphics": "Radeon Athlon PRO 3045B",
+        "Benchmark": "563"
+    },
+    {
+        "Graphics": "Radeon Athlon Silver 3050U",
+        "Benchmark": "674"
+    },
+    {
+        "Graphics": "RADEON E2400",
+        "Benchmark": "51"
+    },
+    {
+        "Graphics": "RADEON E4690",
+        "Benchmark": "405"
+    },
+    {
+        "Graphics": "Radeon E6460",
+        "Benchmark": "323"
+    },
+    {
+        "Graphics": "Radeon E6465",
+        "Benchmark": "231"
+    },
+    {
+        "Graphics": "Radeon E6760",
+        "Benchmark": "876"
+    },
+    {
+        "Graphics": "Radeon E8860",
+        "Benchmark": "1686"
+    },
+    {
+        "Graphics": "Radeon E8870PCIe",
+        "Benchmark": "3368"
+    },
+    {
+        "Graphics": "Radeon Eng Sample: 100-000000144-40_38/38_Y",
+        "Benchmark": "1731"
+    },
+    {
+        "Graphics": "Radeon Eng Sample: 100-000000146-20_37/30_Y",
+        "Benchmark": "2123"
+    },
+    {
+        "Graphics": "Radeon EPYC 4124P 4-Core",
+        "Benchmark": "1614"
+    },
+    {
+        "Graphics": "Radeon EPYC 4244P 6-Core",
+        "Benchmark": "1424"
+    },
+    {
+        "Graphics": "Radeon EPYC 4344P 8-Core",
+        "Benchmark": "1634"
+    },
+    {
+        "Graphics": "Radeon EPYC 4364P 8-Core",
+        "Benchmark": "1002"
+    },
+    {
+        "Graphics": "Radeon EPYC 4464P 12-Core",
+        "Benchmark": "1331"
+    },
+    {
+        "Graphics": "Radeon EPYC 4484PX 12-Core",
+        "Benchmark": "1619"
+    },
+    {
+        "Graphics": "Radeon EPYC 4564P 16-Core",
+        "Benchmark": "1374"
+    },
+    {
+        "Graphics": "Radeon EPYC 4584PX 16-Core",
+        "Benchmark": "1661"
+    },
+    {
+        "Graphics": "Radeon HD4650",
+        "Benchmark": "239"
+    },
+    {
+        "Graphics": "Radeon HD4670",
+        "Benchmark": "365"
+    },
+    {
+        "Graphics": "RADEON HD6370D",
+        "Benchmark": "320"
+    },
+    {
+        "Graphics": "RADEON HD6410D",
+        "Benchmark": "422"
+    },
+    {
+        "Graphics": "RADEON HD6530D",
+        "Benchmark": "531"
+    },
+    {
+        "Graphics": "RADEON HD7450",
+        "Benchmark": "199"
+    },
+    {
+        "Graphics": "Radeon HD8530M",
+        "Benchmark": "490"
+    },
+    {
+        "Graphics": "Radeon HD8970M",
+        "Benchmark": "3368"
+    },
+    {
+        "Graphics": "Radeon HD 2350",
+        "Benchmark": "76"
+    },
+    {
+        "Graphics": "Radeon HD 2400",
+        "Benchmark": "120"
+    },
+    {
+        "Graphics": "Radeon HD 2400 PCI",
+        "Benchmark": "14"
+    },
+    {
+        "Graphics": "Radeon HD 2400 Pro",
+        "Benchmark": "114"
+    },
+    {
+        "Graphics": "Radeon HD 2400 XT",
+        "Benchmark": "118"
+    },
+    {
+        "Graphics": "Radeon HD 2600 PRO",
+        "Benchmark": "211"
+    },
+    {
+        "Graphics": "Radeon HD 2600 Pro AGP",
+        "Benchmark": "110"
+    },
+    {
+        "Graphics": "Radeon HD 2600 XT",
+        "Benchmark": "282"
+    },
+    {
+        "Graphics": "Radeon HD 2900 GT",
+        "Benchmark": "292"
+    },
+    {
+        "Graphics": "Radeon HD 2900 PRO",
+        "Benchmark": "627"
+    },
+    {
+        "Graphics": "Radeon HD 2900 XT",
+        "Benchmark": "659"
+    },
+    {
+        "Graphics": "Radeon HD 3000",
+        "Benchmark": "95"
+    },
+    {
+        "Graphics": "Radeon HD 3200",
+        "Benchmark": "82"
+    },
+    {
+        "Graphics": "Radeon HD 3300",
+        "Benchmark": "126"
+    },
+    {
+        "Graphics": "Radeon HD 3450",
+        "Benchmark": "182"
+    },
+    {
+        "Graphics": "Radeon HD 3470",
+        "Benchmark": "117"
+    },
+    {
+        "Graphics": "Radeon HD 3650 AGP",
+        "Benchmark": "150"
+    },
+    {
+        "Graphics": "Radeon HD 3670",
+        "Benchmark": "168"
+    },
+    {
+        "Graphics": "Radeon HD 3850",
+        "Benchmark": "401"
+    },
+    {
+        "Graphics": "Radeon HD 3850 AGP",
+        "Benchmark": "432"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 3850 X2",
+        "Benchmark": "822"
+    },
+    {
+        "Graphics": "Radeon HD 3870",
+        "Benchmark": "551"
+    },
+    {
+        "Graphics": "Radeon HD 3870 X2",
+        "Benchmark": "586"
+    },
+    {
+        "Graphics": "Radeon HD 4200",
+        "Benchmark": "111"
+    },
+    {
+        "Graphics": "Radeon HD 4250",
+        "Benchmark": "122"
+    },
+    {
+        "Graphics": "Radeon HD 4270",
+        "Benchmark": "109"
+    },
+    {
+        "Graphics": "Radeon HD 4290",
+        "Benchmark": "140"
+    },
+    {
+        "Graphics": "Radeon HD 4300/4500 Serisi",
+        "Benchmark": "155"
+    },
+    {
+        "Graphics": "Radeon HD 4330",
+        "Benchmark": "135"
+    },
+    {
+        "Graphics": "Radeon HD 4350",
+        "Benchmark": "161"
+    },
+    {
+        "Graphics": "Radeon HD 4550",
+        "Benchmark": "235"
+    },
+    {
+        "Graphics": "Radeon HD 4650",
+        "Benchmark": "248"
+    },
+    {
+        "Graphics": "Radeon HD 4650 AGP",
+        "Benchmark": "207"
+    },
+    {
+        "Graphics": "Radeon HD 4670",
+        "Benchmark": "381"
+    },
+    {
+        "Graphics": "Radeon HD 4770",
+        "Benchmark": "907"
+    },
+    {
+        "Graphics": "Radeon HD 4810",
+        "Benchmark": "769"
+    },
+    {
+        "Graphics": "Radeon HD 4830",
+        "Benchmark": "844"
+    },
+    {
+        "Graphics": "Radeon HD 4850",
+        "Benchmark": "941"
+    },
+    {
+        "Graphics": "Radeon HD 4850 X2",
+        "Benchmark": "1132"
+    },
+    {
+        "Graphics": "Radeon HD 4870",
+        "Benchmark": "1386"
+    },
+    {
+        "Graphics": "Radeon HD 4870 X2",
+        "Benchmark": "1309"
+    },
+    {
+        "Graphics": "Radeon HD 4890",
+        "Benchmark": "1543"
+    },
+    {
+        "Graphics": "Radeon HD 5450",
+        "Benchmark": "136"
+    },
+    {
+        "Graphics": "Radeon HD 5470",
+        "Benchmark": "268"
+    },
+    {
+        "Graphics": "Radeon HD 5550",
+        "Benchmark": "376"
+    },
+    {
+        "Graphics": "Radeon HD 5570",
+        "Benchmark": "479"
+    },
+    {
+        "Graphics": "Radeon HD 5600/5700",
+        "Benchmark": "615"
+    },
+    {
+        "Graphics": "Radeon HD 5670",
+        "Benchmark": "799"
+    },
+    {
+        "Graphics": "Radeon HD 5750",
+        "Benchmark": "1169"
+    },
+    {
+        "Graphics": "Radeon HD 5770",
+        "Benchmark": "1345"
+    },
+    {
+        "Graphics": "Radeon HD 5830",
+        "Benchmark": "1732"
+    },
+    {
+        "Graphics": "Radeon HD 5850",
+        "Benchmark": "1968"
+    },
+    {
+        "Graphics": "Radeon HD 5870",
+        "Benchmark": "2190"
+    },
+    {
+        "Graphics": "Radeon HD 5970",
+        "Benchmark": "2275"
+    },
+    {
+        "Graphics": "Radeon HD 6230",
+        "Benchmark": "179"
+    },
+    {
+        "Graphics": "Radeon HD 6250",
+        "Benchmark": "93"
+    },
+    {
+        "Graphics": "Radeon HD 6290",
+        "Benchmark": "104"
+    },
+    {
+        "Graphics": "Radeon HD 6290M",
+        "Benchmark": "140"
+    },
+    {
+        "Graphics": "Radeon HD 6300M",
+        "Benchmark": "144"
+    },
+    {
+        "Graphics": "Radeon HD 6310",
+        "Benchmark": "122"
+    },
+    {
+        "Graphics": "Radeon HD 6320",
+        "Benchmark": "147"
+    },
+    {
+        "Graphics": "Radeon HD 6320 Graphic",
+        "Benchmark": "216"
+    },
+    {
+        "Graphics": "Radeon HD 6320M",
+        "Benchmark": "198"
+    },
+    {
+        "Graphics": "RADEON HD 6350",
+        "Benchmark": "140"
+    },
+    {
+        "Graphics": "Radeon HD 6370D",
+        "Benchmark": "255"
+    },
+    {
+        "Graphics": "Radeon HD 6370M",
+        "Benchmark": "275"
+    },
+    {
+        "Graphics": "Radeon HD 6380G",
+        "Benchmark": "200"
+    },
+    {
+        "Graphics": "Radeon HD 6410D",
+        "Benchmark": "236"
+    },
+    {
+        "Graphics": "Radeon HD 6430M",
+        "Benchmark": "192"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 6450",
+        "Benchmark": "197"
+    },
+    {
+        "Graphics": "Radeon HD 6450 + 8470D Dual",
+        "Benchmark": "762"
+    },
+    {
+        "Graphics": "Radeon HD 6450A",
+        "Benchmark": "260"
+    },
+    {
+        "Graphics": "Radeon HD 6470M",
+        "Benchmark": "225"
+    },
+    {
+        "Graphics": "Radeon HD 6480G",
+        "Benchmark": "256"
+    },
+    {
+        "Graphics": "Radeon HD 6480M",
+        "Benchmark": "353"
+    },
+    {
+        "Graphics": "Radeon HD 6490M",
+        "Benchmark": "377"
+    },
+    {
+        "Graphics": "Radeon HD 6520G",
+        "Benchmark": "299"
+    },
+    {
+        "Graphics": "Radeon HD 6530D",
+        "Benchmark": "337"
+    },
+    {
+        "Graphics": "Radeon HD 6550A",
+        "Benchmark": "707"
+    },
+    {
+        "Graphics": "Radeon HD 6550D",
+        "Benchmark": "400"
+    },
+    {
+        "Graphics": "Radeon HD 6570",
+        "Benchmark": "558"
+    },
+    {
+        "Graphics": "Radeon HD 6610M",
+        "Benchmark": "565"
+    },
+    {
+        "Graphics": "Radeon HD 6620G",
+        "Benchmark": "341"
+    },
+    {
+        "Graphics": "Radeon HD 6630M",
+        "Benchmark": "684"
+    },
+    {
+        "Graphics": "Radeon HD 6650A",
+        "Benchmark": "835"
+    },
+    {
+        "Graphics": "Radeon HD 6650M",
+        "Benchmark": "758"
+    },
+    {
+        "Graphics": "Radeon HD 6670",
+        "Benchmark": "727"
+    },
+    {
+        "Graphics": "Radeon HD 6670 + 6670 Dual",
+        "Benchmark": "646"
+    },
+    {
+        "Graphics": "Radeon HD 6670 + 7660D Dual",
+        "Benchmark": "1492"
+    },
+    {
+        "Graphics": "Radeon HD 6670/7670",
+        "Benchmark": "945"
+    },
+    {
+        "Graphics": "Radeon HD 6700M",
+        "Benchmark": "1016"
+    },
+    {
+        "Graphics": "Radeon HD 6750",
+        "Benchmark": "1036"
+    },
+    {
+        "Graphics": "Radeon HD 6750M",
+        "Benchmark": "937"
+    },
+    {
+        "Graphics": "Radeon HD 6770",
+        "Benchmark": "1261"
+    },
+    {
+        "Graphics": "Radeon HD 6770M",
+        "Benchmark": "964"
+    },
+    {
+        "Graphics": "Radeon HD 6790",
+        "Benchmark": "1548"
+    },
+    {
+        "Graphics": "Radeon HD 6800M",
+        "Benchmark": "772"
+    },
+    {
+        "Graphics": "Radeon HD 6850",
+        "Benchmark": "1948"
+    },
+    {
+        "Graphics": "Radeon HD 6850 X2",
+        "Benchmark": "2534"
+    },
+    {
+        "Graphics": "Radeon HD 6870",
+        "Benchmark": "2208"
+    },
+    {
+        "Graphics": "Radeon HD 6900M",
+        "Benchmark": "1701"
+    },
+    {
+        "Graphics": "Radeon HD 6950",
+        "Benchmark": "2592"
+    },
+    {
+        "Graphics": "Radeon HD 6970",
+        "Benchmark": "2840"
+    },
+    {
+        "Graphics": "Radeon HD 6970M",
+        "Benchmark": "2270"
+    },
+    {
+        "Graphics": "Radeon HD 6990",
+        "Benchmark": "3013"
+    },
+    {
+        "Graphics": "Radeon HD 7290",
+        "Benchmark": "111"
+    },
+    {
+        "Graphics": "Radeon HD 7290M",
+        "Benchmark": "123"
+    },
+    {
+        "Graphics": "Radeon HD 7310",
+        "Benchmark": "128"
+    },
+    {
+        "Graphics": "Radeon HD 7310 - Carte graphique",
+        "Benchmark": "174"
+    },
+    {
+        "Graphics": "Radeon HD 7310G",
+        "Benchmark": "180"
+    },
+    {
+        "Graphics": "Radeon HD 7310M",
+        "Benchmark": "166"
+    },
+    {
+        "Graphics": "Radeon HD 7340",
+        "Benchmark": "153"
+    },
+    {
+        "Graphics": "Radeon HD 7340G",
+        "Benchmark": "196"
+    },
+    {
+        "Graphics": "Radeon HD 7340M",
+        "Benchmark": "221"
+    },
+    {
+        "Graphics": "Radeon HD 7350",
+        "Benchmark": "165"
+    },
+    {
+        "Graphics": "Radeon HD 7400G",
+        "Benchmark": "267"
+    },
+    {
+        "Graphics": "Radeon HD 7420G",
+        "Benchmark": "305"
+    },
+    {
+        "Graphics": "Radeon HD 7450",
+        "Benchmark": "223"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 7450A",
+        "Benchmark": "288"
+    },
+    {
+        "Graphics": "Radeon HD 7450M",
+        "Benchmark": "329"
+    },
+    {
+        "Graphics": "Radeon HD 7470",
+        "Benchmark": "289"
+    },
+    {
+        "Graphics": "Radeon HD 7470M",
+        "Benchmark": "407"
+    },
+    {
+        "Graphics": "Radeon HD 7480D",
+        "Benchmark": "281"
+    },
+    {
+        "Graphics": "Radeon HD 7500G",
+        "Benchmark": "310"
+    },
+    {
+        "Graphics": "Radeon HD 7500G + 7500M/7600M Dual",
+        "Benchmark": "616"
+    },
+    {
+        "Graphics": "Radeon HD 7500G + 7550M Dual",
+        "Benchmark": "497"
+    },
+    {
+        "Graphics": "Radeon HD 7500G + HD 7500M/7600M Dual",
+        "Benchmark": "355"
+    },
+    {
+        "Graphics": "Radeon HD 7520G",
+        "Benchmark": "313"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7400M Dual",
+        "Benchmark": "486"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7470M Dual",
+        "Benchmark": "542"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7500/7600 Dual",
+        "Benchmark": "582"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7600M Dual",
+        "Benchmark": "591"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7610M Dual",
+        "Benchmark": "588"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7650M Dual",
+        "Benchmark": "453"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7670M Dual",
+        "Benchmark": "523"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 7700M Dual",
+        "Benchmark": "1060"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 8600/8700M Dual",
+        "Benchmark": "311"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + 8750M Dual",
+        "Benchmark": "376"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 7400M Dual",
+        "Benchmark": "544"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 7500/7600 Dual",
+        "Benchmark": "832"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 7600M Dual",
+        "Benchmark": "447"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 7670M Dual",
+        "Benchmark": "495"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 7700M Dual",
+        "Benchmark": "574"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 8600/8700M Dual",
+        "Benchmark": "623"
+    },
+    {
+        "Graphics": "Radeon HD 7520G + HD 8750M Dual",
+        "Benchmark": "651"
+    },
+    {
+        "Graphics": "Radeon HD 7520G N HD 7520G + HD 7500/7600 7500/760",
+        "Benchmark": "574"
+    },
+    {
+        "Graphics": "Radeon HD 7520G N HD 7520G + HD 7600M N HD 7600M D",
+        "Benchmark": "364"
+    },
+    {
+        "Graphics": "Radeon HD 7540D",
+        "Benchmark": "333"
+    },
+    {
+        "Graphics": "Radeon HD 7540D + 6570 Dual",
+        "Benchmark": "719"
+    },
+    {
+        "Graphics": "Radeon HD 7540D + 7500 Dual",
+        "Benchmark": "821"
+    },
+    {
+        "Graphics": "Radeon HD 7540D + HD 6450 Dual",
+        "Benchmark": "643"
+    },
+    {
+        "Graphics": "Radeon HD 7550M",
+        "Benchmark": "464"
+    },
+    {
+        "Graphics": "Radeon HD 7550M/7650M",
+        "Benchmark": "728"
+    },
+    {
+        "Graphics": "Radeon HD 7560D",
+        "Benchmark": "453"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 6450 Dual",
+        "Benchmark": "568"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 6570 Dual",
+        "Benchmark": "833"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 6670 Dual",
+        "Benchmark": "1130"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 7560D Dual",
+        "Benchmark": "982"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 7570 Dual",
+        "Benchmark": "985"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 7670 Dual",
+        "Benchmark": "1426"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + 7700 Dual",
+        "Benchmark": "1919"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 6570 Dual",
+        "Benchmark": "1237"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 6670 Dual",
+        "Benchmark": "1554"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 7000 Dual",
+        "Benchmark": "534"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 7600 Dual",
+        "Benchmark": "1258"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 7670 Dual",
+        "Benchmark": "1380"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 7700 Dual",
+        "Benchmark": "1346"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + HD 8570 Dual",
+        "Benchmark": "935"
+    },
+    {
+        "Graphics": "Radeon HD 7560D + R5 235 Dual",
+        "Benchmark": "563"
+    },
+    {
+        "Graphics": "Radeon HD 7570",
+        "Benchmark": "612"
+    },
+    {
+        "Graphics": "Radeon HD 7570M",
+        "Benchmark": "427"
+    },
+    {
+        "Graphics": "Radeon HD 7570M/HD 7670M",
+        "Benchmark": "699"
+    },
+    {
+        "Graphics": "Radeon HD 7580D",
+        "Benchmark": "350"
+    },
+    {
+        "Graphics": "Radeon HD 7600G",
+        "Benchmark": "332"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + 6400M Dual",
+        "Benchmark": "376"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + 7450M Dual",
+        "Benchmark": "389"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + 7500M/7600M Dual",
+        "Benchmark": "405"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + 7550M Dual",
+        "Benchmark": "423"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + 8500M/8700M Dual",
+        "Benchmark": "333"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + HD 7400M Dual",
+        "Benchmark": "328"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + HD 7500M/7600M Dual",
+        "Benchmark": "476"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + HD 7550M Dual",
+        "Benchmark": "509"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + HD 8670M Dual",
+        "Benchmark": "543"
+    },
+    {
+        "Graphics": "Radeon HD 7600G + HD Dual",
+        "Benchmark": "435"
+    },
+    {
+        "Graphics": "Radeon HD 7600G N HD 7600G + HD ON HD Dual",
+        "Benchmark": "526"
+    },
+    {
+        "Graphics": "Radeon HD 7600M + 7600M Dual",
+        "Benchmark": "773"
+    },
+    {
+        "Graphics": "Radeon HD 7610M",
+        "Benchmark": "632"
+    },
+    {
+        "Graphics": "Radeon HD 7620G",
+        "Benchmark": "364"
+    },
+    {
+        "Graphics": "Radeon HD 7620G + 8600M Dual",
+        "Benchmark": "508"
+    },
+    {
+        "Graphics": "Radeon HD 7620G + 8670M Dual",
+        "Benchmark": "577"
+    },
+    {
+        "Graphics": "Radeon HD 7620G + HD 8600M Dual",
+        "Benchmark": "442"
+    },
+    {
+        "Graphics": "Radeon HD 7620G + HD 8670M Dual",
+        "Benchmark": "507"
+    },
+    {
+        "Graphics": "Radeon HD 7620G N HD 7620G + HD 8600M N HD 8600M D",
+        "Benchmark": "451"
+    },
+    {
+        "Graphics": "Radeon HD 7640G",
+        "Benchmark": "456"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 6400M Dual",
+        "Benchmark": "526"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7400M Dual",
+        "Benchmark": "637"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7450M Dual",
+        "Benchmark": "754"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7470M Dual",
+        "Benchmark": "595"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7500/7600 Dual",
+        "Benchmark": "627"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7500M/7600M Dual",
+        "Benchmark": "775"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7600M Dual",
+        "Benchmark": "705"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7610M Dual",
+        "Benchmark": "510"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7650M Dual",
+        "Benchmark": "747"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7670M Dual",
+        "Benchmark": "644"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7690M Dual",
+        "Benchmark": "945"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 7700M Dual",
+        "Benchmark": "690"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 8500M Dual",
+        "Benchmark": "585"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 8570M Dual",
+        "Benchmark": "558"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 8600/8700M Dual",
+        "Benchmark": "688"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 8600M Dual",
+        "Benchmark": "249"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 8670M Dual",
+        "Benchmark": "558"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + 8750M Dual",
+        "Benchmark": "654"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7400M Dual",
+        "Benchmark": "576"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7500/7600 Dual",
+        "Benchmark": "423"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7600M Dual",
+        "Benchmark": "704"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7600M N HD 7600M Dual",
+        "Benchmark": "406"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7670M Dual",
+        "Benchmark": "518"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7700M Dual",
+        "Benchmark": "589"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 7700M N HD 7700M Dual",
+        "Benchmark": "630"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 8500M Dual",
+        "Benchmark": "607"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 8500M N HD 8500M Dual",
+        "Benchmark": "665"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 8570M Dual",
+        "Benchmark": "474"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 8600/8700M Dual",
+        "Benchmark": "586"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 8670M Dual",
+        "Benchmark": "677"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + HD 8750M Dual",
+        "Benchmark": "996"
+    },
+    {
+        "Graphics": "Radeon HD 7640G + R5 M200 Dual",
+        "Benchmark": "559"
+    },
+    {
+        "Graphics": "Radeon HD 7640G N HD 7640G + HD 7600M N HD 7600M D",
+        "Benchmark": "824"
+    },
+    {
+        "Graphics": "Radeon HD 7640G N HD 7640G + HD 7670M Dual",
+        "Benchmark": "679"
+    },
+    {
+        "Graphics": "Radeon HD 7640G N HD 7640G + HD 8570M Dual",
+        "Benchmark": "422"
+    },
+    {
+        "Graphics": "Radeon HD 7650A",
+        "Benchmark": "567"
+    },
+    {
+        "Graphics": "Radeon HD 7650M",
+        "Benchmark": "441"
+    },
+    {
+        "Graphics": "Radeon HD 7660D",
+        "Benchmark": "509"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + 6570 Dual",
+        "Benchmark": "1100"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + 6670 Dual",
+        "Benchmark": "1238"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + 7470 Dual",
+        "Benchmark": "465"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + 7500 Dual",
+        "Benchmark": "1121"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + 7540D Dual",
+        "Benchmark": "1204"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + 7670 Dual",
+        "Benchmark": "1061"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + HD 6670 Dual",
+        "Benchmark": "1484"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + HD 7000 Dual",
+        "Benchmark": "633"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + HD 7400 Dual",
+        "Benchmark": "339"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + HD 7700 Dual",
+        "Benchmark": "1958"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + R5 235 Dual",
+        "Benchmark": "523"
+    },
+    {
+        "Graphics": "Radeon HD 7660D + R7 240 Dual",
+        "Benchmark": "941"
+    },
+    {
+        "Graphics": "Radeon HD 7660G",
+        "Benchmark": "473"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7400M Dual",
+        "Benchmark": "588"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7470M Dual",
+        "Benchmark": "630"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7600M Dual",
+        "Benchmark": "831"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7610M Dual",
+        "Benchmark": "745"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7670M Dual",
+        "Benchmark": "743"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7700M Dual",
+        "Benchmark": "757"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 7730M Dual",
+        "Benchmark": "931"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 8600M Dual",
+        "Benchmark": "445"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + 8670M Dual",
+        "Benchmark": "587"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7500/7600 7500/7600 Dual",
+        "Benchmark": "1002"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7500/7600 Dual",
+        "Benchmark": "760"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7500M/7600M Dual",
+        "Benchmark": "999"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7600M Dual",
+        "Benchmark": "568"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7600M N HD 7600M Dual",
+        "Benchmark": "460"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7670M Dual",
+        "Benchmark": "706"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7700M Dual",
+        "Benchmark": "777"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 7730M Dual",
+        "Benchmark": "881"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 8500M Dual",
+        "Benchmark": "758"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 8600/8700M Dual",
+        "Benchmark": "747"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 8600M Dual",
+        "Benchmark": "363"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 7660G + HD 8670M Dual",
+        "Benchmark": "711"
+    },
+    {
+        "Graphics": "Radeon HD 7660G N HD 7660G + HD 7600M N HD 7600M D",
+        "Benchmark": "722"
+    },
+    {
+        "Graphics": "Radeon HD 7660G N HD 7660G + HD 7670M Dual",
+        "Benchmark": "704"
+    },
+    {
+        "Graphics": "Radeon HD 7660G N HD 7660G + HD 7700M N HD 7700M D",
+        "Benchmark": "966"
+    },
+    {
+        "Graphics": "Radeon HD 7670",
+        "Benchmark": "817"
+    },
+    {
+        "Graphics": "Radeon HD 7670A",
+        "Benchmark": "1050"
+    },
+    {
+        "Graphics": "Radeon HD 7670M",
+        "Benchmark": "473"
+    },
+    {
+        "Graphics": "Radeon HD 7670M + 7670M Dual",
+        "Benchmark": "738"
+    },
+    {
+        "Graphics": "Radeon HD 7690M",
+        "Benchmark": "847"
+    },
+    {
+        "Graphics": "Radeon HD 7690M XT",
+        "Benchmark": "1009"
+    },
+    {
+        "Graphics": "Radeon HD 7700-serie",
+        "Benchmark": "1899"
+    },
+    {
+        "Graphics": "Radeon HD 7730",
+        "Benchmark": "1188"
+    },
+    {
+        "Graphics": "Radeon HD 7730M",
+        "Benchmark": "780"
+    },
+    {
+        "Graphics": "Radeon HD 7750",
+        "Benchmark": "1692"
+    },
+    {
+        "Graphics": "Radeon HD 7750M",
+        "Benchmark": "1191"
+    },
+    {
+        "Graphics": "Radeon HD 7770",
+        "Benchmark": "2174"
+    },
+    {
+        "Graphics": "Radeon HD 7790",
+        "Benchmark": "3090"
+    },
+    {
+        "Graphics": "Radeon HD 7800-serie",
+        "Benchmark": "4029"
+    },
+    {
+        "Graphics": "Radeon HD 7850",
+        "Benchmark": "3886"
+    },
+    {
+        "Graphics": "Radeon HD 7850M",
+        "Benchmark": "1372"
+    },
+    {
+        "Graphics": "Radeon HD 7870",
+        "Benchmark": "4602"
+    },
+    {
+        "Graphics": "Radeon HD 7870 XT",
+        "Benchmark": "4469"
+    },
+    {
+        "Graphics": "Radeon HD 7870M",
+        "Benchmark": "1507"
+    },
+    {
+        "Graphics": "Radeon HD 7950 / R9 280",
+        "Benchmark": "4764"
+    },
+    {
+        "Graphics": "Radeon HD 7970 / R9 280X",
+        "Benchmark": "5247"
+    },
+    {
+        "Graphics": "Radeon HD 7970M",
+        "Benchmark": "3568"
+    },
+    {
+        "Graphics": "Radeon HD 7990",
+        "Benchmark": "5565"
+    },
+    {
+        "Graphics": "Radeon HD 8180",
+        "Benchmark": "134"
+    },
+    {
+        "Graphics": "Radeon HD 8210",
+        "Benchmark": "195"
+    },
+    {
+        "Graphics": "Radeon HD 8210E",
+        "Benchmark": "193"
+    },
+    {
+        "Graphics": "Radeon HD 8240",
+        "Benchmark": "246"
+    },
+    {
+        "Graphics": "Radeon HD 8250",
+        "Benchmark": "212"
+    },
+    {
+        "Graphics": "Radeon HD 8280",
+        "Benchmark": "260"
+    },
+    {
+        "Graphics": "Radeon HD 8280E",
+        "Benchmark": "256"
+    },
+    {
+        "Graphics": "Radeon HD 8280G",
+        "Benchmark": "269"
+    },
+    {
+        "Graphics": "Radeon HD 8310E",
+        "Benchmark": "340"
+    },
+    {
+        "Graphics": "Radeon HD 8330",
+        "Benchmark": "270"
+    },
+    {
+        "Graphics": "Radeon HD 8330E",
+        "Benchmark": "262"
+    },
+    {
+        "Graphics": "Radeon HD 8350",
+        "Benchmark": "162"
+    },
+    {
+        "Graphics": "Radeon HD 8350G",
+        "Benchmark": "258"
+    },
+    {
+        "Graphics": "Radeon HD 8370D",
+        "Benchmark": "316"
+    },
+    {
+        "Graphics": "Radeon HD 8400",
+        "Benchmark": "273"
+    },
+    {
+        "Graphics": "Radeon HD 8400E",
+        "Benchmark": "275"
+    },
+    {
+        "Graphics": "Radeon HD 8410G",
+        "Benchmark": "435"
+    },
+    {
+        "Graphics": "Radeon HD 8450G",
+        "Benchmark": "338"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + 8600/8700M Dual",
+        "Benchmark": "1070"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + 8600M Dual",
+        "Benchmark": "545"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + 8670M Dual",
+        "Benchmark": "474"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + 8750M Dual",
+        "Benchmark": "637"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + HD 8600M Dual",
+        "Benchmark": "452"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + HD 8670M Dual",
+        "Benchmark": "477"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + HD 8750M Dual",
+        "Benchmark": "503"
+    },
+    {
+        "Graphics": "Radeon HD 8450G + R5 M230 Dual",
+        "Benchmark": "578"
+    },
+    {
+        "Graphics": "Radeon HD 8470",
+        "Benchmark": "247"
+    },
+    {
+        "Graphics": "Radeon HD 8470D",
+        "Benchmark": "377"
+    },
+    {
+        "Graphics": "Radeon HD 8470D + 6450 Dual",
+        "Benchmark": "717"
+    },
+    {
+        "Graphics": "Radeon HD 8470D + 6570 Dual",
+        "Benchmark": "837"
+    },
+    {
+        "Graphics": "Radeon HD 8470D + HD 6450 Dual",
+        "Benchmark": "862"
+    },
+    {
+        "Graphics": "Radeon HD 8470D + HD 6670 Dual",
+        "Benchmark": "1435"
+    },
+    {
+        "Graphics": "Radeon HD 8470D + HD 7500 Dual",
+        "Benchmark": "1545"
+    },
+    {
+        "Graphics": "Radeon HD 8490",
+        "Benchmark": "263"
+    },
+    {
+        "Graphics": "Radeon HD 8500M",
+        "Benchmark": "438"
+    },
+    {
+        "Graphics": "Radeon HD 8500M/8700M",
+        "Benchmark": "852"
+    },
+    {
+        "Graphics": "Radeon HD 8510G",
+        "Benchmark": "371"
+    },
+    {
+        "Graphics": "Radeon HD 8510G + 8500M Dual",
+        "Benchmark": "596"
+    },
+    {
+        "Graphics": "Radeon HD 8510G + HD 8500M Dual",
+        "Benchmark": "629"
+    },
+    {
+        "Graphics": "Radeon HD 8550D",
+        "Benchmark": "566"
+    },
+    {
+        "Graphics": "Radeon HD 8550G",
+        "Benchmark": "417"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 7600M Dual",
+        "Benchmark": "901"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8500M Dual",
+        "Benchmark": "602"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8570M Dual",
+        "Benchmark": "532"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8600/8700M Dual",
+        "Benchmark": "802"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8600M Dual",
+        "Benchmark": "617"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8670M Dual",
+        "Benchmark": "579"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8690M Dual",
+        "Benchmark": "664"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + 8750M Dual",
+        "Benchmark": "795"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 7600M Dual",
+        "Benchmark": "547"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 8500M Dual",
+        "Benchmark": "558"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 8570M Dual",
+        "Benchmark": "529"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 8600/8700M Dual",
+        "Benchmark": "654"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 8600M Dual",
+        "Benchmark": "593"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 8670M Dual",
+        "Benchmark": "546"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + HD 8750M Dual",
+        "Benchmark": "819"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + R5 M200 Dual",
+        "Benchmark": "619"
+    },
+    {
+        "Graphics": "Radeon HD 8550G + R5 M230 Dual",
+        "Benchmark": "487"
+    },
+    {
+        "Graphics": "Radeon HD 8550G N HD 8550G + HD 8600M N HD 8600M D",
+        "Benchmark": "611"
+    },
+    {
+        "Graphics": "Radeon HD 8570",
+        "Benchmark": "940"
+    },
+    {
+        "Graphics": "Radeon HD 8570 + 8670D Dual",
+        "Benchmark": "620"
+    },
+    {
+        "Graphics": "Radeon HD 8570 + HD 7660D Dual",
+        "Benchmark": "949"
+    },
+    {
+        "Graphics": "Radeon HD 8570D",
+        "Benchmark": "431"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + 6570 Dual",
+        "Benchmark": "1239"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + 6670 Dual",
+        "Benchmark": "1039"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD8490 Dual",
+        "Benchmark": "374"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD 6570 Dual",
+        "Benchmark": "868"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD 6670 Dual",
+        "Benchmark": "1260"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD 7000 Dual",
+        "Benchmark": "753"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD 7700 Dual",
+        "Benchmark": "1834"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD 8470 Dual",
+        "Benchmark": "338"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + HD 8570 Dual",
+        "Benchmark": "1032"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + R5 235 Dual",
+        "Benchmark": "470"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + R7 200 Dual",
+        "Benchmark": "999"
+    },
+    {
+        "Graphics": "Radeon HD 8570D + R7 240 Dual",
+        "Benchmark": "963"
+    },
+    {
+        "Graphics": "Radeon HD 8570M",
+        "Benchmark": "449"
+    },
+    {
+        "Graphics": "Radeon HD 8600/8700M",
+        "Benchmark": "1029"
+    },
+    {
+        "Graphics": "Radeon HD 8610G",
+        "Benchmark": "407"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + 8500M Dual",
+        "Benchmark": "610"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + 8600M Dual",
+        "Benchmark": "588"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + 8670M Dual",
+        "Benchmark": "599"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + HD 8500M Dual",
+        "Benchmark": "645"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + HD 8600M Dual",
+        "Benchmark": "480"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + HD 8670M Dual",
+        "Benchmark": "577"
+    },
+    {
+        "Graphics": "Radeon HD 8610G + R5 M200 Dual",
+        "Benchmark": "676"
+    },
+    {
+        "Graphics": "Radeon HD 8650D",
+        "Benchmark": "396"
+    },
+    {
+        "Graphics": "Radeon HD 8650G",
+        "Benchmark": "517"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 7600M Dual",
+        "Benchmark": "741"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 7670M Dual",
+        "Benchmark": "883"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 7700M Dual",
+        "Benchmark": "1126"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 8500M Dual",
+        "Benchmark": "626"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 8570M Dual",
+        "Benchmark": "654"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 8600/8700M Dual",
+        "Benchmark": "831"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 8600M Dual",
+        "Benchmark": "613"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 8670M Dual",
+        "Benchmark": "635"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + 8750M Dual",
+        "Benchmark": "786"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 7600M Dual",
+        "Benchmark": "819"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 7670M Dual",
+        "Benchmark": "634"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8570M Dual",
+        "Benchmark": "716"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8600/8700M Dual",
+        "Benchmark": "763"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8600M Dual",
+        "Benchmark": "606"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8600M N HD 8600M Dual",
+        "Benchmark": "757"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8670M Dual",
+        "Benchmark": "585"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8750M Dual",
+        "Benchmark": "651"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + HD 8790M Dual",
+        "Benchmark": "799"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + R5 M200 Dual",
+        "Benchmark": "722"
+    },
+    {
+        "Graphics": "Radeon HD 8650G + R5 M230 Dual",
+        "Benchmark": "686"
+    },
+    {
+        "Graphics": "Radeon HD 8650G N HD 8650G + HD 8570M Dual",
+        "Benchmark": "773"
+    },
+    {
+        "Graphics": "Radeon HD 8650G N HD 8650G + HD 8600/8700M Dual",
+        "Benchmark": "796"
+    },
+    {
+        "Graphics": "Radeon HD 8650G N HD 8650G + HD 8600M N HD 8600M D",
+        "Benchmark": "679"
+    },
+    {
+        "Graphics": "Radeon HD 8670D",
+        "Benchmark": "533"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + 6670 Dual",
+        "Benchmark": "1361"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + 7000 Dual",
+        "Benchmark": "811"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + 7700 Dual",
+        "Benchmark": "1788"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + 8570 Dual",
+        "Benchmark": "974"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + HD 6670 Dual",
+        "Benchmark": "1221"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + HD 7000 Dual",
+        "Benchmark": "718"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + HD 7600 Dual",
+        "Benchmark": "1317"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + HD 7700 Dual",
+        "Benchmark": "1892"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + R5 235 Dual",
+        "Benchmark": "836"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + R5 330 Dual",
+        "Benchmark": "746"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + R7 200 Dual",
+        "Benchmark": "949"
+    },
+    {
+        "Graphics": "Radeon HD 8670D + R7 240 Dual",
+        "Benchmark": "1020"
+    },
+    {
+        "Graphics": "Radeon HD 8670D N HD 8670D + HD 8670D Dual",
+        "Benchmark": "488"
+    },
+    {
+        "Graphics": "Radeon HD 8670M",
+        "Benchmark": "520"
+    },
+    {
+        "Graphics": "Radeon HD 8690A",
+        "Benchmark": "510"
+    },
+    {
+        "Graphics": "Radeon HD 8690M",
+        "Benchmark": "984"
+    },
+    {
+        "Graphics": "Radeon HD 8730M",
+        "Benchmark": "811"
+    },
+    {
+        "Graphics": "Radeon HD 8750M",
+        "Benchmark": "1020"
+    },
+    {
+        "Graphics": "Radeon HD 8790M",
+        "Benchmark": "1305"
+    },
+    {
+        "Graphics": "Radeon HD 8790M / R9 M290X",
+        "Benchmark": "1210"
+    },
+    {
+        "Graphics": "Radeon HD 8850M",
+        "Benchmark": "973"
+    },
+    {
+        "Graphics": "Radeon HD 8850M / R9 M265X",
+        "Benchmark": "1139"
+    },
+    {
+        "Graphics": "Radeon HD 8870M",
+        "Benchmark": "1638"
+    },
+    {
+        "Graphics": "Radeon HD 8870M / R9 M270X / M370X",
+        "Benchmark": "1799"
+    },
+    {
+        "Graphics": "Radeon HD 8950",
+        "Benchmark": "2816"
+    },
+    {
+        "Graphics": "Radeon HD 8970M",
+        "Benchmark": "3876"
+    },
+    {
+        "Graphics": "Radeon HD 8990",
+        "Benchmark": "5214"
+    },
+    {
+        "Graphics": "Radeon HD HD7850M",
+        "Benchmark": "1651"
+    },
+    {
+        "Graphics": "Radeon HDG 4670",
+        "Benchmark": "170"
+    },
+    {
+        "Graphics": "RADEON IGP 34xM",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "RADEON IGP 320",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Radeon IGP 320M",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "Radeon IGP 340M",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON IGP 345M",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "RADEON IGP 350M",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "Radeon Infoshock 3000",
+        "Benchmark": "106"
+    },
+    {
+        "Graphics": "Radeon Instinct MI25 MxGPU",
+        "Benchmark": "4403"
+    },
+    {
+        "Graphics": "Radeon M535DX",
+        "Benchmark": "749"
+    },
+    {
+        "Graphics": "Radeon Pro",
+        "Benchmark": "2365"
+    },
+    {
+        "Graphics": "Radeon Pro 450",
+        "Benchmark": "2722"
+    },
+    {
+        "Graphics": "Radeon Pro 455",
+        "Benchmark": "3112"
+    },
+    {
+        "Graphics": "Radeon Pro 460",
+        "Benchmark": "3452"
+    },
+    {
+        "Graphics": "Radeon Pro 465",
+        "Benchmark": "4537"
+    },
+    {
+        "Graphics": "Radeon Pro 555",
+        "Benchmark": "3140"
+    },
+    {
+        "Graphics": "Radeon Pro 560",
+        "Benchmark": "3475"
+    },
+    {
+        "Graphics": "Radeon Pro 560X",
+        "Benchmark": "3677"
+    },
+    {
+        "Graphics": "Radeon Pro 570",
+        "Benchmark": "6336"
+    },
+    {
+        "Graphics": "Radeon Pro 580",
+        "Benchmark": "7753"
+    },
+    {
+        "Graphics": "Radeon Pro 580X",
+        "Benchmark": "7540"
+    },
+    {
+        "Graphics": "Radeon Pro 5300",
+        "Benchmark": "7125"
+    },
+    {
+        "Graphics": "Radeon Pro 5300M",
+        "Benchmark": "5926"
+    },
+    {
+        "Graphics": "Radeon Pro 5500 XT",
+        "Benchmark": "7940"
+    },
+    {
+        "Graphics": "Radeon Pro 5500M",
+        "Benchmark": "6723"
+    },
+    {
+        "Graphics": "Radeon Pro 5600M",
+        "Benchmark": "9278"
+    },
+    {
+        "Graphics": "Radeon Pro 5700",
+        "Benchmark": "11582"
+    },
+    {
+        "Graphics": "Radeon Pro 5700 XT",
+        "Benchmark": "12557"
+    },
+    {
+        "Graphics": "Radeon Pro Duo",
+        "Benchmark": "8298"
+    },
+    {
+        "Graphics": "Radeon PRO Ryzen 5 PRO 6650U",
+        "Benchmark": "4066"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon PRO Ryzen 7 PRO 6850U",
+        "Benchmark": "5582"
+    },
+    {
+        "Graphics": "Radeon Pro SSG",
+        "Benchmark": "10971"
+    },
+    {
+        "Graphics": "Radeon Pro V340 MxGPU",
+        "Benchmark": "2853"
+    },
+    {
+        "Graphics": "Radeon Pro V520 MxGPU",
+        "Benchmark": "12257"
+    },
+    {
+        "Graphics": "Radeon Pro V620 MxGPU",
+        "Benchmark": "15632"
+    },
+    {
+        "Graphics": "Radeon PRO V710 MxGPU",
+        "Benchmark": "13129"
+    },
+    {
+        "Graphics": "Radeon Pro Vega 16",
+        "Benchmark": "4809"
+    },
+    {
+        "Graphics": "Radeon Pro Vega 20",
+        "Benchmark": "5039"
+    },
+    {
+        "Graphics": "Radeon Pro Vega 48",
+        "Benchmark": "11289"
+    },
+    {
+        "Graphics": "Radeon Pro Vega 56",
+        "Benchmark": "12353"
+    },
+    {
+        "Graphics": "Radeon Pro Vega 64",
+        "Benchmark": "12890"
+    },
+    {
+        "Graphics": "Radeon Pro Vega 64X",
+        "Benchmark": "13369"
+    },
+    {
+        "Graphics": "Radeon Pro Vega II",
+        "Benchmark": "15596"
+    },
+    {
+        "Graphics": "Radeon Pro Vega II Duo",
+        "Benchmark": "14018"
+    },
+    {
+        "Graphics": "Radeon Pro VII",
+        "Benchmark": "13081"
+    },
+    {
+        "Graphics": "Radeon Pro W5500",
+        "Benchmark": "8974"
+    },
+    {
+        "Graphics": "Radeon Pro W5500M",
+        "Benchmark": "3469"
+    },
+    {
+        "Graphics": "Radeon Pro W5500X",
+        "Benchmark": "7350"
+    },
+    {
+        "Graphics": "Radeon Pro W5700",
+        "Benchmark": "14556"
+    },
+    {
+        "Graphics": "Radeon PRO W6300",
+        "Benchmark": "5559"
+    },
+    {
+        "Graphics": "Radeon PRO W6400",
+        "Benchmark": "8126"
+    },
+    {
+        "Graphics": "Radeon PRO W6600",
+        "Benchmark": "15382"
+    },
+    {
+        "Graphics": "Radeon PRO W6600M",
+        "Benchmark": "11287"
+    },
+    {
+        "Graphics": "Radeon PRO W6600X",
+        "Benchmark": "13113"
+    },
+    {
+        "Graphics": "Radeon PRO W6800",
+        "Benchmark": "19969"
+    },
+    {
+        "Graphics": "Radeon PRO W7500",
+        "Benchmark": "13372"
+    },
+    {
+        "Graphics": "Radeon PRO W7600",
+        "Benchmark": "16156"
+    },
+    {
+        "Graphics": "Radeon PRO W7700",
+        "Benchmark": "23158"
+    },
+    {
+        "Graphics": "Radeon PRO W7800",
+        "Benchmark": "27499"
+    },
+    {
+        "Graphics": "Radeon PRO W7900",
+        "Benchmark": "28959"
+    },
+    {
+        "Graphics": "Radeon Pro WX 2100",
+        "Benchmark": "1869"
+    },
+    {
+        "Graphics": "Radeon Pro WX 3100",
+        "Benchmark": "2628"
+    },
+    {
+        "Graphics": "Radeon Pro WX 3200",
+        "Benchmark": "2360"
+    },
+    {
+        "Graphics": "Radeon Pro WX 4100",
+        "Benchmark": "3685"
+    },
+    {
+        "Graphics": "Radeon Pro WX 4130",
+        "Benchmark": "1998"
+    },
+    {
+        "Graphics": "Radeon Pro WX 4150",
+        "Benchmark": "2574"
+    },
+    {
+        "Graphics": "Radeon Pro WX 4170",
+        "Benchmark": "2732"
+    },
+    {
+        "Graphics": "Radeon Pro WX 5100",
+        "Benchmark": "5493"
+    },
+    {
+        "Graphics": "Radeon Pro WX 7100",
+        "Benchmark": "7795"
+    },
+    {
+        "Graphics": "Radeon Pro WX 7130",
+        "Benchmark": "6689"
+    },
+    {
+        "Graphics": "Radeon Pro WX 8200",
+        "Benchmark": "13046"
+    },
+    {
+        "Graphics": "Radeon Pro WX 9100",
+        "Benchmark": "12285"
+    },
+    {
+        "Graphics": "Radeon Pro WX Vega M GL",
+        "Benchmark": "4809"
+    },
+    {
+        "Graphics": "Radeon R1E",
+        "Benchmark": "301"
+    },
+    {
+        "Graphics": "Radeon R2",
+        "Benchmark": "249"
+    },
+    {
+        "Graphics": "Radeon R2E",
+        "Benchmark": "208"
+    },
+    {
+        "Graphics": "Radeon R3",
+        "Benchmark": "311"
+    },
+    {
+        "Graphics": "Radeon R3E",
+        "Benchmark": "224"
+    },
+    {
+        "Graphics": "Radeon R4",
+        "Benchmark": "342"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon R4E",
+        "Benchmark": "487"
+    },
+    {
+        "Graphics": "Radeon R5 220",
+        "Benchmark": "147"
+    },
+    {
+        "Graphics": "Radeon R5 230",
+        "Benchmark": "221"
+    },
+    {
+        "Graphics": "Radeon R5 235",
+        "Benchmark": "336"
+    },
+    {
+        "Graphics": "Radeon R5 235 + HD 7560D Dual",
+        "Benchmark": "743"
+    },
+    {
+        "Graphics": "Radeon R5 235 + HD 8570D Dual",
+        "Benchmark": "737"
+    },
+    {
+        "Graphics": "Radeon R5 235X",
+        "Benchmark": "277"
+    },
+    {
+        "Graphics": "Radeon R5 240",
+        "Benchmark": "550"
+    },
+    {
+        "Graphics": "Radeon R5 310",
+        "Benchmark": "331"
+    },
+    {
+        "Graphics": "Radeon R5 330",
+        "Benchmark": "520"
+    },
+    {
+        "Graphics": "Radeon R5 340",
+        "Benchmark": "935"
+    },
+    {
+        "Graphics": "Radeon R5 420",
+        "Benchmark": "574"
+    },
+    {
+        "Graphics": "Radeon R5 430",
+        "Benchmark": "893"
+    },
+    {
+        "Graphics": "Radeon R5 435",
+        "Benchmark": "761"
+    },
+    {
+        "Graphics": "Radeon R5 A6-7480",
+        "Benchmark": "704"
+    },
+    {
+        "Graphics": "Radeon R5 A6-8500P",
+        "Benchmark": "586"
+    },
+    {
+        "Graphics": "Radeon R5 A6-9400 RADEON R5, 6 COMPUTE CORES 2C+4G",
+        "Benchmark": "605"
+    },
+    {
+        "Graphics": "Radeon R5 A6-9500 2C+6G",
+        "Benchmark": "853"
+    },
+    {
+        "Graphics": "Radeon R5 A6-9500 RADEON R5, 8 COMPUTE CORES 2C+6G",
+        "Benchmark": "928"
+    },
+    {
+        "Graphics": "Radeon R5 A6-9500E 2C+4G",
+        "Benchmark": "1014"
+    },
+    {
+        "Graphics": "Radeon R5 A6-9500E RADEON R5, 6 COMPUTE CORES 2C+4",
+        "Benchmark": "692"
+    },
+    {
+        "Graphics": "Radeon R5 A10-9600P 4C+6G",
+        "Benchmark": "619"
+    },
+    {
+        "Graphics": "Radeon R5 A10-9600P RADEON R5, 10 COMPUTE CORES 4C",
+        "Benchmark": "703"
+    },
+    {
+        "Graphics": "Radeon R5 A10-9620P 4C+6G",
+        "Benchmark": "731"
+    },
+    {
+        "Graphics": "Radeon R5 A10-9620P RADEON R5, 10 COMPUTE CORES 4C",
+        "Benchmark": "660"
+    },
+    {
+        "Graphics": "Radeon R5 A10-9630P 4C+6G",
+        "Benchmark": "977"
+    },
+    {
+        "Graphics": "Radeon R5 A10-9630P RADEON R5, 10 COMPUTE CORES 4C",
+        "Benchmark": "734"
+    },
+    {
+        "Graphics": "Radeon R5 A240",
+        "Benchmark": "576"
+    },
+    {
+        "Graphics": "Radeon R5 M230",
+        "Benchmark": "418"
+    },
+    {
+        "Graphics": "Radeon R5 M240",
+        "Benchmark": "467"
+    },
+    {
+        "Graphics": "Radeon R5 M255",
+        "Benchmark": "544"
+    },
+    {
+        "Graphics": "Radeon R5 M315",
+        "Benchmark": "478"
+    },
+    {
+        "Graphics": "Radeon R5 M320",
+        "Benchmark": "467"
+    },
+    {
+        "Graphics": "Radeon R5 M330",
+        "Benchmark": "595"
+    },
+    {
+        "Graphics": "Radeon R5 M335",
+        "Benchmark": "548"
+    },
+    {
+        "Graphics": "Radeon R5 M420",
+        "Benchmark": "505"
+    },
+    {
+        "Graphics": "Radeon R5 M430",
+        "Benchmark": "648"
+    },
+    {
+        "Graphics": "Radeon R5 M435",
+        "Benchmark": "852"
+    },
+    {
+        "Graphics": "Radeon R5 Opteron X3216",
+        "Benchmark": "415"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8500B 2C+4G",
+        "Benchmark": "508"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8500B R5, 6 Compute Cores 2C+4G",
+        "Benchmark": "478"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8530B 2C+4G",
+        "Benchmark": "689"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8530B R5, 6 COMPUTE CORES 2C+4G",
+        "Benchmark": "463"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8570 2C+6G",
+        "Benchmark": "847"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8570 R5, 8 COMPUTE CORES 2C+6G",
+        "Benchmark": "949"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8570E 2C+4G",
+        "Benchmark": "637"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-8570E R5, 6 COMPUTE CORES 2C+4G",
+        "Benchmark": "662"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-9500 2C+6G",
+        "Benchmark": "1096"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-9500 R5, 8 COMPUTE CORES 2C+6G",
+        "Benchmark": "793"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-9500B 2C+4G",
+        "Benchmark": "693"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-9500B R5, 6 COMPUTE CORES 2C+4G",
+        "Benchmark": "408"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A6-9500E 2C+4G",
+        "Benchmark": "770"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A8-9600B 4C+6G",
+        "Benchmark": "658"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A8-9600B R5, 10 COMPUTE CORES 4C+6G",
+        "Benchmark": "574"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A10-8730B 4C+6G",
+        "Benchmark": "695"
+    },
+    {
+        "Graphics": "Radeon R5 PRO A10-8730B R5, 10 COMPUTE CORES 4C+6G",
+        "Benchmark": "602"
+    },
+    {
+        "Graphics": "Radeon R5E",
+        "Benchmark": "315"
+    },
+    {
+        "Graphics": "Radeon R6",
+        "Benchmark": "610"
+    },
+    {
+        "Graphics": "Radeon R6 + R7 M265DX Dual",
+        "Benchmark": "570"
+    },
+    {
+        "Graphics": "Radeon R6 A8-8600P",
+        "Benchmark": "474"
+    },
+    {
+        "Graphics": "Radeon R6 A10-8700P",
+        "Benchmark": "546"
+    },
+    {
+        "Graphics": "Radeon R6 A10-9600P 4C+6G",
+        "Benchmark": "970"
+    },
+    {
+        "Graphics": "Radeon R6 M255DX",
+        "Benchmark": "605"
+    },
+    {
+        "Graphics": "Radeon R6 Opteron X3418",
+        "Benchmark": "955"
+    },
+    {
+        "Graphics": "Radeon R6 PRO A8-8600B 4C+6G",
+        "Benchmark": "531"
+    },
+    {
+        "Graphics": "Radeon R6 PRO A8-8600B R6, 10 Compute Cores 4C+6G",
+        "Benchmark": "613"
+    },
+    {
+        "Graphics": "Radeon R6 PRO A10-8700B 4C+6G",
+        "Benchmark": "538"
+    },
+    {
+        "Graphics": "Radeon R6 PRO A10-8700B R6, 10 Compute Cores 4C+6G",
+        "Benchmark": "543"
+    },
+    {
+        "Graphics": "Radeon R7 240",
+        "Benchmark": "900"
+    },
+    {
+        "Graphics": "Radeon R7 240 + HD 8570D Dual",
+        "Benchmark": "917"
+    },
+    {
+        "Graphics": "Radeon R7 240 + HD 8670D Dual",
+        "Benchmark": "930"
+    },
+    {
+        "Graphics": "Radeon R7 250",
+        "Benchmark": "1049"
+    },
+    {
+        "Graphics": "Radeon R7 250X",
+        "Benchmark": "2268"
+    },
+    {
+        "Graphics": "Radeon R7 260",
+        "Benchmark": "2891"
+    },
+    {
+        "Graphics": "Radeon R7 260X",
+        "Benchmark": "3189"
+    },
+    {
+        "Graphics": "Radeon R7 340",
+        "Benchmark": "1000"
+    },
+    {
+        "Graphics": "Radeon R7 360",
+        "Benchmark": "3135"
+    },
+    {
+        "Graphics": "Radeon R7 370",
+        "Benchmark": "4494"
+    },
+    {
+        "Graphics": "Radeon R7 430",
+        "Benchmark": "1091"
+    },
+    {
+        "Graphics": "Radeon R7 450",
+        "Benchmark": "1892"
+    },
+    {
+        "Graphics": "Radeon R7 7850A10-7850K",
+        "Benchmark": "551"
+    },
+    {
+        "Graphics": "Radeon R7 +8G",
+        "Benchmark": "1190"
+    },
+    {
+        "Graphics": "Radeon R7 + HD 7700 Dual",
+        "Benchmark": "1962"
+    },
+    {
+        "Graphics": "Radeon R7 + R5 330 Dual",
+        "Benchmark": "1028"
+    },
+    {
+        "Graphics": "Radeon R7 + R5 340 Dual",
+        "Benchmark": "1234"
+    },
+    {
+        "Graphics": "Radeon R7 + R5 435 Dual A10-9700 RADEON",
+        "Benchmark": "885"
+    },
+    {
+        "Graphics": "Radeon R7 + R5 Dual",
+        "Benchmark": "897"
+    },
+    {
+        "Graphics": "Radeon R7 + R7 200 Dual",
+        "Benchmark": "1077"
+    },
+    {
+        "Graphics": "Radeon R7 + R7 240 Dual",
+        "Benchmark": "1045"
+    },
+    {
+        "Graphics": "Radeon R7 + R7 250 Dual",
+        "Benchmark": "1232"
+    },
+    {
+        "Graphics": "Radeon R7 + R7 350 Dual",
+        "Benchmark": "1982"
+    },
+    {
+        "Graphics": "Radeon R7 A8 PRO-7600B",
+        "Benchmark": "666"
+    },
+    {
+        "Graphics": "Radeon R7 A8-7500",
+        "Benchmark": "860"
+    },
+    {
+        "Graphics": "Radeon R7 A8-7500 4C+6G",
+        "Benchmark": "853"
+    },
+    {
+        "Graphics": "Radeon R7 A8-7600",
+        "Benchmark": "776"
+    },
+    {
+        "Graphics": "Radeon R7 A8-7650K",
+        "Benchmark": "747"
+    },
+    {
+        "Graphics": "Radeon R7 A8-7670K",
+        "Benchmark": "846"
+    },
+    {
+        "Graphics": "Radeon R7 A8-7680",
+        "Benchmark": "819"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon R7 A8-8650",
+        "Benchmark": "912"
+    },
+    {
+        "Graphics": "Radeon R7 A8-9600 RADEON",
+        "Benchmark": "835"
+    },
+    {
+        "Graphics": "Radeon R7 A10 Extreme Edition",
+        "Benchmark": "821"
+    },
+    {
+        "Graphics": "Radeon R7 A10 PRO-7800B",
+        "Benchmark": "757"
+    },
+    {
+        "Graphics": "Radeon R7 A10 PRO-7850B",
+        "Benchmark": "822"
+    },
+    {
+        "Graphics": "Radeon R7 A10-7700K",
+        "Benchmark": "792"
+    },
+    {
+        "Graphics": "Radeon R7 A10-7800",
+        "Benchmark": "728"
+    },
+    {
+        "Graphics": "Radeon R7 A10-7850K",
+        "Benchmark": "945"
+    },
+    {
+        "Graphics": "Radeon R7 A10-7860K",
+        "Benchmark": "908"
+    },
+    {
+        "Graphics": "Radeon R7 A10-7870K",
+        "Benchmark": "1094"
+    },
+    {
+        "Graphics": "Radeon R7 A10-7890K",
+        "Benchmark": "972"
+    },
+    {
+        "Graphics": "Radeon R7 A10-8750",
+        "Benchmark": "856"
+    },
+    {
+        "Graphics": "Radeon R7 A10-8850",
+        "Benchmark": "773"
+    },
+    {
+        "Graphics": "Radeon R7 A10-9700 RADEON",
+        "Benchmark": "917"
+    },
+    {
+        "Graphics": "Radeon R7 A10-9700E RADEON",
+        "Benchmark": "872"
+    },
+    {
+        "Graphics": "Radeon R7 A12-9700P RADEON",
+        "Benchmark": "710"
+    },
+    {
+        "Graphics": "Radeon R7 A12-9720P RADEON",
+        "Benchmark": "724"
+    },
+    {
+        "Graphics": "Radeon R7 A12-9730P RADEON",
+        "Benchmark": "1014"
+    },
+    {
+        "Graphics": "Radeon R7 A12-9800 RADEON",
+        "Benchmark": "1066"
+    },
+    {
+        "Graphics": "Radeon R7 A12-9800E RADEON",
+        "Benchmark": "913"
+    },
+    {
+        "Graphics": "Radeon R7 A265",
+        "Benchmark": "993"
+    },
+    {
+        "Graphics": "Radeon R7 A360",
+        "Benchmark": "607"
+    },
+    {
+        "Graphics": "Radeon R7 A365",
+        "Benchmark": "781"
+    },
+    {
+        "Graphics": "Radeon R7 A370",
+        "Benchmark": "1281"
+    },
+    {
+        "Graphics": "Radeon R7 FX-8800P",
+        "Benchmark": "815"
+    },
+    {
+        "Graphics": "Radeon R7 FX-9800P RADEON",
+        "Benchmark": "775"
+    },
+    {
+        "Graphics": "Radeon R7 FX-9830P RADEON",
+        "Benchmark": "1394"
+    },
+    {
+        "Graphics": "Radeon R7 G",
+        "Benchmark": "869"
+    },
+    {
+        "Graphics": "Radeon R7 M260",
+        "Benchmark": "519"
+    },
+    {
+        "Graphics": "Radeon R7 M260DX",
+        "Benchmark": "816"
+    },
+    {
+        "Graphics": "Radeon R7 M260X",
+        "Benchmark": "994"
+    },
+    {
+        "Graphics": "Radeon R7 M265",
+        "Benchmark": "536"
+    },
+    {
+        "Graphics": "Radeon R7 M265DX",
+        "Benchmark": "498"
+    },
+    {
+        "Graphics": "Radeon R7 M270",
+        "Benchmark": "766"
+    },
+    {
+        "Graphics": "Radeon R7 M340",
+        "Benchmark": "650"
+    },
+    {
+        "Graphics": "Radeon R7 M350",
+        "Benchmark": "1167"
+    },
+    {
+        "Graphics": "Radeon R7 M360",
+        "Benchmark": "582"
+    },
+    {
+        "Graphics": "Radeon R7 M365X",
+        "Benchmark": "794"
+    },
+    {
+        "Graphics": "Radeon R7 M370",
+        "Benchmark": "1417"
+    },
+    {
+        "Graphics": "Radeon R7 M380",
+        "Benchmark": "1668"
+    },
+    {
+        "Graphics": "Radeon R7 M440",
+        "Benchmark": "899"
+    },
+    {
+        "Graphics": "Radeon R7 M445",
+        "Benchmark": "938"
+    },
+    {
+        "Graphics": "Radeon R7 M460",
+        "Benchmark": "1057"
+    },
+    {
+        "Graphics": "Radeon R7 M465",
+        "Benchmark": "1135"
+    },
+    {
+        "Graphics": "Radeon R7 M465X",
+        "Benchmark": "1786"
+    },
+    {
+        "Graphics": "Radeon R7 Opteron X3421",
+        "Benchmark": "1135"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A6-9500 2C+6G",
+        "Benchmark": "781"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A8-8650B",
+        "Benchmark": "714"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A8-8670E",
+        "Benchmark": "1162"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A8-9600",
+        "Benchmark": "847"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-8750B",
+        "Benchmark": "776"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-8770",
+        "Benchmark": "917"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-8770E",
+        "Benchmark": "804"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-8850B",
+        "Benchmark": "945"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-9700",
+        "Benchmark": "809"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-9700B",
+        "Benchmark": "628"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A10-9700E",
+        "Benchmark": "931"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-8800B",
+        "Benchmark": "619"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-8830B",
+        "Benchmark": "581"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-8870",
+        "Benchmark": "931"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-8870E",
+        "Benchmark": "892"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-9800",
+        "Benchmark": "975"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-9800B",
+        "Benchmark": "697"
+    },
+    {
+        "Graphics": "Radeon R7 PRO A12-9800E",
+        "Benchmark": "971"
+    },
+    {
+        "Graphics": "Radeon R7E",
+        "Benchmark": "564"
+    },
+    {
+        "Graphics": "Radeon R8 M365DX",
+        "Benchmark": "647"
+    },
+    {
+        "Graphics": "Radeon R8 M445DX",
+        "Benchmark": "796"
+    },
+    {
+        "Graphics": "Radeon R8 M535DX",
+        "Benchmark": "670"
+    },
+    {
+        "Graphics": "Radeon R9 255",
+        "Benchmark": "1435"
+    },
+    {
+        "Graphics": "Radeon R9 260",
+        "Benchmark": "3047"
+    },
+    {
+        "Graphics": "Radeon R9 270",
+        "Benchmark": "4306"
+    },
+    {
+        "Graphics": "Radeon R9 270 / R7 370",
+        "Benchmark": "4259"
+    },
+    {
+        "Graphics": "Radeon R9 270X",
+        "Benchmark": "4871"
+    },
+    {
+        "Graphics": "Radeon R9 280",
+        "Benchmark": "5542"
+    },
+    {
+        "Graphics": "Radeon R9 280X",
+        "Benchmark": "6123"
+    },
+    {
+        "Graphics": "Radeon R9 285 / 380",
+        "Benchmark": "5549"
+    },
+    {
+        "Graphics": "Radeon R9 290",
+        "Benchmark": "8208"
+    },
+    {
+        "Graphics": "Radeon R9 290 / 390",
+        "Benchmark": "8150"
+    },
+    {
+        "Graphics": "Radeon R9 290X",
+        "Benchmark": "8513"
+    },
+    {
+        "Graphics": "Radeon R9 290X / 390X",
+        "Benchmark": "8380"
+    },
+    {
+        "Graphics": "Radeon R9 295X2",
+        "Benchmark": "8681"
+    },
+    {
+        "Graphics": "Radeon R9 350",
+        "Benchmark": "1988"
+    },
+    {
+        "Graphics": "Radeon R9 360",
+        "Benchmark": "3031"
+    },
+    {
+        "Graphics": "Radeon R9 370",
+        "Benchmark": "4722"
+    },
+    {
+        "Graphics": "Radeon R9 380",
+        "Benchmark": "6063"
+    },
+    {
+        "Graphics": "Radeon R9 380X",
+        "Benchmark": "6156"
+    },
+    {
+        "Graphics": "Radeon R9 390",
+        "Benchmark": "8872"
+    },
+    {
+        "Graphics": "Radeon R9 390X",
+        "Benchmark": "9359"
+    },
+    {
+        "Graphics": "Radeon R9 Fury",
+        "Benchmark": "9539"
+    },
+    {
+        "Graphics": "Radeon R9 Fury + Fury X",
+        "Benchmark": "9741"
+    },
+    {
+        "Graphics": "Radeon R9 Fury X",
+        "Benchmark": "9439"
+    },
+    {
+        "Graphics": "Radeon R9 M265X",
+        "Benchmark": "1152"
+    },
+    {
+        "Graphics": "Radeon R9 M270X",
+        "Benchmark": "1204"
+    },
+    {
+        "Graphics": "Radeon R9 M275",
+        "Benchmark": "1114"
+    },
+    {
+        "Graphics": "Radeon R9 M275X",
+        "Benchmark": "1699"
+    },
+    {
+        "Graphics": "Radeon R9 M275X / M375",
+        "Benchmark": "1574"
+    },
+    {
+        "Graphics": "Radeon R9 M280X",
+        "Benchmark": "813"
+    },
+    {
+        "Graphics": "Radeon R9 M290X",
+        "Benchmark": "3217"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon R9 M295X",
+        "Benchmark": "5150"
+    },
+    {
+        "Graphics": "Radeon R9 M360",
+        "Benchmark": "1842"
+    },
+    {
+        "Graphics": "Radeon R9 M365X",
+        "Benchmark": "1481"
+    },
+    {
+        "Graphics": "Radeon R9 M370X",
+        "Benchmark": "1551"
+    },
+    {
+        "Graphics": "Radeon R9 M375",
+        "Benchmark": "973"
+    },
+    {
+        "Graphics": "Radeon R9 M375X",
+        "Benchmark": "1715"
+    },
+    {
+        "Graphics": "Radeon R9 M380",
+        "Benchmark": "2773"
+    },
+    {
+        "Graphics": "Radeon R9 M385",
+        "Benchmark": "2060"
+    },
+    {
+        "Graphics": "Radeon R9 M385X",
+        "Benchmark": "1993"
+    },
+    {
+        "Graphics": "Radeon R9 M390X",
+        "Benchmark": "3850"
+    },
+    {
+        "Graphics": "Radeon R9 M395",
+        "Benchmark": "4915"
+    },
+    {
+        "Graphics": "Radeon R9 M395X",
+        "Benchmark": "5128"
+    },
+    {
+        "Graphics": "Radeon R9 M470",
+        "Benchmark": "2330"
+    },
+    {
+        "Graphics": "Radeon R9 M470X",
+        "Benchmark": "3244"
+    },
+    {
+        "Graphics": "Radeon R9 M485X",
+        "Benchmark": "3660"
+    },
+    {
+        "Graphics": "Radeon RX590 GME",
+        "Benchmark": "8443"
+    },
+    {
+        "Graphics": "Radeon RX 460",
+        "Benchmark": "4092"
+    },
+    {
+        "Graphics": "Radeon RX 470/570",
+        "Benchmark": "7959"
+    },
+    {
+        "Graphics": "Radeon RX 480",
+        "Benchmark": "8569"
+    },
+    {
+        "Graphics": "Radeon RX 540",
+        "Benchmark": "2013"
+    },
+    {
+        "Graphics": "Radeon RX 550",
+        "Benchmark": "2688"
+    },
+    {
+        "Graphics": "Radeon RX 550X",
+        "Benchmark": "2357"
+    },
+    {
+        "Graphics": "Radeon RX 560",
+        "Benchmark": "3659"
+    },
+    {
+        "Graphics": "Radeon RX 560X",
+        "Benchmark": "3168"
+    },
+    {
+        "Graphics": "Radeon RX 570X",
+        "Benchmark": "1923"
+    },
+    {
+        "Graphics": "Radeon RX 580",
+        "Benchmark": "8822"
+    },
+    {
+        "Graphics": "Radeon RX 580 2048SP",
+        "Benchmark": "7665"
+    },
+    {
+        "Graphics": "Radeon RX 580X",
+        "Benchmark": "7536"
+    },
+    {
+        "Graphics": "Radeon RX 590",
+        "Benchmark": "9373"
+    },
+    {
+        "Graphics": "Radeon RX 640",
+        "Benchmark": "2145"
+    },
+    {
+        "Graphics": "Radeon RX 780",
+        "Benchmark": "7657"
+    },
+    {
+        "Graphics": "Radeon RX 5300",
+        "Benchmark": "7587"
+    },
+    {
+        "Graphics": "Radeon RX 5300M",
+        "Benchmark": "4723"
+    },
+    {
+        "Graphics": "Radeon RX 5500",
+        "Benchmark": "8780"
+    },
+    {
+        "Graphics": "Radeon RX 5500 XT",
+        "Benchmark": "9092"
+    },
+    {
+        "Graphics": "Radeon RX 5500M",
+        "Benchmark": "5796"
+    },
+    {
+        "Graphics": "Radeon RX 5600",
+        "Benchmark": "11725"
+    },
+    {
+        "Graphics": "Radeon RX 5600 OEM",
+        "Benchmark": "12842"
+    },
+    {
+        "Graphics": "Radeon RX 5600 XT",
+        "Benchmark": "13481"
+    },
+    {
+        "Graphics": "Radeon RX 5600M",
+        "Benchmark": "8861"
+    },
+    {
+        "Graphics": "Radeon RX 5700",
+        "Benchmark": "14333"
+    },
+    {
+        "Graphics": "Radeon RX 5700 XT",
+        "Benchmark": "16335"
+    },
+    {
+        "Graphics": "Radeon RX 5700 XT 50th Anniversary",
+        "Benchmark": "16418"
+    },
+    {
+        "Graphics": "Radeon RX 6300",
+        "Benchmark": "5295"
+    },
+    {
+        "Graphics": "Radeon RX 6300M",
+        "Benchmark": "6421"
+    },
+    {
+        "Graphics": "Radeon RX 6400",
+        "Benchmark": "7658"
+    },
+    {
+        "Graphics": "Radeon RX 6500",
+        "Benchmark": "7502"
+    },
+    {
+        "Graphics": "Radeon RX 6500 XT",
+        "Benchmark": "9601"
+    },
+    {
+        "Graphics": "Radeon RX 6500M",
+        "Benchmark": "7534"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon RX 6550M",
+        "Benchmark": "9772"
+    },
+    {
+        "Graphics": "Radeon RX 6600",
+        "Benchmark": "15099"
+    },
+    {
+        "Graphics": "Radeon RX 6600 LE",
+        "Benchmark": "15387"
+    },
+    {
+        "Graphics": "Radeon RX 6600 XT",
+        "Benchmark": "16478"
+    },
+    {
+        "Graphics": "Radeon RX 6600M",
+        "Benchmark": "13933"
+    },
+    {
+        "Graphics": "Radeon RX 6600S",
+        "Benchmark": "11715"
+    },
+    {
+        "Graphics": "Radeon RX 6650 XT",
+        "Benchmark": "17143"
+    },
+    {
+        "Graphics": "Radeon RX 6650M",
+        "Benchmark": "15018"
+    },
+    {
+        "Graphics": "Radeon RX 6650M XT",
+        "Benchmark": "17070"
+    },
+    {
+        "Graphics": "Radeon RX 6700",
+        "Benchmark": "19167"
+    },
+    {
+        "Graphics": "Radeon RX 6700 XT",
+        "Benchmark": "19810"
+    },
+    {
+        "Graphics": "Radeon RX 6700M",
+        "Benchmark": "13609"
+    },
+    {
+        "Graphics": "Radeon RX 6700S",
+        "Benchmark": "15036"
+    },
+    {
+        "Graphics": "Radeon RX 6750 GRE 10GB",
+        "Benchmark": "18354"
+    },
+    {
+        "Graphics": "Radeon RX 6750 GRE 12GB",
+        "Benchmark": "19956"
+    },
+    {
+        "Graphics": "Radeon RX 6750 XT",
+        "Benchmark": "20727"
+    },
+    {
+        "Graphics": "Radeon RX 6800",
+        "Benchmark": "22112"
+    },
+    {
+        "Graphics": "Radeon RX 6800 XT",
+        "Benchmark": "25005"
+    },
+    {
+        "Graphics": "Radeon RX 6800M",
+        "Benchmark": "13259"
+    },
+    {
+        "Graphics": "Radeon RX 6800S",
+        "Benchmark": "15826"
+    },
+    {
+        "Graphics": "Radeon RX 6850M",
+        "Benchmark": "12274"
+    },
+    {
+        "Graphics": "Radeon RX 6850M XT",
+        "Benchmark": "17336"
+    },
+    {
+        "Graphics": "Radeon RX 6900 XT",
+        "Benchmark": "26747"
+    },
+    {
+        "Graphics": "Radeon RX 6950 XT",
+        "Benchmark": "28126"
+    },
+    {
+        "Graphics": "Radeon RX 7600",
+        "Benchmark": "16610"
+    },
+    {
+        "Graphics": "Radeon RX 7600 XT",
+        "Benchmark": "17142"
+    },
+    {
+        "Graphics": "Radeon RX 7600M",
+        "Benchmark": "11581"
+    },
+    {
+        "Graphics": "Radeon RX 7600M XT",
+        "Benchmark": "13154"
+    },
+    {
+        "Graphics": "Radeon RX 7600S",
+        "Benchmark": "15428"
+    },
+    {
+        "Graphics": "Radeon RX 7650 GRE",
+        "Benchmark": "16992"
+    },
+    {
+        "Graphics": "Radeon RX 7700 XT",
+        "Benchmark": "22467"
+    },
+    {
+        "Graphics": "Radeon RX 7700S",
+        "Benchmark": "15343"
+    },
+    {
+        "Graphics": "Radeon RX 7800 XT",
+        "Benchmark": "24239"
+    },
+    {
+        "Graphics": "Radeon RX 7800M",
+        "Benchmark": "17029"
+    },
+    {
+        "Graphics": "Radeon RX 7900 GRE",
+        "Benchmark": "27056"
+    },
+    {
+        "Graphics": "Radeon RX 7900 XT",
+        "Benchmark": "28928"
+    },
+    {
+        "Graphics": "Radeon RX 7900 XTX",
+        "Benchmark": "31166"
+    },
+    {
+        "Graphics": "Radeon RX 7900M",
+        "Benchmark": "23033"
+    },
+    {
+        "Graphics": "Radeon RX 9070",
+        "Benchmark": "24974"
+    },
+    {
+        "Graphics": "Radeon RX 9070 GRE",
+        "Benchmark": "20506"
+    },
+    {
+        "Graphics": "Radeon RX 9070 XT",
+        "Benchmark": "26918"
+    },
+    {
+        "Graphics": "Radeon RX Vega11",
+        "Benchmark": "1605"
+    },
+    {
+        "Graphics": "Radeon RX Vega11 Ryzen 7 3750H",
+        "Benchmark": "1711"
+    },
+    {
+        "Graphics": "Radeon RX Vega11 Ryzen 7 Microsoft Surface Edition",
+        "Benchmark": "1420"
+    },
+    {
+        "Graphics": "Radeon RX Vega 6 Ryzen 3 3200U",
+        "Benchmark": "906"
+    },
+    {
+        "Graphics": "Radeon RX Vega 8",
+        "Benchmark": "1527"
+    },
+    {
+        "Graphics": "Radeon RX Vega 10",
+        "Benchmark": "1631"
+    },
+    {
+        "Graphics": "Radeon RX Vega 10 Ryzen 7 3700C",
+        "Benchmark": "1166"
+    },
+    {
+        "Graphics": "Radeon RX Vega 10 Ryzen 7 3700U",
+        "Benchmark": "1485"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon RX Vega 10 Ryzen 7 3750H",
+        "Benchmark": "1883"
+    },
+    {
+        "Graphics": "Radeon RX Vega 10 Ryzen 7 PRO 3700U w/",
+        "Benchmark": "1503"
+    },
+    {
+        "Graphics": "Radeon RX Vega 11",
+        "Benchmark": "2104"
+    },
+    {
+        "Graphics": "Radeon RX Vega 11 PRD",
+        "Benchmark": "2401"
+    },
+    {
+        "Graphics": "Radeon RX Vega 11 Processor",
+        "Benchmark": "1766"
+    },
+    {
+        "Graphics": "Radeon RX Vega 11 Ryzen 5 3350G",
+        "Benchmark": "1957"
+    },
+    {
+        "Graphics": "Radeon RX Vega 11 Ryzen 5 3400G",
+        "Benchmark": "2157"
+    },
+    {
+        "Graphics": "Radeon RX Vega 11 Ryzen 5 3400GE",
+        "Benchmark": "1941"
+    },
+    {
+        "Graphics": "Radeon RX Vega 56",
+        "Benchmark": "13082"
+    },
+    {
+        "Graphics": "Radeon RX Vega 64",
+        "Benchmark": "14095"
+    },
+    {
+        "Graphics": "Radeon RX Vega - Renoir Ryzen 3 5300U",
+        "Benchmark": "2312"
+    },
+    {
+        "Graphics": "Radeon RX Vega M GH",
+        "Benchmark": "6587"
+    },
+    {
+        "Graphics": "Radeon RX Vega M GL",
+        "Benchmark": "3867"
+    },
+    {
+        "Graphics": "Radeon RX Vega Ryzen 3 5300U",
+        "Benchmark": "2329"
+    },
+    {
+        "Graphics": "Radeon RX Vega Ryzen 5 5600GT",
+        "Benchmark": "9558"
+    },
+    {
+        "Graphics": "Radeon RX Vega Ryzen 7 5825U",
+        "Benchmark": "2916"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 3250U",
+        "Benchmark": "807"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 5300U",
+        "Benchmark": "1611"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 5425U",
+        "Benchmark": "1531"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 7330U",
+        "Benchmark": "1639"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 7335U",
+        "Benchmark": "2158"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 PRO 4355GE",
+        "Benchmark": "1431"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 PRO 5355GE",
+        "Benchmark": "1951"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 PRO 5450U",
+        "Benchmark": "1710"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 PRO 5475U",
+        "Benchmark": "1541"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 PRO 7330U",
+        "Benchmark": "1832"
+    },
+    {
+        "Graphics": "Radeon Ryzen 3 PRO 7335U",
+        "Benchmark": "1992"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 3450U",
+        "Benchmark": "1114"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 3550H",
+        "Benchmark": "1730"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 4600GE with Radeon Graphics",
+        "Benchmark": "2249"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5500GT",
+        "Benchmark": "2501"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5500U",
+        "Benchmark": "2043"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5560U",
+        "Benchmark": "2031"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5600GE",
+        "Benchmark": "2471"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5600GT",
+        "Benchmark": "2426"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5600H",
+        "Benchmark": "2423"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5600U",
+        "Benchmark": "2098"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 5625U",
+        "Benchmark": "2120"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 6600H",
+        "Benchmark": "3462"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 6600HS Creator Edition",
+        "Benchmark": "3766"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 6600U",
+        "Benchmark": "3293"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7430U",
+        "Benchmark": "2554"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7530U",
+        "Benchmark": "2230"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7533HS",
+        "Benchmark": "3523"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7535HS",
+        "Benchmark": "3094"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7535U",
+        "Benchmark": "3158"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7600 6-Core",
+        "Benchmark": "1738"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7600X3D 6-Core",
+        "Benchmark": "1869"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 7600X 6-Core",
+        "Benchmark": "1698"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 Microsoft Surface Edition",
+        "Benchmark": "2050"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 4400G",
+        "Benchmark": "2276"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 4655G",
+        "Benchmark": "2283"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 4655GE",
+        "Benchmark": "2361"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 5650G",
+        "Benchmark": "2282"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 5650GE",
+        "Benchmark": "2316"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 5655G",
+        "Benchmark": "2567"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 5655GE",
+        "Benchmark": "1801"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 5675U",
+        "Benchmark": "1915"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 6650H",
+        "Benchmark": "2678"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 6650U",
+        "Benchmark": "3658"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 Pro 7535U",
+        "Benchmark": "2997"
+    },
+    {
+        "Graphics": "Radeon Ryzen 5 PRO 7645 6-Core",
+        "Benchmark": "1488"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 3700U",
+        "Benchmark": "1301"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 4700G",
+        "Benchmark": "2583"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 4700GE",
+        "Benchmark": "2595"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 4700U",
+        "Benchmark": "2035"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 4800H",
+        "Benchmark": "3308"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 4800HS",
+        "Benchmark": "3208"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 4800U",
+        "Benchmark": "2320"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 5700U",
+        "Benchmark": "2259"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 5800H",
+        "Benchmark": "2820"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 5800HS",
+        "Benchmark": "2539"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 5800U",
+        "Benchmark": "2403"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 5825U",
+        "Benchmark": "2392"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 6800H",
+        "Benchmark": "4989"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 6800HS",
+        "Benchmark": "6025"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 6800HS Creator Edition",
+        "Benchmark": "5362"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 6800U",
+        "Benchmark": "4540"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 6810U",
+        "Benchmark": "5937"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7700 8-Core",
+        "Benchmark": "1782"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7700X 8-Core",
+        "Benchmark": "1981"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7730U",
+        "Benchmark": "2424"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7735H",
+        "Benchmark": "5334"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7735HS",
+        "Benchmark": "5055"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7735U",
+        "Benchmark": "4743"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7736U",
+        "Benchmark": "5818"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 7800X3D 8-Core",
+        "Benchmark": "1786"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 Microsoft Surface Edition",
+        "Benchmark": "2275"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 4750G",
+        "Benchmark": "2496"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 4750GE",
+        "Benchmark": "2379"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 4750U",
+        "Benchmark": "2020"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 5755GE",
+        "Benchmark": "2117"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 5875U",
+        "Benchmark": "2146"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 6850H",
+        "Benchmark": "5366"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 6850HS",
+        "Benchmark": "5057"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 6850U",
+        "Benchmark": "5107"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 6860Z",
+        "Benchmark": "4558"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 7730U",
+        "Benchmark": "2294"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 Pro 7735U",
+        "Benchmark": "3899"
+    },
+    {
+        "Graphics": "Radeon Ryzen 7 PRO 7745 8-Core",
+        "Benchmark": "1655"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 4900H",
+        "Benchmark": "2599"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 4950U Mobile",
+        "Benchmark": "2594"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 5900H",
+        "Benchmark": "2960"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 6900HS",
+        "Benchmark": "6602"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 6900HS Creator Edition",
+        "Benchmark": "5155"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 7900 12-Core",
+        "Benchmark": "1999"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 7900X3D 12-Core",
+        "Benchmark": "1774"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 7900X 12-Core",
+        "Benchmark": "2296"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 7950X3D 16-Core",
+        "Benchmark": "1657"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 7950X 16-Core",
+        "Benchmark": "3313"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 PRO 6950H",
+        "Benchmark": "5770"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 PRO 6950HS",
+        "Benchmark": "4427"
+    },
+    {
+        "Graphics": "Radeon Ryzen 9 PRO 7945 12-Core",
+        "Benchmark": "1626"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded R2312",
+        "Benchmark": "853"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded R2314",
+        "Benchmark": "997"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded R2514",
+        "Benchmark": "1581"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded R2544",
+        "Benchmark": "1864"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded V2516",
+        "Benchmark": "1723"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded V2546",
+        "Benchmark": "1435"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded V2718",
+        "Benchmark": "1998"
+    },
+    {
+        "Graphics": "Radeon Ryzen Embedded V2748",
+        "Benchmark": "2216"
+    },
+    {
+        "Graphics": "Radeon Ryzen Z2 Go",
+        "Benchmark": "4989"
+    },
+    {
+        "Graphics": "Radeon Sky 500",
+        "Benchmark": "4709"
+    },
+    {
+        "Graphics": "Radeon TM",
+        "Benchmark": "5605"
+    },
+    {
+        "Graphics": "Radeon TM R9 A360",
+        "Benchmark": "2060"
+    },
+    {
+        "Graphics": "Radeon VE",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "Radeon Vega 2",
+        "Benchmark": "506"
+    },
+    {
+        "Graphics": "Radeon Vega 2 Athlon Silver 3050U",
+        "Benchmark": "521"
+    },
+    {
+        "Graphics": "Radeon Vega 3",
+        "Benchmark": "889"
+    },
+    {
+        "Graphics": "Radeon Vega 3 3020e",
+        "Benchmark": "553"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon 300GE",
+        "Benchmark": "1044"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon 300U",
+        "Benchmark": "832"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon 320GE",
+        "Benchmark": "677"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon 3000G",
+        "Benchmark": "955"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon Gold 3150G",
+        "Benchmark": "1088"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon Gold 3150U",
+        "Benchmark": "668"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon Gold PRO 3150G",
+        "Benchmark": "671"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon PRO 300GE w/",
+        "Benchmark": "1010"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon Silver 3050e",
+        "Benchmark": "485"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Athlon Silver 3050U",
+        "Benchmark": "874"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Mobile",
+        "Benchmark": "1047"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Ryzen 3 3200U",
+        "Benchmark": "838"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Ryzen 3 3250U",
+        "Benchmark": "679"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Ryzen Embedded R1305G",
+        "Benchmark": "580"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Ryzen Embedded R1505G",
+        "Benchmark": "741"
+    },
+    {
+        "Graphics": "Radeon Vega 3 Ryzen Embedded R1606G",
+        "Benchmark": "856"
+    },
+    {
+        "Graphics": "Radeon Vega 6",
+        "Benchmark": "1309"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon Vega 6 Ryzen 3 3300U",
+        "Benchmark": "1302"
+    },
+    {
+        "Graphics": "Radeon Vega 6 Ryzen 3 3350U",
+        "Benchmark": "1480"
+    },
+    {
+        "Graphics": "Radeon Vega 6 Ryzen 3 PRO 3300U w/",
+        "Benchmark": "1340"
+    },
+    {
+        "Graphics": "Radeon Vega 8",
+        "Benchmark": "1577"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Mobile",
+        "Benchmark": "1426"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 3 3200G",
+        "Benchmark": "1718"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 3 3200GE",
+        "Benchmark": "1994"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 3 PRO 3200G",
+        "Benchmark": "1261"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 3 PRO 3200GE w/",
+        "Benchmark": "1571"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 5 3450U",
+        "Benchmark": "1288"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 5 3500U",
+        "Benchmark": "1352"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 5 3550H",
+        "Benchmark": "1699"
+    },
+    {
+        "Graphics": "Radeon Vega 8 Ryzen 5 PRO 3500U w/",
+        "Benchmark": "1480"
+    },
+    {
+        "Graphics": "Radeon Vega 9",
+        "Benchmark": "1587"
+    },
+    {
+        "Graphics": "Radeon Vega 9 Ryzen 5 3550H",
+        "Benchmark": "1571"
+    },
+    {
+        "Graphics": "Radeon Vega 9 Ryzen 5 Microsoft Surface Edition",
+        "Benchmark": "1481"
+    },
+    {
+        "Graphics": "Radeon Vega 10",
+        "Benchmark": "1544"
+    },
+    {
+        "Graphics": "Radeon Vega 10 Mobile",
+        "Benchmark": "1528"
+    },
+    {
+        "Graphics": "Radeon Vega 10 Ryzen 7 PRO 3700U w/",
+        "Benchmark": "1580"
+    },
+    {
+        "Graphics": "Radeon Vega 11",
+        "Benchmark": "1862"
+    },
+    {
+        "Graphics": "Radeon Vega 11 Ryzen 5 PRO 3350G",
+        "Benchmark": "2185"
+    },
+    {
+        "Graphics": "Radeon Vega 11 Ryzen 5 PRO 3400G",
+        "Benchmark": "2007"
+    },
+    {
+        "Graphics": "Radeon Vega 11 Ryzen 5 PRO 3400GE w/",
+        "Benchmark": "1397"
+    },
+    {
+        "Graphics": "Radeon Vega Frontier Edition",
+        "Benchmark": "13013"
+    },
+    {
+        "Graphics": "Radeon VII",
+        "Benchmark": "16351"
+    },
+    {
+        "Graphics": "RADEON X300SE",
+        "Benchmark": "38"
+    },
+    {
+        "Graphics": "RADEON X550",
+        "Benchmark": "50"
+    },
+    {
+        "Graphics": "RADEON X550XT",
+        "Benchmark": "56"
+    },
+    {
+        "Graphics": "Radeon X550XTX",
+        "Benchmark": "70"
+    },
+    {
+        "Graphics": "RADEON X600 256MB HyperMemory",
+        "Benchmark": "56"
+    },
+    {
+        "Graphics": "RADEON X600 PRO",
+        "Benchmark": "67"
+    },
+    {
+        "Graphics": "RADEON X600 SE",
+        "Benchmark": "49"
+    },
+    {
+        "Graphics": "RADEON X600XT",
+        "Benchmark": "91"
+    },
+    {
+        "Graphics": "RADEON X700",
+        "Benchmark": "72"
+    },
+    {
+        "Graphics": "RADEON X700 PRO",
+        "Benchmark": "75"
+    },
+    {
+        "Graphics": "RADEON X700 SE",
+        "Benchmark": "71"
+    },
+    {
+        "Graphics": "RADEON X800 GT",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "RADEON X800 GTO",
+        "Benchmark": "114"
+    },
+    {
+        "Graphics": "RADEON X800 PRO",
+        "Benchmark": "64"
+    },
+    {
+        "Graphics": "RADEON X800 PRO/GTO",
+        "Benchmark": "73"
+    },
+    {
+        "Graphics": "RADEON X800 SE",
+        "Benchmark": "129"
+    },
+    {
+        "Graphics": "RADEON X800 XL",
+        "Benchmark": "69"
+    },
+    {
+        "Graphics": "RADEON X800 XT",
+        "Benchmark": "97"
+    },
+    {
+        "Graphics": "RADEON X800 XT Platinum Edition",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "RADEON X800GT",
+        "Benchmark": "79"
+    },
+    {
+        "Graphics": "RADEON X850 PRO",
+        "Benchmark": "72"
+    },
+    {
+        "Graphics": "RADEON X850 XT",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "RADEON X850 XT Platinum Edition",
+        "Benchmark": "81"
+    },
+    {
+        "Graphics": "Radeon X1050",
+        "Benchmark": "49"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Radeon X1200",
+        "Benchmark": "32"
+    },
+    {
+        "Graphics": "Radeon X1250",
+        "Benchmark": "37"
+    },
+    {
+        "Graphics": "Radeon X1270",
+        "Benchmark": "31"
+    },
+    {
+        "Graphics": "Radeon X1300",
+        "Benchmark": "58"
+    },
+    {
+        "Graphics": "Radeon X1300 PRO",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "Radeon X1550",
+        "Benchmark": "66"
+    },
+    {
+        "Graphics": "Radeon X1550 64-bit",
+        "Benchmark": "47"
+    },
+    {
+        "Graphics": "Radeon X1600",
+        "Benchmark": "49"
+    },
+    {
+        "Graphics": "Radeon X1600 Pro",
+        "Benchmark": "98"
+    },
+    {
+        "Graphics": "Radeon X1600 Pro / X1300XT",
+        "Benchmark": "69"
+    },
+    {
+        "Graphics": "Radeon X1600 XT",
+        "Benchmark": "115"
+    },
+    {
+        "Graphics": "Radeon X1650 GTO",
+        "Benchmark": "74"
+    },
+    {
+        "Graphics": "Radeon X1650 Pro",
+        "Benchmark": "84"
+    },
+    {
+        "Graphics": "Radeon X1650 SE",
+        "Benchmark": "71"
+    },
+    {
+        "Graphics": "Radeon X1700 Targa Edition",
+        "Benchmark": "116"
+    },
+    {
+        "Graphics": "Radeon X1800 GTO",
+        "Benchmark": "140"
+    },
+    {
+        "Graphics": "Radeon X1900 CrossFire Edition",
+        "Benchmark": "137"
+    },
+    {
+        "Graphics": "Radeon X1900 GT",
+        "Benchmark": "145"
+    },
+    {
+        "Graphics": "Radeon X1950 CrossFire Edition",
+        "Benchmark": "151"
+    },
+    {
+        "Graphics": "Radeon X1950 GT",
+        "Benchmark": "106"
+    },
+    {
+        "Graphics": "Radeon X1950 Pro",
+        "Benchmark": "112"
+    },
+    {
+        "Graphics": "RADEON XPRESS 200",
+        "Benchmark": "29"
+    },
+    {
+        "Graphics": "RADEON XPRESS 200 CROSSFIRE",
+        "Benchmark": "18"
+    },
+    {
+        "Graphics": "RADEON XPRESS 200M",
+        "Benchmark": "22"
+    },
+    {
+        "Graphics": "Radeon Xpress 1100",
+        "Benchmark": "34"
+    },
+    {
+        "Graphics": "Radeon Xpress 1150",
+        "Benchmark": "29"
+    },
+    {
+        "Graphics": "Radeon Xpress 1200",
+        "Benchmark": "35"
+    },
+    {
+        "Graphics": "Radeon Xpress 1250",
+        "Benchmark": "42"
+    },
+    {
+        "Graphics": "Radeon Xpress 1270",
+        "Benchmark": "26"
+    },
+    {
+        "Graphics": "Radeon Xpress 1300",
+        "Benchmark": "52"
+    },
+    {
+        "Graphics": "Radeon Xpress 1300M",
+        "Benchmark": "40"
+    },
+    {
+        "Graphics": "RadeonT 610M",
+        "Benchmark": "1081"
+    },
+    {
+        "Graphics": "RadeonT 660M",
+        "Benchmark": "2220"
+    },
+    {
+        "Graphics": "RadeonT 660M Ryzen 5 7535HS",
+        "Benchmark": "4051"
+    },
+    {
+        "Graphics": "RadeonT 680M Ryzen 7 7735HS",
+        "Benchmark": "5626"
+    },
+    {
+        "Graphics": "RadeonT 780M",
+        "Benchmark": "7098"
+    },
+    {
+        "Graphics": "RadeonT RX 6850M XT",
+        "Benchmark": "14609"
+    },
+    {
+        "Graphics": "RadeonT RX Vega 11",
+        "Benchmark": "1842"
+    },
+    {
+        "Graphics": "RadeonT Ryzen 3 3250U",
+        "Benchmark": "581"
+    },
+    {
+        "Graphics": "Rage 128 Pro",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "RAGE 128 PRO AGP 4X TMDS",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "Rage Fury Pro/Xpert 2000 Pro",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RDPDD Chained DD",
+        "Benchmark": "224"
+    },
+    {
+        "Graphics": "Red Hat QXL controller",
+        "Benchmark": "52"
+    },
+    {
+        "Graphics": "RGH Drivers v3",
+        "Benchmark": "11"
+    },
+    {
+        "Graphics": "RIVA TNT2 Model 64/Model 64 Pro",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RIVA TNT2/TNT2 Pro",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "RTX 500 Ada Generation Laptop GPU",
+        "Benchmark": "10940"
+    },
+    {
+        "Graphics": "RTX 1000 Ada Generation Laptop GPU",
+        "Benchmark": "13382"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "RTX 2000 Ada Generation",
+        "Benchmark": "17087"
+    },
+    {
+        "Graphics": "RTX 2000 Ada Generation Embedded GPU",
+        "Benchmark": "15334"
+    },
+    {
+        "Graphics": "RTX 2000 Ada Generation Laptop GPU",
+        "Benchmark": "15228"
+    },
+    {
+        "Graphics": "RTX 2000E Ada Generation",
+        "Benchmark": "14143"
+    },
+    {
+        "Graphics": "RTX 3000 Ada Generation Laptop GPU",
+        "Benchmark": "15870"
+    },
+    {
+        "Graphics": "RTX 3500 Ada Generation Embedded GPU",
+        "Benchmark": "25188"
+    },
+    {
+        "Graphics": "RTX 3500 Ada Generation Laptop GPU",
+        "Benchmark": "19847"
+    },
+    {
+        "Graphics": "RTX 4000 Ada Generation",
+        "Benchmark": "23724"
+    },
+    {
+        "Graphics": "RTX 4000 Ada Generation Laptop GPU",
+        "Benchmark": "22293"
+    },
+    {
+        "Graphics": "RTX 4000 SFF Ada Generation",
+        "Benchmark": "20469"
+    },
+    {
+        "Graphics": "RTX 4500 Ada Generation",
+        "Benchmark": "27468"
+    },
+    {
+        "Graphics": "RTX 5000 Ada Generation",
+        "Benchmark": "30166"
+    },
+    {
+        "Graphics": "RTX 5000 Ada Generation Embedded GPU",
+        "Benchmark": "27774"
+    },
+    {
+        "Graphics": "RTX 5000 Ada Generation Laptop GPU",
+        "Benchmark": "23891"
+    },
+    {
+        "Graphics": "RTX 5880 Ada Generation",
+        "Benchmark": "23750"
+    },
+    {
+        "Graphics": "RTX 6000 Ada Generation",
+        "Benchmark": "28551"
+    },
+    {
+        "Graphics": "RTX A400",
+        "Benchmark": "5859"
+    },
+    {
+        "Graphics": "RTX A500 Embedded GPU",
+        "Benchmark": "5292"
+    },
+    {
+        "Graphics": "RTX A500 Laptop GPU",
+        "Benchmark": "6689"
+    },
+    {
+        "Graphics": "RTX A1000",
+        "Benchmark": "10619"
+    },
+    {
+        "Graphics": "RTX A1000 6GB Laptop GPU",
+        "Benchmark": "10081"
+    },
+    {
+        "Graphics": "RTX A1000 Embedded GPU",
+        "Benchmark": "11460"
+    },
+    {
+        "Graphics": "RTX A1000 Laptop GPU",
+        "Benchmark": "9558"
+    },
+    {
+        "Graphics": "RTX A2000",
+        "Benchmark": "13582"
+    },
+    {
+        "Graphics": "RTX A2000 8GB Laptop GPU",
+        "Benchmark": "10678"
+    },
+    {
+        "Graphics": "RTX A2000 12GB",
+        "Benchmark": "13743"
+    },
+    {
+        "Graphics": "RTX A2000 Embedded GPU",
+        "Benchmark": "10860"
+    },
+    {
+        "Graphics": "RTX A2000 Laptop GPU",
+        "Benchmark": "9703"
+    },
+    {
+        "Graphics": "RTX A3000 12GB Laptop GPU",
+        "Benchmark": "13692"
+    },
+    {
+        "Graphics": "RTX A3000 Laptop GPU",
+        "Benchmark": "12652"
+    },
+    {
+        "Graphics": "RTX A4000",
+        "Benchmark": "19519"
+    },
+    {
+        "Graphics": "RTX A4000 Laptop GPU",
+        "Benchmark": "14894"
+    },
+    {
+        "Graphics": "RTX A4500",
+        "Benchmark": "21246"
+    },
+    {
+        "Graphics": "RTX A4500 Embedded GPU",
+        "Benchmark": "8309"
+    },
+    {
+        "Graphics": "RTX A4500 Laptop GPU",
+        "Benchmark": "16792"
+    },
+    {
+        "Graphics": "RTX A5000",
+        "Benchmark": "22544"
+    },
+    {
+        "Graphics": "RTX A5000 Laptop GPU",
+        "Benchmark": "16066"
+    },
+    {
+        "Graphics": "RTX A5500",
+        "Benchmark": "21376"
+    },
+    {
+        "Graphics": "RTX A5500 Laptop GPU",
+        "Benchmark": "17275"
+    },
+    {
+        "Graphics": "RTX A6000",
+        "Benchmark": "22623"
+    },
+    {
+        "Graphics": "RTX PRO 500 Blackwell Generation Laptop GPU",
+        "Benchmark": "15341"
+    },
+    {
+        "Graphics": "RTX PRO 1000 Blackwell Generation Laptop GPU",
+        "Benchmark": "14131"
+    },
+    {
+        "Graphics": "RTX PRO 2000 Blackwell Generation Laptop GPU",
+        "Benchmark": "15569"
+    },
+    {
+        "Graphics": "RTX PRO 3000 Blackwell Generation Laptop GPU",
+        "Benchmark": "32375"
+    },
+    {
+        "Graphics": "RTX PRO 6000 Blackwell Workstation Edition",
+        "Benchmark": "28386"
+    },
+    {
+        "Graphics": "RV530 PRO",
+        "Benchmark": "118"
+    },
+    {
+        "Graphics": "Ryzen 3 4300G with Radeon Graphics",
+        "Benchmark": "1614"
+    },
+    {
+        "Graphics": "Ryzen 3 4300GE with Radeon Graphics",
+        "Benchmark": "2326"
+    },
+    {
+        "Graphics": "Ryzen 3 4300U with Radeon Graphics",
+        "Benchmark": "1360"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Ryzen 3 5300G with Radeon Graphics",
+        "Benchmark": "1981"
+    },
+    {
+        "Graphics": "Ryzen 3 5300GE with Radeon Graphics",
+        "Benchmark": "1950"
+    },
+    {
+        "Graphics": "Ryzen 3 5300U with Radeon Graphics",
+        "Benchmark": "1539"
+    },
+    {
+        "Graphics": "Ryzen 3 5400U with Radeon Graphics",
+        "Benchmark": "1601"
+    },
+    {
+        "Graphics": "Ryzen 3 5425U with Radeon Graphics",
+        "Benchmark": "1691"
+    },
+    {
+        "Graphics": "Ryzen 3 7330U with Radeon Graphics",
+        "Benchmark": "1693"
+    },
+    {
+        "Graphics": "Ryzen 3 7335U with Radeon Graphics",
+        "Benchmark": "1980"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 4200GE with Radeon Graphics",
+        "Benchmark": "1748"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 4300U with Radeon Graphics",
+        "Benchmark": "1542"
+    },
+    {
+        "Graphics": "Ryzen 3 Pro 4350G with Radeon Graphics",
+        "Benchmark": "2093"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 4350GE with Radeon Graphics",
+        "Benchmark": "1931"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 4450U with Radeon Graphics",
+        "Benchmark": "1503"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 5350G with Radeon Graphics",
+        "Benchmark": "2299"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 5350GE with Radeon Graphics",
+        "Benchmark": "1819"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 5450U with Radeon Graphics",
+        "Benchmark": "1617"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 5475U with Radeon Graphics",
+        "Benchmark": "1431"
+    },
+    {
+        "Graphics": "Ryzen 3 PRO 7330U with Radeon Graphics",
+        "Benchmark": "2144"
+    },
+    {
+        "Graphics": "Ryzen 5 2500U with Radeon Vega",
+        "Benchmark": "1503"
+    },
+    {
+        "Graphics": "Ryzen 5 4500U with Radeon Graphics",
+        "Benchmark": "1809"
+    },
+    {
+        "Graphics": "Ryzen 5 4600G with Radeon Graphics",
+        "Benchmark": "2358"
+    },
+    {
+        "Graphics": "Ryzen 5 4600H with Radeon Graphics",
+        "Benchmark": "2129"
+    },
+    {
+        "Graphics": "Ryzen 5 4600HS with Radeon Graphics",
+        "Benchmark": "8370"
+    },
+    {
+        "Graphics": "Ryzen 5 4600U with Radeon Graphics",
+        "Benchmark": "1904"
+    },
+    {
+        "Graphics": "Ryzen 5 5500GT with Radeon Graphics",
+        "Benchmark": "2224"
+    },
+    {
+        "Graphics": "Ryzen 5 5500U with Radeon Graphics",
+        "Benchmark": "1970"
+    },
+    {
+        "Graphics": "Ryzen 5 5560U with Radeon Graphics",
+        "Benchmark": "2098"
+    },
+    {
+        "Graphics": "Ryzen 5 5600G with Radeon Graphics",
+        "Benchmark": "2570"
+    },
+    {
+        "Graphics": "Ryzen 5 5600GE with Radeon Graphics",
+        "Benchmark": "2547"
+    },
+    {
+        "Graphics": "Ryzen 5 5600GT with Radeon Graphics",
+        "Benchmark": "2200"
+    },
+    {
+        "Graphics": "Ryzen 5 5600H with Radeon Graphics",
+        "Benchmark": "2297"
+    },
+    {
+        "Graphics": "Ryzen 5 5600U with Radeon Graphics",
+        "Benchmark": "2150"
+    },
+    {
+        "Graphics": "Ryzen 5 5625U with Radeon Graphics",
+        "Benchmark": "1996"
+    },
+    {
+        "Graphics": "Ryzen 5 6600H with Radeon Graphics",
+        "Benchmark": "3579"
+    },
+    {
+        "Graphics": "Ryzen 5 6600HS Creator Edition",
+        "Benchmark": "3690"
+    },
+    {
+        "Graphics": "Ryzen 5 6600U with Radeon Graphics",
+        "Benchmark": "3233"
+    },
+    {
+        "Graphics": "Ryzen 5 7430U with Radeon Graphics",
+        "Benchmark": "2270"
+    },
+    {
+        "Graphics": "Ryzen 5 7530U with Radeon Graphics",
+        "Benchmark": "2250"
+    },
+    {
+        "Graphics": "Ryzen 5 7535U with Radeon Graphics",
+        "Benchmark": "3323"
+    },
+    {
+        "Graphics": "Ryzen 5 9600X 6-Core Processor",
+        "Benchmark": "1858"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 4400G with Radeon Graphics",
+        "Benchmark": "2305"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 4400GE with Radeon Graphics",
+        "Benchmark": "1441"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 4500U with Radeon Graphics",
+        "Benchmark": "2007"
+    },
+    {
+        "Graphics": "Ryzen 5 Pro 4650G with Radeon Graphics",
+        "Benchmark": "2389"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 4650GE with Radeon Graphics",
+        "Benchmark": "2139"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 4650U with Radeon Graphics",
+        "Benchmark": "1686"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 5650G with Radeon Graphics",
+        "Benchmark": "2481"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 5650GE with Radeon Graphics",
+        "Benchmark": "2455"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 5650U with Radeon Graphics",
+        "Benchmark": "1956"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 5675U with Radeon Graphics",
+        "Benchmark": "1719"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 6650U",
+        "Benchmark": "3519"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 6650U with Radeon Graphics",
+        "Benchmark": "3533"
+    },
+    {
+        "Graphics": "Ryzen 5 PRO 7530U with Radeon Graphics",
+        "Benchmark": "1882"
+    },
+    {
+        "Graphics": "Ryzen 5 Pro 7535U with Radeon Graphics",
+        "Benchmark": "3750"
+    },
+    {
+        "Graphics": "Ryzen 7 2700U with Radeon Vega",
+        "Benchmark": "1617"
+    },
+    {
+        "Graphics": "Ryzen 7 4700G with Radeon Graphics",
+        "Benchmark": "2186"
+    },
+    {
+        "Graphics": "Ryzen 7 4700GE with Radeon Graphics",
+        "Benchmark": "2496"
+    },
+    {
+        "Graphics": "Ryzen 7 4700U with Radeon Graphics",
+        "Benchmark": "2034"
+    },
+    {
+        "Graphics": "Ryzen 7 4800H with Radeon Graphics",
+        "Benchmark": "2113"
+    },
+    {
+        "Graphics": "Ryzen 7 4800U with Radeon Graphics",
+        "Benchmark": "2343"
+    },
+    {
+        "Graphics": "Ryzen 7 5700G with Radeon Graphics",
+        "Benchmark": "2770"
+    },
+    {
+        "Graphics": "Ryzen 7 5700GE with Radeon Graphics",
+        "Benchmark": "2762"
+    },
+    {
+        "Graphics": "Ryzen 7 5700U with Radeon Graphics",
+        "Benchmark": "2241"
+    },
+    {
+        "Graphics": "Ryzen 7 5800H with Radeon Graphics",
+        "Benchmark": "2736"
+    },
+    {
+        "Graphics": "Ryzen 7 5800HS with Radeon Graphics",
+        "Benchmark": "2795"
+    },
+    {
+        "Graphics": "Ryzen 7 5800U with Radeon Graphics",
+        "Benchmark": "2310"
+    },
+    {
+        "Graphics": "Ryzen 7 5825U with Radeon Graphics",
+        "Benchmark": "2351"
+    },
+    {
+        "Graphics": "Ryzen 7 6800H",
+        "Benchmark": "5247"
+    },
+    {
+        "Graphics": "Ryzen 7 6800H with Radeon Graphics",
+        "Benchmark": "4959"
+    },
+    {
+        "Graphics": "Ryzen 7 6800HS",
+        "Benchmark": "5237"
+    },
+    {
+        "Graphics": "Ryzen 7 6800HS Creator Edition",
+        "Benchmark": "5465"
+    },
+    {
+        "Graphics": "Ryzen 7 6800HS with Radeon Graphics",
+        "Benchmark": "6240"
+    },
+    {
+        "Graphics": "Ryzen 7 6800U",
+        "Benchmark": "5006"
+    },
+    {
+        "Graphics": "Ryzen 7 6800U with Radeon Graphics",
+        "Benchmark": "4760"
+    },
+    {
+        "Graphics": "Ryzen 7 7730U with Radeon Graphics",
+        "Benchmark": "2433"
+    },
+    {
+        "Graphics": "Ryzen 7 7735HS with Radeon Graphics",
+        "Benchmark": "5175"
+    },
+    {
+        "Graphics": "Ryzen 7 7735U with Radeon Graphics",
+        "Benchmark": "5081"
+    },
+    {
+        "Graphics": "Ryzen 7 9700X 8-Core Processor",
+        "Benchmark": "2250"
+    },
+    {
+        "Graphics": "Ryzen 7 9800X3D 8-Core Processor",
+        "Benchmark": "1830"
+    },
+    {
+        "Graphics": "Ryzen 7 Extreme Edition",
+        "Benchmark": "2151"
+    },
+    {
+        "Graphics": "Ryzen 7 Pro 4750G with Radeon Graphics",
+        "Benchmark": "2681"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 4750GE with Radeon Graphics",
+        "Benchmark": "2549"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 4750U with Radeon Graphics",
+        "Benchmark": "2029"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 5750G with Radeon Graphics",
+        "Benchmark": "2367"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 5750GE with Radeon Graphics",
+        "Benchmark": "2476"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 5850U with Radeon Graphics",
+        "Benchmark": "2338"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 5875U with Radeon Graphics",
+        "Benchmark": "2067"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 6850H with Radeon Graphics",
+        "Benchmark": "5790"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 6850HS with Radeon Graphics",
+        "Benchmark": "4087"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 6850U",
+        "Benchmark": "5580"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 6850U with Radeon Graphics",
+        "Benchmark": "5116"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 6860Z",
+        "Benchmark": "5076"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 6860Z with Radeon Graphics",
+        "Benchmark": "4869"
+    },
+    {
+        "Graphics": "Ryzen 7 PRO 7730U with Radeon Graphics",
+        "Benchmark": "2566"
+    },
+    {
+        "Graphics": "Ryzen 7 Pro 7735U with Radeon Graphics",
+        "Benchmark": "5142"
+    },
+    {
+        "Graphics": "Ryzen 9 4900HS with Radeon Graphics",
+        "Benchmark": "7022"
+    },
+    {
+        "Graphics": "Ryzen 9 5900HS with Radeon Graphics",
+        "Benchmark": "5479"
+    },
+    {
+        "Graphics": "Ryzen 9 5900HX with Radeon Graphics",
+        "Benchmark": "2935"
+    },
+    {
+        "Graphics": "Ryzen 9 6900HS",
+        "Benchmark": "8005"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Ryzen 9 6900HS with Radeon Graphics",
+        "Benchmark": "6109"
+    },
+    {
+        "Graphics": "Ryzen 9 6900HX with Radeon Graphics",
+        "Benchmark": "5174"
+    },
+    {
+        "Graphics": "Ryzen 9 9900X 12-Core Processor",
+        "Benchmark": "1729"
+    },
+    {
+        "Graphics": "Ryzen 9 9950X 16-Core Processor",
+        "Benchmark": "1770"
+    },
+    {
+        "Graphics": "Ryzen 9 PRO 6950H",
+        "Benchmark": "5758"
+    },
+    {
+        "Graphics": "Ryzen 9 PRO 6950H with Radeon Graphics",
+        "Benchmark": "6176"
+    },
+    {
+        "Graphics": "Ryzen 9 PRO 6950HS with Radeon Graphics",
+        "Benchmark": "4704"
+    },
+    {
+        "Graphics": "S3 5400EW",
+        "Benchmark": "146"
+    },
+    {
+        "Graphics": "S3 Chrome 430 ULP",
+        "Benchmark": "39"
+    },
+    {
+        "Graphics": "S3 Chrome S25 DDR2",
+        "Benchmark": "18"
+    },
+    {
+        "Graphics": "S3 Chrome S27 DDR3",
+        "Benchmark": "33"
+    },
+    {
+        "Graphics": "S3 Inc. Savage4",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "S3 ProSavageDDR",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "S3 SuperSavage/IXC 1014",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "SAPPHIRE RADEON 9000 ATLANTIS PRO",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "SAPPHIRE RADEON 9600 ATLANTIS",
+        "Benchmark": "47"
+    },
+    {
+        "Graphics": "Sapphire RADEON X800 GT",
+        "Benchmark": "112"
+    },
+    {
+        "Graphics": "SAPPHIRE Radeon X1550",
+        "Benchmark": "61"
+    },
+    {
+        "Graphics": "Seria Mobility Radeon HD 3400",
+        "Benchmark": "124"
+    },
+    {
+        "Graphics": "Seria Radeon HD 7700",
+        "Benchmark": "1603"
+    },
+    {
+        "Graphics": "Snapdragon X Elite - X1E001DE - Qualcomm Adreno GP",
+        "Benchmark": "3245"
+    },
+    {
+        "Graphics": "Snapdragon X Elite - X1E78100 - Qualcomm Adreno GP",
+        "Benchmark": "2565"
+    },
+    {
+        "Graphics": "Snapdragon X Elite - X1E80100 - Qualcomm Adreno GP",
+        "Benchmark": "2613"
+    },
+    {
+        "Graphics": "Snapdragon X Elite - X1E84100 - Qualcomm Adreno GP",
+        "Benchmark": "2981"
+    },
+    {
+        "Graphics": "Snapdragon X Plus - X1P64100 - Qualcomm Adreno GPU",
+        "Benchmark": "2601"
+    },
+    {
+        "Graphics": "SUMO 964A",
+        "Benchmark": "497"
+    },
+    {
+        "Graphics": "SUMO 9640",
+        "Benchmark": "650"
+    },
+    {
+        "Graphics": "SUMO 9644",
+        "Benchmark": "465"
+    },
+    {
+        "Graphics": "SuperDisplay Virtual Adapter",
+        "Benchmark": "10390"
+    },
+    {
+        "Graphics": "Surface Duo Adreno 640 GPU",
+        "Benchmark": "592"
+    },
+    {
+        "Graphics": "T400",
+        "Benchmark": "3601"
+    },
+    {
+        "Graphics": "T400 4GB",
+        "Benchmark": "3802"
+    },
+    {
+        "Graphics": "T500",
+        "Benchmark": "3645"
+    },
+    {
+        "Graphics": "T550 Laptop GPU",
+        "Benchmark": "4780"
+    },
+    {
+        "Graphics": "T600",
+        "Benchmark": "6476"
+    },
+    {
+        "Graphics": "T600 Laptop GPU",
+        "Benchmark": "7082"
+    },
+    {
+        "Graphics": "T1000",
+        "Benchmark": "7623"
+    },
+    {
+        "Graphics": "T1000 8GB",
+        "Benchmark": "7644"
+    },
+    {
+        "Graphics": "T1200 Laptop GPU",
+        "Benchmark": "7773"
+    },
+    {
+        "Graphics": "TENSOR 1.0 Driver Intel HD 630",
+        "Benchmark": "1299"
+    },
+    {
+        "Graphics": "Tesla C2050",
+        "Benchmark": "3175"
+    },
+    {
+        "Graphics": "Tesla C2050 / C2070",
+        "Benchmark": "3428"
+    },
+    {
+        "Graphics": "Tesla C2070",
+        "Benchmark": "3120"
+    },
+    {
+        "Graphics": "Tesla C2075",
+        "Benchmark": "3016"
+    },
+    {
+        "Graphics": "Tesla K20m",
+        "Benchmark": "4432"
+    },
+    {
+        "Graphics": "Tesla K20Xm",
+        "Benchmark": "4403"
+    },
+    {
+        "Graphics": "Tesla K40c",
+        "Benchmark": "4494"
+    },
+    {
+        "Graphics": "Tesla K40m",
+        "Benchmark": "3143"
+    },
+    {
+        "Graphics": "Tesla K80",
+        "Benchmark": "4680"
+    },
+    {
+        "Graphics": "Videocard Name",
+        "Benchmark": "Passmark G3D Mark"
+    },
+    {
+        "Graphics": "",
+        "Benchmark": "(higher is better)"
+    },
+    {
+        "Graphics": "Tesla M6",
+        "Benchmark": "6226"
+    },
+    {
+        "Graphics": "Tesla M10",
+        "Benchmark": "3045"
+    },
+    {
+        "Graphics": "Tesla M40",
+        "Benchmark": "10219"
+    },
+    {
+        "Graphics": "Tesla M40 24GB",
+        "Benchmark": "10641"
+    },
+    {
+        "Graphics": "Tesla M60",
+        "Benchmark": "7651"
+    },
+    {
+        "Graphics": "Tesla M2070-Q",
+        "Benchmark": "1305"
+    },
+    {
+        "Graphics": "Tesla P4",
+        "Benchmark": "9097"
+    },
+    {
+        "Graphics": "Tesla P40",
+        "Benchmark": "12266"
+    },
+    {
+        "Graphics": "Tesla P100-PCIE-16GB",
+        "Benchmark": "11813"
+    },
+    {
+        "Graphics": "Tesla T4",
+        "Benchmark": "10647"
+    },
+    {
+        "Graphics": "Tesla T10",
+        "Benchmark": "12557"
+    },
+    {
+        "Graphics": "Tesla V100-PCIE-16GB",
+        "Benchmark": "12328"
+    },
+    {
+        "Graphics": "TITAN RTX",
+        "Benchmark": "20331"
+    },
+    {
+        "Graphics": "TITAN V",
+        "Benchmark": "19738"
+    },
+    {
+        "Graphics": "TITAN V CEO Edition",
+        "Benchmark": "16987"
+    },
+    {
+        "Graphics": "TITAN Xp COLLECTORS EDITION",
+        "Benchmark": "18775"
+    },
+    {
+        "Graphics": "TRINITY DEVASTATOR MOBILE",
+        "Benchmark": "578"
+    },
+    {
+        "Graphics": "TRINITY SCRAPPER MOBILE",
+        "Benchmark": "498"
+    },
+    {
+        "Graphics": "V9560XT",
+        "Benchmark": "6"
+    },
+    {
+        "Graphics": "Vanta/Vanta LT",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC3 IGP",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC IGP",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC IGP Family",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC IGP Family WDDM",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC IGP Prerelease WDDM 1.1",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC IGP WDDM",
+        "Benchmark": "2"
+    },
+    {
+        "Graphics": "VIA Chrome9 HC IGP WDDM 1.1",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "VIA Chrome9 HCM IGP",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "VIA Chrome9 HD IGP",
+        "Benchmark": "9"
+    },
+    {
+        "Graphics": "VIA/S3G C-645/640 GPU",
+        "Benchmark": "132"
+    },
+    {
+        "Graphics": "VIA/S3G Chrome 645/640 GPU",
+        "Benchmark": "109"
+    },
+    {
+        "Graphics": "VIA/S3G DeltaChrome IGP",
+        "Benchmark": "3"
+    },
+    {
+        "Graphics": "VIA/S3G KM400/KN400",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "VIA/S3G UniChrome IGP",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "VIA/S3G UniChrome Pro IGP",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "VIA/S3G UniChromeII",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "Virtual Display Device",
+        "Benchmark": "1661"
+    },
+    {
+        "Graphics": "VirtualMonitor Device",
+        "Benchmark": "2130"
+    },
+    {
+        "Graphics": "VisionTek Radeon 7000",
+        "Benchmark": "1"
+    },
+    {
+        "Graphics": "VMware Horizon Indirect Display Driver",
+        "Benchmark": "3565"
+    },
+    {
+        "Graphics": "WinFast A250 LE",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "Xabre",
+        "Benchmark": "5"
+    },
+    {
+        "Graphics": "XGI Volari Family v1.13.23.D_V",
+        "Benchmark": "4"
+    },
+    {
+        "Graphics": "ZX C-1080",
+        "Benchmark": "315"
+    },
+    {
+        "Graphics": "ZX C-1190",
+        "Benchmark": "416"
+    },
+    {
+        "Graphics": "ZX Chrome 645/640 GPU",
+        "Benchmark": "147"
+    }
+]

--- a/src/renderer/src/pages/game-details/sidebar/sidebar.scss
+++ b/src/renderer/src/pages/game-details/sidebar/sidebar.scss
@@ -24,11 +24,44 @@
   }
 
   &__button {
-    border: solid 1px globals.$border-color;
-    border-left: none;
-    border-right: none;
+    flex: 1;
+    border: 1px solid globals.$border-color;
     border-radius: 0;
-    width: 100%;
+    background-color: globals.$background-color;
+    color: globals.$body-color;
+    font-weight: bold;
+    font-size: globals.$body-font-size;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: calc(globals.$spacing-unit * 2);
+
+    &:first-child {
+      border-right: none;
+    }
+    &:last-child {
+      border-left: none;
+    }
+
+    transition: background-color 0.2s ease, color 0.2s ease;
+    outline: none;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.15);;
+    }
+    &:active {
+      opacity: globals.$active-opacity;
+    }
+
+    &[aria-pressed="true"] {
+      background-color: globals.$muted-color;
+      color: globals.$dark-background-color;
+      border-color: globals.$muted-color;
+
+      &:hover {
+        background-color: globals.$muted-color;
+      }
+    }
   }
 
   &__details {
@@ -193,4 +226,21 @@
 
 .achievements-placeholder__blur {
   filter: blur(4px);
+}
+
+.system-subtitle {
+  margin: 0.5rem 0 0.25rem;
+  padding-left: calc(globals.$spacing-unit * 2);
+  font-size: globals.$body-font-size;
+  font-weight: bold;
+  color: globals.$body-color;
+}
+
+.system-info {
+  list-style: none;
+  margin-top: 0.75rem;
+}
+
+.system-info li {
+  margin-bottom: 0.25rem;
 }

--- a/src/renderer/src/pages/game-details/sidebar/sidebar.tsx
+++ b/src/renderer/src/pages/game-details/sidebar/sidebar.tsx
@@ -1,12 +1,10 @@
 import { useContext, useEffect, useState } from "react";
 import type {
   HowLongToBeatCategory,
-  SteamAppDetails,
   UserAchievement,
 } from "@types";
 import { useTranslation } from "react-i18next";
-import { Button, Link } from "@renderer/components";
-
+import { Link } from "@renderer/components";
 import { gameDetailsContext } from "@renderer/context";
 import { useDate, useFormat, useUserDetails } from "@renderer/hooks";
 import {
@@ -20,6 +18,7 @@ import { howLongToBeatEntriesTable } from "@renderer/dexie";
 import { SidebarSection } from "../sidebar-section/sidebar-section";
 import { buildGameAchievementPath } from "@renderer/helpers";
 import { useSubscription } from "@renderer/hooks/use-subscription";
+import { CanYouRunItSection } from "./can-you-run-it-section";
 import "./sidebar.scss";
 
 const achievementsPlaceholder: UserAchievement[] = [
@@ -62,20 +61,17 @@ export function Sidebar() {
     data: HowLongToBeatCategory[] | null;
   }>({ isLoading: true, data: null });
 
-  const { userDetails, hasActiveSubscription } = useUserDetails();
-  const [activeRequirement, setActiveRequirement] =
-    useState<keyof SteamAppDetails["pc_requirements"]>("minimum");
-
-  const { gameTitle, shopDetails, objectId, shop, stats, achievements } =
-    useContext(gameDetailsContext);
-
-  const { showHydraCloudModal } = useSubscription();
   const { t } = useTranslation("game_details");
   const { formatDateTime } = useDate();
   const { numberFormatter } = useFormat();
 
+  const { userDetails, hasActiveSubscription } = useUserDetails();
+  const { gameTitle, objectId, shop, stats, achievements } =
+    useContext(gameDetailsContext);
+  const { showHydraCloudModal } = useSubscription();
+
   useEffect(() => {
-    if (objectId) {
+    if (!objectId) return;
       setHowLongToBeat({ isLoading: true, data: null });
 
       howLongToBeatEntriesTable
@@ -111,7 +107,7 @@ export function Sidebar() {
           }
         });
     }
-  }, [objectId, shop, gameTitle]);
+  , [objectId, shop]);
 
   return (
     <aside className="content-sidebar">
@@ -168,7 +164,7 @@ export function Sidebar() {
               <li key={achievement.displayName}>
                 <Link
                   to={buildGameAchievementPath({
-                    shop: shop,
+                    shop,
                     objectId: objectId!,
                     title: gameTitle,
                   })}
@@ -233,36 +229,7 @@ export function Sidebar() {
         isLoading={howLongToBeat.isLoading}
       />
 
-      <SidebarSection title={t("requirements")}>
-        <div className="requirement__button-container">
-          <Button
-            className="requirement__button"
-            onClick={() => setActiveRequirement("minimum")}
-            theme={activeRequirement === "minimum" ? "primary" : "outline"}
-          >
-            {t("minimum")}
-          </Button>
-
-          <Button
-            className="requirement__button"
-            onClick={() => setActiveRequirement("recommended")}
-            theme={activeRequirement === "recommended" ? "primary" : "outline"}
-          >
-            {t("recommended")}
-          </Button>
-        </div>
-
-        <div
-          className="requirement__details"
-          dangerouslySetInnerHTML={{
-            __html:
-              shopDetails?.pc_requirements?.[activeRequirement] ??
-              t(`no_${activeRequirement}_requirements`, {
-                gameTitle,
-              }),
-          }}
-        />
-      </SidebarSection>
+      <CanYouRunItSection />
     </aside>
   );
 }


### PR DESCRIPTION
Related to the issue: https://github.com/hydralauncher/hydra/issues/1541

This PR introduces the new “Can You Run It” section into the game details sidebar, enabling automatic compatibility checks (OS, CPU, GPU, RAM) against the game’s minimum and recommended requirements fetched from Steam.

Before:
![image](https://github.com/user-attachments/assets/25423762-9ea0-4e81-bf23-650c3f9daba7)

After:
![image](https://github.com/user-attachments/assets/b2fd2101-1a2a-4baa-b236-7831358b431f)

If the user’s software/hardware meets or exceeds the recommended requirements, a green dot will appear.

If the user’s software/hardware meets or exceeds the minimum requirements (but is below recommended), a yellow dot will appear.

If the user’s software/hardware falls below the minimum requirements, a red dot will appear.

Two new files containing thousands of benchmark entries for CPUs and GPUs were added, sourced from [CPUBenchmark](https://www.cpubenchmark.net/). These JSON files allow lookup of performance scores when comparing the user’s hardware against Steam’s stated requirements.

User system information is detected via window.electron.getSystemInfo(). An English-language request is made so that the minimum/recommended requirements can be correctly processed by various regular expressions, which simplify the software/hardware strings for display to the user and for lookup in the CPU and GPU JSON files.

This feature was tested on two computers with different operating systems and worked correctly on both. It is recommended to test on additional machines to cover other regex edge cases.