### PR TITLE
feat: Add mission translation script for found missing translation keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "prepare": "husky",
-    "protoc": "npx protoc --ts_out src/main/generated --proto_path proto proto/*.proto"
+    "protoc": "npx protoc --ts_out src/main/generated --proto_path proto proto/*.proto",
+    "export-missing-translations": "node ./src/scripts/generate-missing-translations.js"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/src/scripts/generate-missing-translations.js
+++ b/src/scripts/generate-missing-translations.js
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const targetLang = process.argv[2];
+if (!targetLang) {
+  console.error(
+    "Please provide a target language, e.g., 'node generate-missing-translations.js fr'"
+  );
+  process.exit(1);
+}
+
+const projectRoot = path.resolve(__dirname, "..");
+const enPath = path.join(projectRoot, "locales/en/translation.json");
+const targetDir = path.join(projectRoot, `locales/${targetLang}`);
+const targetTranslationPath = path.join(targetDir, "translation.json");
+const missingKeysPath = path.join(targetDir, "missing_keys.json");
+
+const en = JSON.parse(fs.readFileSync(enPath, "utf8"));
+
+let target = {};
+try {
+  target = JSON.parse(fs.readFileSync(targetTranslationPath, "utf8"));
+} catch {
+  console.warn(`No translation.json for '${targetLang}', starting empty.`);
+}
+
+function mergeMissing(enObj, targetObj) {
+  const missing = {};
+  for (const key in enObj) {
+    if (!(key in targetObj)) {
+      missing[key] = enObj[key];
+    } else if (
+      typeof enObj[key] === "object" &&
+      enObj[key] !== null &&
+      !Array.isArray(enObj[key])
+    ) {
+      const childMissing = mergeMissing(enObj[key], targetObj[key]);
+      if (Object.keys(childMissing).length > 0) missing[key] = childMissing;
+    }
+  }
+  return missing;
+}
+
+const missingKeysObj = mergeMissing(en, target);
+
+fs.mkdirSync(targetDir, { recursive: true });
+fs.writeFileSync(
+  missingKeysPath,
+  JSON.stringify(missingKeysObj, null, 2),
+  "utf8"
+);
+
+console.log(`File '${missingKeysPath}' generated.`);


### PR DESCRIPTION
A script to generate missing translation keys (generate-missing-translations.js).

A new npm script in package.json to run the generator easily, e.g., npm run translations:generate fr

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
