### PR TITLE
[fix] ci: fix version name in aur commit message

### DIFF
--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -137,7 +137,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            COMMIT_MSG="v${{ steps.get-version.outputs.version }}"
+            COMMIT_MSG="${{ steps.get-version.outputs.version }}"
             
             git commit -m "$COMMIT_MSG"
             


### PR DESCRIPTION
omit extra 'v' in commit message

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [ ] I have read and understood the [Contributor Guidelines](https://github.com/hydralauncher/hydra?tab=readme-ov-file#ways-you-can-contribute).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

AUR commits have an extra preceding `v` in commit message. See most recent 2 commits here: https://aur.archlinux.org/cgit/aur.git/log/?h=hydra-launcher-bin

I've removed it.
