### PR TITLE
feat(repacks-modal): add hypervisor badge for repacks with hypervisor

### DIFF
--- a/src/renderer/src/pages/game-details/modals/repacks-modal.scss
+++ b/src/renderer/src/pages/game-details/modals/repacks-modal.scss
@@ -93,6 +93,17 @@
     border: 1px solid rgba(34, 197, 94, 0.5);
   }
 
+  &__hypervisor-badge {
+    background-color: rgba(239, 68, 68, 0.15);
+    color: rgb(254, 202, 202);
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 9px;
+    text-align: center;
+    flex-shrink: 0;
+    border: 1px solid rgba(239, 68, 68, 0.5);
+  }
+
   &__no-results {
     width: 100%;
     padding: calc(globals.$spacing-unit * 4) 0;

--- a/src/renderer/src/pages/game-details/modals/repacks-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/repacks-modal.tsx
@@ -94,6 +94,10 @@ export function RepacksModal({
     return match ? match[1].toLowerCase() : null;
   };
 
+  const hasHypervisorInUris = (uris: string[]): boolean => {
+    return uris.some((uri) => uri.toLowerCase().includes("hypervisor"));
+  };
+
   const { isFeatureEnabled, Feature } = useFeature();
 
   useEffect(() => {
@@ -400,6 +404,11 @@ export function RepacksModal({
 
                   <p className="repacks-modal__repack-title">
                     {repack.title}
+                    {hasHypervisorInUris(repack.uris) && (
+                      <span className="repacks-modal__hypervisor-badge">
+                        Hypervisor
+                      </span>
+                    )}
                     {userPreferences?.enableNewDownloadOptionsBadges !==
                       false &&
                       isNewRepack(repack) && (


### PR DESCRIPTION
uris

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

### Hypervisor badge for repacks

Detects "hypervisor" in magnet URIs (case-insensitive) and displays a red "Hypervisor" badge in the download options modal.

**Files changed:**
- `repacks-modal.tsx`: Added detection logic and badge
- `repacks-modal.scss`: Added red badge styling