### PR TITLE
added new user preference: Startup Location

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import resources from "@locales";
 import { PythonRPC } from "./services/python-rpc";
 import { db, levelKeys } from "./level";
 import { loadState } from "./main";
+import type { UserPreferences } from "@types";
 
 const { autoUpdater } = updater;
 
@@ -140,8 +141,16 @@ app.whenReady().then(async () => {
 
   if (language) i18n.changeLanguage(language);
 
+  const userPreferences = await db
+    .get<string, UserPreferences | null>(levelKeys.userPreferences, {
+      valueEncoding: "json",
+    })
+    .catch(() => null);
+
+  const startupLocation = userPreferences?.startupLocation ?? ""
+
   if (!process.argv.includes("--hidden")) {
-    WindowManager.createMainWindow();
+    WindowManager.createMainWindow(startupLocation);
   }
 
   WindowManager.createNotificationWindow();

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -118,7 +118,7 @@ export class WindowManager {
     };
   }
 
-  public static async createMainWindow() {
+  public static async createMainWindow(hash: string = "") {
     if (this.mainWindow) return;
 
     const { isMaximized = false, ...configWithoutMaximized } =
@@ -193,7 +193,7 @@ export class WindowManager {
       }
     );
 
-    this.loadMainWindowURL();
+    this.loadMainWindowURL(hash);
     this.mainWindow.removeMenu();
 
     this.mainWindow.on("ready-to-show", () => {

--- a/src/renderer/src/pages/settings/settings-behavior.tsx
+++ b/src/renderer/src/pages/settings/settings-behavior.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { CheckboxField } from "@renderer/components";
+import { CheckboxField, SelectField } from "@renderer/components";
 import { useAppSelector } from "@renderer/hooks";
 import { settingsContext } from "@renderer/context";
 import "./settings-behavior.scss";
@@ -12,6 +12,11 @@ export function SettingsBehavior() {
     (state) => state.userPreferences.value
   );
 
+  const startupLocations = [
+    { value: "home", label: "sidebar:home" },
+    { value: "library", label: "sidebar:library" },
+    { value: "catalogue", label: "sidebar:catalogue" },
+  ];
   const [showRunAtStartup, setShowRunAtStartup] = useState(false);
 
   const { updateUserPreferences } = useContext(settingsContext);
@@ -29,6 +34,7 @@ export function SettingsBehavior() {
     enableSteamAchievements: false,
     autoplayGameTrailers: true,
     hideToTrayOnGameStart: false,
+    startupLocation: "home",
   });
 
   const { t } = useTranslation("settings");
@@ -53,6 +59,7 @@ export function SettingsBehavior() {
           userPreferences.enableSteamAchievements ?? false,
         autoplayGameTrailers: userPreferences.autoplayGameTrailers ?? true,
         hideToTrayOnGameStart: userPreferences.hideToTrayOnGameStart ?? false,
+        startupLocation: userPreferences.startupLocation ?? "home",
       });
     }
   }, [userPreferences]);
@@ -70,6 +77,20 @@ export function SettingsBehavior() {
 
   return (
     <>
+      <SelectField
+        label={t("startup_location", "Startup Location")}
+        value={form.startupLocation}
+        onChange={(event) =>
+          handleChange({
+            startupLocation: event.target.value,
+          })
+        }
+        options={startupLocations.map((location) => ({
+          key: location.value,
+          value: location.value,
+          label: t(location.label),
+        }))}
+      />
       <CheckboxField
         label={t("quit_app_instead_hiding")}
         checked={form.preferQuitInsteadOfHiding}

--- a/src/types/level.types.ts
+++ b/src/types/level.types.ts
@@ -124,6 +124,7 @@ export interface UserPreferences {
   enableSteamAchievements?: boolean;
   autoplayGameTrailers?: boolean;
   hideToTrayOnGameStart?: boolean;
+  startupLocation?: string;
 }
 
 export interface ScreenState {


### PR DESCRIPTION
added new way to redirect to startup location when open app

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**


Added a select input to behavior settings: Startup Location
This setting make so that the user can select what page will load when the app starts