### PR TITLE
[feature] add regex to parse-launch-options split

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "sharp": "^0.34.5",
     "sound-play": "^1.1.0",
     "steam-shortcut-editor": "https://github.com/hydralauncher/steam-shortcut-editor",
+    "string-argv": "^0.3.2",
     "sudo-prompt": "^9.2.1",
     "tar": "^7.5.4",
     "tough-cookie": "^5.1.1",

--- a/src/main/events/helpers/parse-launch-options.ts
+++ b/src/main/events/helpers/parse-launch-options.ts
@@ -1,7 +1,9 @@
+import stringArgv from 'string-argv';
+
 export const parseLaunchOptions = (params?: string | null): string[] => {
   if (!params) {
     return [];
   }
 
-  return params.split(/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/);
+  return stringArgv(params);
 };


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Regex explanation: https://regex101.com/r/1ij8KY/2

Motive: enable to use ludusavi directly on launch with wrap in launch options

Example: wrap --name "GAME_NAME" --gui -- "GAME_PATH"

Problem: if GAME_PATH has blank spaces, the actual code split him too, regex fix to no split content inside ""