### PR TITLE
Fix: Playtime font size and original path in edit game modal fix

### DIFF
--- a/src/main/events/library/update-custom-game.ts
+++ b/src/main/events/library/update-custom-game.ts
@@ -11,7 +11,10 @@ const updateCustomGame = async (
   title: string,
   iconUrl?: string,
   logoImageUrl?: string,
-  libraryHeroImageUrl?: string
+  libraryHeroImageUrl?: string,
+  originalIconPath?: string,
+  originalLogoPath?: string,
+  originalHeroPath?: string
 ) => {
   const gameKey = levelKeys.game(shop, objectId);
 
@@ -40,6 +43,9 @@ const updateCustomGame = async (
     iconUrl: iconUrl || null,
     logoImageUrl: logoImageUrl || null,
     libraryHeroImageUrl: libraryHeroImageUrl || null,
+    originalIconPath: originalIconPath || existingGame.originalIconPath || null,
+    originalLogoPath: originalLogoPath || existingGame.originalLogoPath || null,
+    originalHeroPath: originalHeroPath || existingGame.originalHeroPath || null,
   };
 
   await gamesSublevel.put(gameKey, updatedGame);

--- a/src/main/events/library/update-game-custom-assets.ts
+++ b/src/main/events/library/update-game-custom-assets.ts
@@ -38,7 +38,10 @@ const updateGameData = async (
   title: string,
   customIconUrl?: string | null,
   customLogoImageUrl?: string | null,
-  customHeroImageUrl?: string | null
+  customHeroImageUrl?: string | null,
+  customOriginalIconPath?: string | null,
+  customOriginalLogoPath?: string | null,
+  customOriginalHeroPath?: string | null
 ): Promise<Game> => {
   const updatedGame = {
     ...existingGame,
@@ -46,6 +49,9 @@ const updateGameData = async (
     ...(customIconUrl !== undefined && { customIconUrl }),
     ...(customLogoImageUrl !== undefined && { customLogoImageUrl }),
     ...(customHeroImageUrl !== undefined && { customHeroImageUrl }),
+    ...(customOriginalIconPath !== undefined && { customOriginalIconPath }),
+    ...(customOriginalLogoPath !== undefined && { customOriginalLogoPath }),
+    ...(customOriginalHeroPath !== undefined && { customOriginalHeroPath }),
   };
 
   await gamesSublevel.put(gameKey, updatedGame);
@@ -87,7 +93,10 @@ const updateGameCustomAssets = async (
   title: string,
   customIconUrl?: string | null,
   customLogoImageUrl?: string | null,
-  customHeroImageUrl?: string | null
+  customHeroImageUrl?: string | null,
+  customOriginalIconPath?: string | null,
+  customOriginalLogoPath?: string | null,
+  customOriginalHeroPath?: string | null
 ) => {
   const gameKey = levelKeys.game(shop, objectId);
 
@@ -109,7 +118,10 @@ const updateGameCustomAssets = async (
     title,
     customIconUrl,
     customLogoImageUrl,
-    customHeroImageUrl
+    customHeroImageUrl,
+    customOriginalIconPath,
+    customOriginalLogoPath,
+    customOriginalHeroPath
   );
 
   await updateShopAssets(gameKey, title);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -158,7 +158,10 @@ contextBridge.exposeInMainWorld("electron", {
     title: string,
     iconUrl?: string,
     logoImageUrl?: string,
-    libraryHeroImageUrl?: string
+    libraryHeroImageUrl?: string,
+    originalIconPath?: string,
+    originalLogoPath?: string,
+    originalHeroPath?: string
   ) =>
     ipcRenderer.invoke(
       "updateCustomGame",
@@ -167,7 +170,10 @@ contextBridge.exposeInMainWorld("electron", {
       title,
       iconUrl,
       logoImageUrl,
-      libraryHeroImageUrl
+      libraryHeroImageUrl,
+      originalIconPath,
+      originalLogoPath,
+      originalHeroPath
     ),
   updateGameCustomAssets: (
     shop: GameShop,
@@ -175,7 +181,10 @@ contextBridge.exposeInMainWorld("electron", {
     title: string,
     customIconUrl?: string | null,
     customLogoImageUrl?: string | null,
-    customHeroImageUrl?: string | null
+    customHeroImageUrl?: string | null,
+    customOriginalIconPath?: string | null,
+    customOriginalLogoPath?: string | null,
+    customOriginalHeroPath?: string | null
   ) =>
     ipcRenderer.invoke(
       "updateGameCustomAssets",
@@ -184,7 +193,10 @@ contextBridge.exposeInMainWorld("electron", {
       title,
       customIconUrl,
       customLogoImageUrl,
-      customHeroImageUrl
+      customHeroImageUrl,
+      customOriginalIconPath,
+      customOriginalLogoPath,
+      customOriginalHeroPath
     ),
   createGameShortcut: (
     shop: GameShop,

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -125,7 +125,10 @@ declare global {
       title: string,
       iconUrl?: string,
       logoImageUrl?: string,
-      libraryHeroImageUrl?: string
+      libraryHeroImageUrl?: string,
+      originalIconPath?: string,
+      originalLogoPath?: string,
+      originalHeroPath?: string
     ) => Promise<Game>;
     copyCustomGameAsset: (
       sourcePath: string,
@@ -141,7 +144,10 @@ declare global {
       title: string,
       customIconUrl?: string | null,
       customLogoImageUrl?: string | null,
-      customHeroImageUrl?: string | null
+      customHeroImageUrl?: string | null,
+      customOriginalIconPath?: string | null,
+      customOriginalLogoPath?: string | null,
+      customOriginalHeroPath?: string | null
     ) => Promise<Game>;
     createGameShortcut: (
       shop: GameShop,

--- a/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
@@ -84,7 +84,10 @@ export function EditGameModal({
       setDefaultUrls({
         icon: shopDetails?.assets?.iconUrl || game.iconUrl || null,
         logo: shopDetails?.assets?.logoImageUrl || game.logoImageUrl || null,
-        hero: shopDetails?.assets?.libraryHeroImageUrl || game.libraryHeroImageUrl || null,
+        hero:
+          shopDetails?.assets?.libraryHeroImageUrl ||
+          game.libraryHeroImageUrl ||
+          null,
       });
     },
     [shopDetails]
@@ -119,11 +122,11 @@ export function EditGameModal({
   };
 
   const setAssetPath = (assetType: AssetType, path: string): void => {
-    setAssetPaths(prev => ({ ...prev, [assetType]: path }));
+    setAssetPaths((prev) => ({ ...prev, [assetType]: path }));
   };
 
   const setAssetDisplayPath = (assetType: AssetType, path: string): void => {
-    setAssetDisplayPaths(prev => ({ ...prev, [assetType]: path }));
+    setAssetDisplayPaths((prev) => ({ ...prev, [assetType]: path }));
   };
 
   const getDefaultUrl = (assetType: AssetType): string | null => {
@@ -293,7 +296,9 @@ export function EditGameModal({
   // Helper function to prepare custom game assets
   const prepareCustomGameAssets = (game: LibraryGame | Game) => {
     const iconUrl = assetPaths.icon ? `local:${assetPaths.icon}` : game.iconUrl;
-    const logoImageUrl = assetPaths.logo ? `local:${assetPaths.logo}` : game.logoImageUrl;
+    const logoImageUrl = assetPaths.logo
+      ? `local:${assetPaths.logo}`
+      : game.logoImageUrl;
     const libraryHeroImageUrl = assetPaths.hero
       ? `local:${assetPaths.hero}`
       : game.libraryHeroImageUrl;

--- a/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
@@ -39,6 +39,11 @@ export function EditGameModal({
     logo: "",
     hero: "",
   });
+  const [originalAssetPaths, setOriginalAssetPaths] = useState({
+    icon: "",
+    logo: "",
+    hero: "",
+  });
   const [defaultUrls, setDefaultUrls] = useState({
     icon: null as string | null,
     logo: null as string | null,
@@ -66,6 +71,11 @@ export function EditGameModal({
       logo: extractLocalPath(game.logoImageUrl),
       hero: extractLocalPath(game.libraryHeroImageUrl),
     });
+    setOriginalAssetPaths({
+      icon: (game as any).originalIconPath || extractLocalPath(game.iconUrl),
+      logo: (game as any).originalLogoPath || extractLocalPath(game.logoImageUrl),
+      hero: (game as any).originalHeroPath || extractLocalPath(game.libraryHeroImageUrl),
+    });
   }, []);
 
   const setNonCustomGameAssets = useCallback(
@@ -79,6 +89,11 @@ export function EditGameModal({
         icon: extractLocalPath(game.customIconUrl),
         logo: extractLocalPath(game.customLogoImageUrl),
         hero: extractLocalPath(game.customHeroImageUrl),
+      });
+      setOriginalAssetPaths({
+        icon: (game as any).customOriginalIconPath || extractLocalPath(game.customIconUrl),
+        logo: (game as any).customOriginalLogoPath || extractLocalPath(game.customLogoImageUrl),
+        hero: (game as any).customOriginalHeroPath || extractLocalPath(game.customHeroImageUrl),
       });
 
       setDefaultUrls({
@@ -118,7 +133,8 @@ export function EditGameModal({
   };
 
   const getAssetDisplayPath = (assetType: AssetType): string => {
-    return assetDisplayPaths[assetType];
+    // Use original path if available, otherwise fall back to display path
+    return originalAssetPaths[assetType] || assetDisplayPaths[assetType];
   };
 
   const setAssetPath = (assetType: AssetType, path: string): void => {
@@ -153,10 +169,13 @@ export function EditGameModal({
         );
         setAssetPath(assetType, copiedAssetUrl.replace("local:", ""));
         setAssetDisplayPath(assetType, originalPath);
+        // Store the original path for display purposes
+        setOriginalAssetPaths((prev) => ({ ...prev, [assetType]: originalPath }));
       } catch (error) {
         console.error(`Failed to copy ${assetType} asset:`, error);
         setAssetPath(assetType, originalPath);
         setAssetDisplayPath(assetType, originalPath);
+        setOriginalAssetPaths((prev) => ({ ...prev, [assetType]: originalPath }));
       }
     }
   };
@@ -164,6 +183,7 @@ export function EditGameModal({
   const handleRestoreDefault = (assetType: AssetType) => {
     setAssetPath(assetType, "");
     setAssetDisplayPath(assetType, "");
+    setOriginalAssetPaths((prev) => ({ ...prev, [assetType]: "" }));
   };
 
   const getOriginalTitle = (): string => {
@@ -326,7 +346,10 @@ export function EditGameModal({
       gameName.trim(),
       iconUrl || undefined,
       logoImageUrl || undefined,
-      libraryHeroImageUrl || undefined
+      libraryHeroImageUrl || undefined,
+      originalAssetPaths.icon || undefined,
+      originalAssetPaths.logo || undefined,
+      originalAssetPaths.hero || undefined
     );
   };
 
@@ -341,7 +364,10 @@ export function EditGameModal({
       gameName.trim(),
       customIconUrl,
       customLogoImageUrl,
-      customHeroImageUrl
+      customHeroImageUrl,
+      originalAssetPaths.icon || undefined,
+      originalAssetPaths.logo || undefined,
+      originalAssetPaths.hero || undefined
     );
   };
 

--- a/src/renderer/src/pages/profile/profile-content/user-library-game-card.scss
+++ b/src/renderer/src/pages/profile/profile-content/user-library-game-card.scss
@@ -164,10 +164,12 @@
 
     &-long {
       display: inline;
+      font-size: 12px;
     }
 
     &-short {
       display: none;
+      font-size: 12px;
     }
 
     // When the card is narrow (less than 180px), show short format

--- a/src/renderer/src/pages/profile/profile-content/user-library-game-card.tsx
+++ b/src/renderer/src/pages/profile/profile-content/user-library-game-card.tsx
@@ -44,7 +44,6 @@ export function UserLibraryGameCard({
   const [isTooltipHovered, setIsTooltipHovered] = useState(false);
   const [isPinning, setIsPinning] = useState(false);
 
-
   const getStatsItemCount = useCallback(() => {
     let statsCount = 1;
     if (game.achievementsPointsEarnedSum > 0) statsCount++;
@@ -91,14 +90,14 @@ export function UserLibraryGameCard({
 
       const hours = minutes / 60;
       const hoursKey = isShort ? "amount_hours_short" : "amount_hours";
-      const hoursAmount = isShort ? Math.floor(hours) : numberFormatter.format(hours);
-      
+      const hoursAmount = isShort
+        ? Math.floor(hours)
+        : numberFormatter.format(hours);
+
       return t(hoursKey, { amount: hoursAmount });
     },
     [numberFormatter, t]
   );
-
-
 
   const toggleGamePinned = async () => {
     setIsPinning(true);
@@ -162,7 +161,7 @@ export function UserLibraryGameCard({
                 )}
               </div>
             )}
-            <div 
+            <div
               className="user-library-game__playtime"
               data-tooltip-place="top"
               data-tooltip-content={

--- a/src/types/level.types.ts
+++ b/src/types/level.types.ts
@@ -38,6 +38,12 @@ export interface Game {
   customIconUrl?: string | null;
   customLogoImageUrl?: string | null;
   customHeroImageUrl?: string | null;
+  originalIconPath?: string | null;
+  originalLogoPath?: string | null;
+  originalHeroPath?: string | null;
+  customOriginalIconPath?: string | null;
+  customOriginalLogoPath?: string | null;
+  customOriginalHeroPath?: string | null;
   playTimeInMilliseconds: number;
   unsyncedDeltaPlayTimeInMilliseconds?: number;
   lastTimePlayed: Date | null;


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read and understood the [Contributor Guidelines](https://github.com/hydralauncher/hydra?tab=readme-ov-file#ways-you-can-contribute).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

- Fixed playtime font-size to be 12px
- Fixed thing when after updating game asset it was showing temp path instead of original
