### PR TITLE
Update parse-launch-options.ts

### DIFF
--- a/src/main/events/helpers/parse-launch-options.ts
+++ b/src/main/events/helpers/parse-launch-options.ts
@@ -3,5 +3,5 @@ export const parseLaunchOptions = (params?: string | null): string[] => {
     return [];
   }
 
-  return params.split(" ");
+  return params.split(/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/);
 };


### PR DESCRIPTION
Split por espaços, exceto quando o espaço estiver dentro de aspas duplas.

Regex

\s+(?=(?:[^"]*"[^"]*")*[^"]*$)

O que ele faz

* \s+ → pega um ou mais espaços
* (?= ...) → lookahead: só permite o split se…
* (?:[^"]*"[^"]*")* → houver pares completos de aspas à frente
* [^"]*$ → até o fim da string não sobra aspas “abertas”

Ou seja:
só divide se o espaço estiver fora das aspas

Motivo:
Com isso é possível utilizar o wrap do ludusavi nos parâmetros de inicialização sem que ocorra erro quando o path do executável contém espaços.