### PR TITLE
Fixing the gray screen error on the game page

### DIFF
--- a/src/renderer/src/pages/game-details/gallery-slider/gallery-slider.tsx
+++ b/src/renderer/src/pages/game-details/gallery-slider/gallery-slider.tsx
@@ -105,7 +105,6 @@ export function GallerySlider() {
 
     if (shopDetails?.movies) {
       shopDetails.movies.forEach((video, index) => {
-        // Проверяем, что video.mp4 и video.mp4.max существуют
         const videoUrl = video.mp4?.max;
         if (videoUrl) {
           items.push({


### PR DESCRIPTION
Added a check for video.mp4.max existence before pushing to items.

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
Error in the GallerySlider component:
`gallery-slider.tsx:112 Uncaught TypeError: Cannot read properties of undefined (reading 'max')`
This error occurs in the GallerySlider component on line 112 when the code tries to access the max property of an undefined object. This causes the entire React component to crash, resulting in a gray screen.

<img width="1523" height="799" alt="Снимок экрана 2025-11-29 021703" src="https://github.com/user-attachments/assets/d0fd89a5-56ab-4c35-b219-d6168c9d5cda" />
<img width="1523" height="799" alt="Снимок экрана 2025-11-29 021713" src="https://github.com/user-attachments/assets/14a23257-caee-4354-a74c-57d2fba2f824" />