### PR TITLE
Fix: [Linux] achievement notification positioning on multi-monitor setups

### DIFF
--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -302,46 +302,58 @@ export class WindowManager {
     position: AchievementCustomNotificationPosition | undefined
   ) {
     const display = screen.getPrimaryDisplay();
-    const { width, height } = display.workAreaSize;
+    const {
+      x: displayX,
+      y: displayY,
+      width: displayWidth,
+      height: displayHeight,
+    } = display.bounds;
 
     if (position === "bottom-left") {
       return {
-        x: 0,
-        y: height - this.NOTIFICATION_WINDOW_HEIGHT,
+        x: displayX,
+        y: displayY + displayHeight - this.NOTIFICATION_WINDOW_HEIGHT,
       };
     }
 
     if (position === "bottom-center") {
       return {
-        x: (width - this.NOTIFICATION_WINDOW_WIDTH) / 2,
-        y: height - this.NOTIFICATION_WINDOW_HEIGHT,
+        x: displayX + (displayWidth - this.NOTIFICATION_WINDOW_WIDTH) / 2,
+        y: displayY + displayHeight - this.NOTIFICATION_WINDOW_HEIGHT,
       };
     }
 
     if (position === "bottom-right") {
       return {
-        x: width - this.NOTIFICATION_WINDOW_WIDTH,
-        y: height - this.NOTIFICATION_WINDOW_HEIGHT,
+        x: displayX + displayWidth - this.NOTIFICATION_WINDOW_WIDTH,
+        y: displayY + displayHeight - this.NOTIFICATION_WINDOW_HEIGHT,
+      };
+    }
+
+    if (position === "top-left") {
+      return {
+        x: displayX,
+        y: displayY,
       };
     }
 
     if (position === "top-center") {
       return {
-        x: (width - this.NOTIFICATION_WINDOW_WIDTH) / 2,
-        y: 0,
+        x: displayX + (displayWidth - this.NOTIFICATION_WINDOW_WIDTH) / 2,
+        y: displayY,
       };
     }
 
     if (position === "top-right") {
       return {
-        x: width - this.NOTIFICATION_WINDOW_WIDTH,
-        y: 0,
+        x: displayX + displayWidth - this.NOTIFICATION_WINDOW_WIDTH,
+        y: displayY,
       };
     }
 
     return {
-      x: 0,
-      y: 0,
+      x: displayX,
+      y: displayY,
     };
   }
 


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read and understood the [Contributor Guidelines](https://github.com/hydralauncher/hydra?tab=readme-ov-file#ways-you-can-contribute).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

**Description of bug**

Ever since the introduction of the new "toast" style achievement notifications, there has been a pretty annoying bug on Linux regarding multi-monitor or dual-monitor setups, especially those arranged side-by-side, where the notification windows were being placed relative to the wrong screen. "Bottom-left" would appear on the left side of the **secondary** monitor instead of the **primary** monitor, "bottom-center" would appear towards the right of the **secondary** monitor instead of the **primary** monitor etc...

**Description of fix**

The original code used only the primary display's width and height without accounting for the display's actual `x` and `y` offset in the global coordinate space. 
The updated code uses `display.bounds.x` and `display.bounds.y` for every position calculation. This ensures that all toast coordinates are computed relative to the correct display's origin, so notifications now appear correctly on any monitor, regardless of its orientation or position in the desktop layout.

**Additional**

- This bug was only present on Linux systems when using dual-monitor setups. I never encountered it on Windows.
- Specific distros where I confirmed this issue were Linux Mint, Ubuntu, and Bazzite.  
- This SHOULD function perfectly fine on Windows as well, but I do not have any means to test this at the moment. Someone can likely test and confirm this working properly on Windows if needed. 