### PR TITLE
[feature] Add Steam shortcut deletion

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -530,7 +530,13 @@
     "hide_original": "Hide original",
     "review_from_blocked_user": "Review from blocked user",
     "show": "Show",
-    "hide": "Hide"
+    "hide": "Hide",
+    "create_steam_shortcut_modal_vr_flag": "VR Game (In Steam: update the VR flag or delete/recreate the shortcut)",
+    "create_steam_shortcut_modal_create_button": "Create",
+    "create_steam_shortcut_modal_cancel_button": "Cancel",
+    "delete_shortcut_success": "Steam shortcut deleted successfully",
+    "delete_shortcut_error": "Failed to delete Steam shortcut",
+    "delete_steam_shortcut": "Delete Steam shortcut"
   },
   "activation": {
     "title": "Activate Hydra",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -504,14 +504,17 @@
     "download_error_premiumize_transfer_started": "Transfert lancé sur Premiumize, réessayez dans un instant.",
     "create_steam_shortcut_modal_vr_flag": "Jeu VR (Dans Steam : mettre à jour le flag VR ou supprimer/recréer le raccourci)",
     "create_steam_shortcut_modal_create_button": "Créer",
-    "create_steam_shortcut_modal_cancel_button": "Annuler",
     "protondb_tier_borked": "Borked",
     "protondb_tier_bronze": "Bronze",
     "protondb_tier_silver": "Silver",
     "protondb_tier_gold": "Gold",
     "protondb_tier_platinum": "Platinum",
     "protondb_tier_unknown": "Unknown",
-    "protondb_badge_title": "ProtonDB {{tier}}"
+    "protondb_badge_title": "ProtonDB {{tier}}",
+    "create_steam_shortcut_modal_cancel_button": "Annuler",
+    "delete_shortcut_success": "Raccourci Steam supprimé avec succès",
+    "delete_shortcut_error": "Échec de la suppression du raccourci Steam",
+    "delete_steam_shortcut": "Supprimer le raccourci Steam"
   },
   "activation": {
     "title": "Activer Hydra",

--- a/src/main/events/library/check-steam-shortcut.ts
+++ b/src/main/events/library/check-steam-shortcut.ts
@@ -1,0 +1,67 @@
+import { registerEvent } from "../register-event";
+import type { GameShop } from "@types";
+import { gamesSublevel, levelKeys } from "@main/level";
+import { getSteamShortcuts, getSteamUsersIds, logger } from "@main/services";
+
+const checkSteamShortcut = async (
+  _event: Electron.IpcMainInvokeEvent,
+  shop: GameShop,
+  objectId: string
+) => {
+  const gameKey = levelKeys.game(shop, objectId);
+  const game = await gamesSublevel.get(gameKey);
+
+  if (!game?.executablePath) return false;
+
+  const steamUserIds = await getSteamUsersIds();
+  if (!steamUserIds.length) return false;
+
+  // Check by existing steamShortcutAppId first
+  if (game.steamShortcutAppId) {
+    for (const userId of steamUserIds) {
+      const shortcuts = await getSteamShortcuts(userId);
+      if (shortcuts.some((s) => s.appid === game.steamShortcutAppId)) {
+        return true;
+      }
+    }
+  }
+
+  // Fallback: check by executablePath or title
+  for (const userId of steamUserIds) {
+    const shortcuts = await getSteamShortcuts(userId);
+    const match = shortcuts.find(
+      (s) => s.Exe === game.executablePath || s.appname === game.title
+    );
+
+    if (match) {
+      // Log the game object before adding steamShortcutAppId
+      logger.info(
+        "Steam shortcut detected for game (before adding steamShortcutAppId):",
+        JSON.stringify(game, null, 2)
+      );
+      logger.info("Matching Steam shortcut:", match);
+
+      // Add steamShortcutAppId to game if missing for better tracking
+      if (!game.steamShortcutAppId && match.appid) {
+        const updatedGame = {
+          ...game,
+          steamShortcutAppId: match.appid,
+        };
+        await gamesSublevel.put(gameKey, updatedGame);
+
+        logger.info(
+          "Updated game with steamShortcutAppId:",
+          JSON.stringify(updatedGame, null, 2)
+        );
+      }
+
+      logger.info("Displaying game object after Steam shortcut check:", game);
+
+      return true;
+    }
+  }
+
+  return false;
+};
+
+registerEvent("checkSteamShortcut", checkSteamShortcut);

--- a/src/main/events/library/create-steam-shortcut.ts
+++ b/src/main/events/library/create-steam-shortcut.ts
@@ -153,6 +153,11 @@ const createSteamShortcut = async (
       await writeSteamShortcuts(steamUserId, steamShortcuts);
     }
 
+    await gamesSublevel.put(gameKey, {
+      ...game,
+      steamShortcutAppId: newShortcut.appid,
+    });
+
     if (process.platform === "linux" && !game.winePrefixPath) {
       const steamWinePrefixes = path.join(
         SystemPath.getPath("home"),

--- a/src/main/events/library/delete-steam-shortcut.ts
+++ b/src/main/events/library/delete-steam-shortcut.ts
@@ -1,0 +1,107 @@
+import { registerEvent } from "../register-event";
+import type { GameShop } from "@types";
+import { gamesSublevel, levelKeys } from "@main/level";
+import {
+  getSteamLocation,
+  getSteamUsersIds,
+  getSteamShortcuts,
+  writeSteamShortcuts,
+  logger,
+} from "@main/services";
+import fs from "node:fs";
+import path from "node:path";
+
+const deleteSteamShortcutHandler = async (
+  _event: Electron.IpcMainInvokeEvent,
+  shop: GameShop,
+  objectId: string
+) => {
+  const gameKey = levelKeys.game(shop, objectId);
+  const game = await gamesSublevel.get(gameKey);
+
+  if (!game?.executablePath) {
+    logger.info(
+      `[deleteSteamShortcut] No game or executable found for ${shop}-${objectId}`
+    );
+    return false;
+  }
+
+  if (!game.steamShortcutAppId) {
+    logger.info(`[deleteSteamShortcut] No Steam App ID for ${game.title}`);
+    return false;
+  }
+
+  const steamAppId = game.steamShortcutAppId;
+  const steamUserIds = await getSteamUsersIds();
+
+  if (!steamUserIds.length) {
+    logger.error("[deleteSteamShortcut] No Steam users found");
+    return false;
+  }
+
+  logger.info(
+    `[deleteSteamShortcut] Removing Steam shortcut for ${game.title} (AppID: ${steamAppId})`
+  );
+
+  for (const steamUserId of steamUserIds) {
+    const steamShortcuts = await getSteamShortcuts(steamUserId);
+
+    const shortcutExists = steamShortcuts.some((s) => s.appid === steamAppId);
+    if (!shortcutExists) {
+      logger.info(
+        `[deleteSteamShortcut] No matching shortcut for user ${steamUserId}`
+      );
+      continue;
+    }
+
+    // Filter out the shortcut
+    const updatedShortcuts = steamShortcuts.filter(
+      (s) => s.appid !== steamAppId
+    );
+
+    // Write back
+    await writeSteamShortcuts(steamUserId, updatedShortcuts);
+    logger.info(
+      `[deleteSteamShortcut] Shortcut removed for user ${steamUserId}`
+    );
+
+    // Remove Steam grid assets
+    const gridPath = path.join(
+      await getSteamLocation(),
+      "userdata",
+      steamUserId.toString(),
+      "config",
+      "grid"
+    );
+
+    const assetFiles = [
+      `${steamAppId}_hero.jpg`,
+      `${steamAppId}_logo.png`,
+      `${steamAppId}p.jpg`,
+      `${steamAppId}.jpg`,
+      `${steamAppId}.ico`,
+    ];
+
+    for (const file of assetFiles) {
+      const filePath = path.join(gridPath, file);
+      if (fs.existsSync(filePath)) {
+        await fs.promises.unlink(filePath);
+        logger.info(`[deleteSteamShortcut] Deleted asset: ${file}`);
+      }
+    }
+  }
+
+  // Clear Steam shortcut AppID in DB
+  await gamesSublevel.put(gameKey, {
+    ...game,
+    steamShortcutAppId: undefined,
+  });
+
+  logger.info(
+    `[deleteSteamShortcut] Cleared steamShortcutAppId for ${game.title}`
+  );
+
+  return true;
+};
+
+registerEvent("deleteSteamShortcut", deleteSteamShortcutHandler);

--- a/src/main/events/library/index.ts
+++ b/src/main/events/library/index.ts
@@ -45,3 +45,5 @@ import "./update-executable-path";
 import "./update-game-custom-assets";
 import "./update-launch-options";
 import "./verify-executable-path";
+import "./delete-steam-shortcut";
+import "./check-steam-shortcut";

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -314,6 +314,10 @@ contextBridge.exposeInMainWorld("electron", {
     objectId: string,
     options?: CreateSteamShortcutOptions
   ) => ipcRenderer.invoke("createSteamShortcut", shop, objectId, options),
+  deleteSteamShortcut: (shop: GameShop, objectId: string) =>
+    ipcRenderer.invoke("deleteSteamShortcut", shop, objectId),
+  checkSteamShortcut: (shop: GameShop, objectId: string) =>
+    ipcRenderer.invoke("checkSteamShortcut", shop, objectId),
   onGamesRunning: (
     cb: (
       gamesRunning: Pick<GameRunning, "id" | "sessionDurationInMillis">[]

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -292,6 +292,8 @@ declare global {
       objectId: string,
       options?: CreateSteamShortcutOptions
     ) => Promise<void>;
+    deleteSteamShortcut: (shop: GameShop, objectId: string) => Promise<void>;
+    checkSteamShortcut: (shop: GameShop, objectId: string) => Promise<boolean>;
 
     /* Download sources */
     addDownloadSource: (url: string) => Promise<DownloadSource>;

--- a/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
@@ -110,6 +110,7 @@ export function GameOptionsModal({
     string | null
   >(null);
   const [showSteamShortcutModal, setShowSteamShortcutModal] = useState(false);
+  const [steamShortcutExists, setSteamShortcutExists] = useState(false);
 
   const {
     removeGameInstaller,
@@ -226,6 +227,19 @@ export function GameOptionsModal({
       .catch(() => setWinetricksAvailable(false));
   }, [visible]);
 
+  useEffect(() => {
+    if (game.shop !== "custom") {
+      console.log(
+        "Checking Steam shortcut existence for",
+        window.electron.checkSteamShortcut(game.shop, game.objectId)
+      );
+      window.electron
+        .checkSteamShortcut(game.shop, game.objectId)
+        .then(setSteamShortcutExists)
+        .catch(() => setSteamShortcutExists(false));
+    }
+  }, [game.shop, game.objectId]);
+
   const debounceUpdateLaunchOptions = useRef(
     debounce(async (value: string) => {
       const gameKey = getGameKey(game.shop, game.objectId);
@@ -297,6 +311,12 @@ export function GameOptionsModal({
         t("you_might_need_to_restart_steam")
       );
 
+      const exists = await window.electron.checkSteamShortcut(
+        game.shop,
+        game.objectId
+      );
+      setSteamShortcutExists(exists);
+
       updateGame();
     } catch (error: unknown) {
       logger.error("Failed to create Steam shortcut", error);
@@ -307,33 +327,44 @@ export function GameOptionsModal({
     }
   };
 
-  const handleCreateShortcut = async () => {
+  const handleDeleteSteamShortcut = async () => {
     try {
-      const locations: ShortcutLocation[] =
-        window.electron.platform === "win32"
-          ? ["desktop", "start_menu"]
-          : ["desktop"];
+      setCreatingSteamShortcut(true);
+      await window.electron.deleteSteamShortcut(game.shop, game.objectId);
 
-      for (const location of locations) {
-        const success = await window.electron.createGameShortcut(
-          game.shop,
-          game.objectId,
-          location
-        );
-
-        if (!success) {
-          throw new Error(t("create_shortcut_error"));
-        }
-      }
-
-      showSuccessToast(t("create_shortcut_success"));
-    } catch (error: unknown) {
-      logger.error("Failed to create shortcut", error);
-      showErrorToast(
-        t("create_shortcut_error"),
-        error instanceof Error ? error.message : undefined
+      showSuccessToast(
+        t("delete_shortcut_success"),
+        t("you_might_need_to_restart_steam")
       );
+
+      const exists = await window.electron.checkSteamShortcut(
+        game.shop,
+        game.objectId
+      );
+      setSteamShortcutExists(exists);
+
+      updateGame();
+    } catch (error: unknown) {
+      logger.error("Failed to delete Steam shortcut", error);
+      showErrorToast(t("delete_shortcut_error"));
+    } finally {
+      setCreatingSteamShortcut(false);
     }
+  };
+
+  const handleCreateShortcut = async (location: ShortcutLocation) => {
+    window.electron
+      .createGameShortcut(game.shop, game.objectId, location)
+      .then((success) => {
+        if (success) {
+          showSuccessToast(t("create_shortcut_success"));
+        } else {
+          showErrorToast(t("create_shortcut_error"));
+        }
+      })
+      .catch(() => {
+        showErrorToast(t("create_shortcut_error"));
+      });
   };
 
   const handleOpenDownloadFolder = async () => {
@@ -692,12 +723,14 @@ export function GameOptionsModal({
                 }
                 loadingSaveFolder={loadingSaveFolder}
                 saveFolderPath={saveFolderPath}
+                steamShortcutExists={steamShortcutExists}
                 onChangeExecutableLocation={handleChangeExecutableLocation}
                 onClearExecutablePath={handleClearExecutablePath}
                 onOpenGameExecutablePath={handleOpenGameExecutablePath}
                 onOpenSaveFolder={handleOpenSaveFolder}
                 onCreateShortcut={handleCreateShortcut}
                 onCreateSteamShortcut={() => setShowSteamShortcutModal(true)}
+                onDeleteSteamShortcut={handleDeleteSteamShortcut}
                 onChangeGameTitle={handleChangeGameTitle}
                 onBlurGameTitle={handleBlurGameTitle}
                 onChangeLaunchOptions={handleChangeLaunchOptions}

--- a/src/renderer/src/pages/game-details/modals/game-options-modal/general-section.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal/general-section.tsx
@@ -15,12 +15,14 @@ interface GeneralSettingsSectionProps {
   shouldShowWinePrefixConfiguration: boolean;
   loadingSaveFolder: boolean;
   saveFolderPath: string | null;
+  steamShortcutExists: boolean;
   onChangeExecutableLocation: () => Promise<void>;
   onClearExecutablePath: () => Promise<void>;
   onOpenGameExecutablePath: () => Promise<void>;
   onOpenSaveFolder: () => Promise<void>;
   onCreateShortcut: (location: ShortcutLocation) => Promise<void>;
   onCreateSteamShortcut: () => void;
+  onDeleteSteamShortcut: () => Promise<void>;
   onChangeGameTitle: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onBlurGameTitle: () => Promise<void>;
   onChangeLaunchOptions: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -37,12 +39,14 @@ export function GeneralSettingsSection({
   shouldShowWinePrefixConfiguration,
   loadingSaveFolder,
   saveFolderPath,
+  steamShortcutExists,
   onChangeExecutableLocation,
   onClearExecutablePath,
   onOpenGameExecutablePath,
   onOpenSaveFolder,
   onCreateShortcut,
   onCreateSteamShortcut,
+  onDeleteSteamShortcut,
   onChangeGameTitle,
   onBlurGameTitle,
   onChangeLaunchOptions,
@@ -139,16 +143,26 @@ export function GeneralSettingsSection({
             <Button onClick={() => onCreateShortcut("desktop")} theme="outline">
               {t("create_shortcut")}
             </Button>
-            {game.shop !== "custom" && (
-              <Button
-                onClick={onCreateSteamShortcut}
-                theme="outline"
-                disabled={creatingSteamShortcut}
-              >
-                <SteamLogo />
-                {t("create_steam_shortcut")}
-              </Button>
-            )}
+            {game.shop !== "custom" &&
+              (steamShortcutExists ? (
+                <Button
+                  onClick={onDeleteSteamShortcut}
+                  theme="danger"
+                  disabled={creatingSteamShortcut}
+                >
+                  <SteamLogo />
+                  {t("delete_steam_shortcut")}
+                </Button>
+              ) : (
+                <Button
+                  onClick={onCreateSteamShortcut}
+                  theme="outline"
+                  disabled={creatingSteamShortcut}
+                >
+                  <SteamLogo />
+                  {t("create_steam_shortcut")}
+                </Button>
+              ))}
             {shouldShowCreateStartMenuShortcut && (
               <Button
                 onClick={() => onCreateShortcut("start_menu")}

--- a/src/types/level.types.ts
+++ b/src/types/level.types.ts
@@ -69,6 +69,7 @@ export interface Game {
   newDownloadOptionsCount?: number;
   installedSizeInBytes?: number | null;
   installerSizeInBytes?: number | null;
+  steamShortcutAppId?: number;
 }
 
 export interface Download {


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

### What

- Added the ability to delete Steam shortcuts via deleteSteamShortcutHandler.
- The Game model now stores the Steam AppID (steamShortcutAppId) for every game added to Steam.
- Added a check when creating shortcuts to update the Game with the AppID if the shortcut already exists.
- This allows Hydra to better track and manipulate Steam shortcut data in the future.

<img width="854" height="662" alt="Capture d’écran 2026-02-24 à 14 57 11" src="https://github.com/user-attachments/assets/15fd40c9-cf81-4e58-9be5-8251cd621056" />
