### PR TITLE
feat: added ability to reset assets for custom game

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -70,7 +70,13 @@
     "edit_game_modal_icon_resolution": "Recommended resolution: 256x256px",
     "edit_game_modal_logo_resolution": "Recommended resolution: 640x360px",
     "edit_game_modal_hero_resolution": "Recommended resolution: 1920x620px",
-    "edit_game_modal_assets": "Assets"
+    "edit_game_modal_assets": "Assets",
+    "edit_game_modal_drop_icon_image_here": "Drop icon image here",
+    "edit_game_modal_drop_logo_image_here": "Drop logo image here",
+    "edit_game_modal_drop_hero_image_here": "Drop hero image here",
+    "edit_game_modal_drop_to_replace_icon": "Drop to replace icon",
+    "edit_game_modal_drop_to_replace_logo": "Drop to replace logo",
+    "edit_game_modal_drop_to_replace_hero": "Drop to replace hero"
   },
   "header": {
     "search": "Search games",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -67,7 +67,14 @@
     "edit_game_modal_image_filter": "Изображение",
     "edit_game_modal_icon_resolution": "Рекомендуемое разрешение: 256x256px",
     "edit_game_modal_logo_resolution": "Рекомендуемое разрешение: 640x360px",
-    "edit_game_modal_hero_resolution": "Рекомендуемое разрешение: 1920x620px"
+    "edit_game_modal_hero_resolution": "Рекомендуемое разрешение: 1920x620px",
+    "edit_game_modal_assets": "Ресурсы",
+    "edit_game_modal_drop_icon_image_here": "Перетащите изображение иконки сюда",
+    "edit_game_modal_drop_logo_image_here": "Перетащите изображение логотипа сюда",
+    "edit_game_modal_drop_hero_image_here": "Перетащите изображение обложки сюда",
+    "edit_game_modal_drop_to_replace_icon": "Перетащите для замены иконки",
+    "edit_game_modal_drop_to_replace_logo": "Перетащите для замены логотипа",
+    "edit_game_modal_drop_to_replace_hero": "Перетащите для замены обложки"
   },
   "header": {
     "search": "Поиск",

--- a/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
@@ -166,7 +166,7 @@ export function EditGameModal({
 
   const getOriginalAssetUrl = (assetType: AssetType): string | null => {
     if (!game || !isCustomGame(game)) return null;
-    
+
     switch (assetType) {
       case "icon":
         return game.iconUrl;
@@ -365,17 +365,36 @@ export function EditGameModal({
   // Helper function to prepare custom game assets
   const prepareCustomGameAssets = (game: LibraryGame | Game) => {
     // For custom games, check if asset was explicitly removed
-    const iconUrl = removedAssets.icon ? null : (assetPaths.icon ? `local:${assetPaths.icon}` : game.iconUrl);
-    const logoImageUrl = removedAssets.logo ? null : (assetPaths.logo ? `local:${assetPaths.logo}` : game.logoImageUrl);
-    
+    let iconUrl;
+    if (removedAssets.icon) {
+      iconUrl = null;
+    } else if (assetPaths.icon) {
+      iconUrl = `local:${assetPaths.icon}`;
+    } else {
+      iconUrl = game.iconUrl;
+    }
+
+    let logoImageUrl;
+    if (removedAssets.logo) {
+      logoImageUrl = null;
+    } else if (assetPaths.logo) {
+      logoImageUrl = `local:${assetPaths.logo}`;
+    } else {
+      logoImageUrl = game.logoImageUrl;
+    }
+
     // For hero image, if removed, restore to the original gradient or keep the original
     let libraryHeroImageUrl;
     if (removedAssets.hero) {
       // If the original hero was a gradient (data URL), keep it, otherwise generate a new one
       const originalHero = game.libraryHeroImageUrl;
-      libraryHeroImageUrl = originalHero?.startsWith('data:image/svg+xml') ? originalHero : generateRandomGradient();
+      libraryHeroImageUrl = originalHero?.startsWith("data:image/svg+xml")
+        ? originalHero
+        : generateRandomGradient();
     } else {
-      libraryHeroImageUrl = assetPaths.hero ? `local:${assetPaths.hero}` : game.libraryHeroImageUrl;
+      libraryHeroImageUrl = assetPaths.hero
+        ? `local:${assetPaths.hero}`
+        : game.libraryHeroImageUrl;
     }
 
     return { iconUrl, logoImageUrl, libraryHeroImageUrl };
@@ -528,17 +547,19 @@ export function EditGameModal({
                 <ImageIcon />
                 {t("edit_game_modal_browse")}
               </Button>
-              {game && (assetPath || (isCustomGame(game) && getOriginalAssetUrl(assetType))) && (
-                <Button
-                  type="button"
-                  theme="outline"
-                  onClick={() => handleRestoreDefault(assetType)}
-                  disabled={isUpdating}
-                  title={`Remove ${assetType}`}
-                >
-                  <XIcon />
-                </Button>
-              )}
+              {game &&
+                (assetPath ||
+                  (isCustomGame(game) && getOriginalAssetUrl(assetType))) && (
+                  <Button
+                    type="button"
+                    theme="outline"
+                    onClick={() => handleRestoreDefault(assetType)}
+                    disabled={isUpdating}
+                    title={`Remove ${assetType}`}
+                  >
+                    <XIcon />
+                  </Button>
+                )}
             </div>
           }
         />

--- a/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/edit-game-modal.tsx
@@ -587,7 +587,7 @@ export function EditGameModal({
             />
             {isDragOver && (
               <div className="edit-game-modal__drop-overlay">
-                <span>Drop to replace {assetType}</span>
+                <span>{t(`edit_game_modal_drop_to_replace_${assetType}`)}</span>
               </div>
             )}
           </button>
@@ -610,7 +610,7 @@ export function EditGameModal({
           >
             <div className="edit-game-modal__drop-zone-content">
               <ImageIcon />
-              <span>Drop {assetType} image here</span>
+              <span>{t(`edit_game_modal_drop_${assetType}_image_here`)}</span>
             </div>
           </button>
         )}


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read and understood the [Contributor Guidelines](https://github.com/hydralauncher/hydra?tab=readme-ov-file#ways-you-can-contribute).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

- Added ability to reset custom game assets to its default in edit-game-modal.ts
