### PR TITLE
[Feature] Download section in big picture + Startup stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,8 @@
     "@types/winreg": "^1.2.36",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.2.1",
+    "baseline-browser-mapping": "^2.10.27",
+    "browserslist": "^4.28.2",
     "electron": "^39.8.5",
     "electron-builder": "^26.0.12",
     "electron-vite": "^4.0.1",

--- a/src/big-picture/src/hooks/index.ts
+++ b/src/big-picture/src/hooks/index.ts
@@ -10,4 +10,4 @@ export * from "./use-navigation-screen-actions.hook";
 export * from "./use-search.hook";
 export * from "./use-format.hook";
 export * from "./use-date.hook";
-export * from "./use-game-details.hook";
+export * from "./use-download.hook";

--- a/src/big-picture/src/hooks/use-download.hook.ts
+++ b/src/big-picture/src/hooks/use-download.hook.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import { IS_DESKTOP } from "../constants";
+import type { DownloadProgress, SeedingStatus, GameShop } from "@types";
+
+export function useDownload() {
+  const [lastPacket, setLastPacket] = useState<DownloadProgress | null>(null);
+  const [seedingStatus, setSeedingStatus] = useState<SeedingStatus[]>([]);
+
+  useEffect(() => {
+    if (!IS_DESKTOP) return;
+
+    const unsubscribeProgress = globalThis.window.electron.onDownloadProgress(
+      (downloadProgress) => {
+        setLastPacket(downloadProgress);
+      }
+    );
+
+    const unsubscribeSeeding = globalThis.window.electron.onSeedingStatus(
+      (value) => setSeedingStatus(value)
+    );
+
+    return () => {
+      unsubscribeProgress();
+      unsubscribeSeeding();
+    };
+  }, []);
+
+  const pauseSeeding = useCallback(
+    async (shop: GameShop, objectId: string) => {
+      if (!IS_DESKTOP) return;
+      await globalThis.window.electron.pauseGameSeed(shop, objectId);
+    },
+    []
+  );
+
+  const resumeSeeding = useCallback(
+    async (shop: GameShop, objectId: string) => {
+      if (!IS_DESKTOP) return;
+      await globalThis.window.electron.resumeGameSeed(shop, objectId);
+    },
+    []
+  );
+
+  const cancelDownload = useCallback(
+    async (shop: GameShop, objectId: string) => {
+      if (!IS_DESKTOP) return;
+      await globalThis.window.electron.cancelGameDownload(shop, objectId);
+    },
+    []
+  );
+
+  const pauseDownload = useCallback(
+    async (shop: GameShop, objectId: string) => {
+      if (!IS_DESKTOP) return;
+      await globalThis.window.electron.pauseGameDownload(shop, objectId);
+    },
+    []
+  );
+
+  const resumeDownload = useCallback(
+    async (shop: GameShop, objectId: string) => {
+      if (!IS_DESKTOP) return;
+      await globalThis.window.electron.resumeGameDownload(shop, objectId);
+    },
+    []
+  );
+
+  return {
+    lastPacket,
+    seedingStatus,
+    pauseSeeding,
+    resumeSeeding,
+    cancelDownload,
+    pauseDownload,
+    resumeDownload,
+  };
+}

--- a/src/big-picture/src/hooks/use-download.hook.ts
+++ b/src/big-picture/src/hooks/use-download.hook.ts
@@ -25,13 +25,10 @@ export function useDownload() {
     };
   }, []);
 
-  const pauseSeeding = useCallback(
-    async (shop: GameShop, objectId: string) => {
-      if (!IS_DESKTOP) return;
-      await globalThis.window.electron.pauseGameSeed(shop, objectId);
-    },
-    []
-  );
+  const pauseSeeding = useCallback(async (shop: GameShop, objectId: string) => {
+    if (!IS_DESKTOP) return;
+    await globalThis.window.electron.pauseGameSeed(shop, objectId);
+  }, []);
 
   const resumeSeeding = useCallback(
     async (shop: GameShop, objectId: string) => {

--- a/src/big-picture/src/layout/navigation.ts
+++ b/src/big-picture/src/layout/navigation.ts
@@ -30,26 +30,21 @@ function normalizePathname(pathname: string) {
 
 export function getBigPictureSidebarItemIdFromPathname(pathname: string) {
   const normalizedPathname = normalizePathname(pathname);
-  const isDev = import.meta.env.DEV;
 
   if (normalizedPathname.startsWith("/catalogue")) {
-    return isDev
-      ? BIG_PICTURE_SIDEBAR_ITEM_IDS.catalogue
-      : BIG_PICTURE_SIDEBAR_ITEM_IDS.home;
+    return BIG_PICTURE_SIDEBAR_ITEM_IDS.catalogue;
   }
 
   if (normalizedPathname.startsWith("/downloads")) {
-    return isDev
-      ? BIG_PICTURE_SIDEBAR_ITEM_IDS.downloads
-      : BIG_PICTURE_SIDEBAR_ITEM_IDS.home;
-  }
-
-  if (normalizedPathname.startsWith("/settings")) {
-    return BIG_PICTURE_SIDEBAR_ITEM_IDS.settings;
+    return BIG_PICTURE_SIDEBAR_ITEM_IDS.downloads;
   }
 
   if (normalizedPathname.startsWith("/library")) {
     return BIG_PICTURE_SIDEBAR_ITEM_IDS.library;
+  }
+
+  if (normalizedPathname.startsWith("/settings")) {
+    return BIG_PICTURE_SIDEBAR_ITEM_IDS.settings;
   }
 
   return BIG_PICTURE_SIDEBAR_ITEM_IDS.home;

--- a/src/big-picture/src/layout/sidebar/index.tsx
+++ b/src/big-picture/src/layout/sidebar/index.tsx
@@ -82,7 +82,7 @@ function SidebarRouter() {
     }>
   ).filter((route) => {
     if (import.meta.env.DEV) return true;
-    return route.key !== "catalogue" && route.key !== "downloads";
+    return route.key !== "catalogue";
   });
 
   return (

--- a/src/big-picture/src/pages/downloads/downloads.tsx
+++ b/src/big-picture/src/pages/downloads/downloads.tsx
@@ -1,7 +1,187 @@
+import { useMemo } from "react";
+import { useDownload, useLibrary } from "../../hooks";
+import { DownloadSimpleIcon } from "@phosphor-icons/react";
+import type { LibraryGame, SeedingStatus } from "@types";
+
 export default function Downloads() {
+  const { library } = useLibrary();
+  const { lastPacket, seedingStatus } = useDownload();
+
+  const downloadingGames = useMemo(() => {
+    return library.filter((game) => {
+      if (!game.download) return false;
+      if (game.download.status === "removed") return false;
+
+      // Currently downloading or extracting
+      const isDownloading = lastPacket?.gameId === game.id;
+      const isExtracting = game.download.extracting;
+
+      return isDownloading || isExtracting;
+    });
+  }, [library, lastPacket]);
+
+  const queuedGames = useMemo(() => {
+    return library.filter((game) => {
+      if (!game.download) return false;
+      if (game.download.status === "removed") return false;
+
+      // Queued, paused, or error
+      const isQueued =
+        game.download.queued &&
+        game.download.status !== "complete" &&
+        game.download.status !== "seeding";
+
+      return (
+        isQueued ||
+        game.download.status === "paused" ||
+        game.download.status === "error"
+      );
+    });
+  }, [library]);
+
+  const hasDownloads = downloadingGames.length > 0 || queuedGames.length > 0;
+
+  if (!hasDownloads) {
+    return (
+      <div style={{ padding: "2rem", textAlign: "center", color: "white" }}>
+        <DownloadSimpleIcon size={48} style={{ marginBottom: "1rem" }} />
+        <h2>No Downloads</h2>
+        <p>Start downloading games to see them here.</p>
+      </div>
+    );
+  }
+
   return (
-    <div>
-      <p style={{ color: "white" }}>Downloads</p>
+    <div style={{ padding: "2rem", color: "white" }}>
+      <h1 style={{ marginBottom: "2rem" }}>Downloads</h1>
+
+      {downloadingGames.length > 0 && (
+        <section style={{ marginBottom: "2rem" }}>
+          <h2 style={{ marginBottom: "1rem" }}>Downloading</h2>
+          <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            {downloadingGames.map((game) => (
+              <DownloadItem
+                key={game.id}
+                game={game}
+                isDownloading={lastPacket?.gameId === game.id}
+                progress={lastPacket?.progress || 0}
+                downloadSpeed={lastPacket?.downloadSpeed || 0}
+                seedingStatus={seedingStatus.find(s => s.gameId === game.id)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {queuedGames.length > 0 && (
+        <section>
+          <h2 style={{ marginBottom: "1rem" }}>Queued</h2>
+          <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            {queuedGames.map((game) => (
+              <DownloadItem
+                key={game.id}
+                game={game}
+                isDownloading={false}
+                progress={game.download?.progress || 0}
+                downloadSpeed={0}
+                seedingStatus={seedingStatus.find(s => s.gameId === game.id)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+interface DownloadItemProps {
+  game: LibraryGame;
+  isDownloading: boolean;
+  progress: number;
+  downloadSpeed: number;
+  seedingStatus?: SeedingStatus;
+}
+
+function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingStatus }: DownloadItemProps) {
+  const formatSpeed = (speed: number) => {
+    if (speed === 0) return "0 B/s";
+    const units = ["B/s", "KB/s", "MB/s", "GB/s"];
+    let unitIndex = 0;
+    while (speed >= 1024 && unitIndex < units.length - 1) {
+      speed /= 1024;
+      unitIndex++;
+    }
+    return `${speed.toFixed(1)} ${units[unitIndex]}`;
+  };
+
+  const getStatusText = () => {
+    if (seedingStatus) {
+      return `Seeding - ${formatSpeed(seedingStatus.uploadSpeed)}`;
+    }
+    if (isDownloading) {
+      return `Downloading - ${formatSpeed(downloadSpeed)}`;
+    }
+    if (game.download?.status === "paused") {
+      return "Paused";
+    }
+    if (game.download?.status === "error") {
+      return "Error";
+    }
+    return "Queued";
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        padding: "1rem",
+        backgroundColor: "#2a2a2a",
+        borderRadius: "8px",
+        gap: "1rem"
+      }}
+    >
+      {game.iconUrl && (
+        <img
+          src={game.iconUrl}
+          alt={game.title}
+          style={{
+            width: "64px",
+            height: "64px",
+            objectFit: "cover",
+            borderRadius: "4px"
+          }}
+        />
+      )}
+      <div style={{ flex: 1 }}>
+        <h3 style={{ margin: 0, marginBottom: "0.5rem" }}>{game.title}</h3>
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <div
+            style={{
+              flex: 1,
+              height: "8px",
+              backgroundColor: "#444",
+              borderRadius: "4px",
+              overflow: "hidden"
+            }}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${progress * 100}%`,
+                backgroundColor: isDownloading ? "#4CAF50" : "#666",
+                transition: "width 0.3s ease"
+              }}
+            />
+          </div>
+          <span style={{ fontSize: "0.9rem", color: "#ccc" }}>
+            {(progress * 100).toFixed(1)}%
+          </span>
+        </div>
+        <p style={{ margin: "0.5rem 0 0 0", fontSize: "0.9rem", color: "#aaa" }}>
+          {getStatusText()}
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/big-picture/src/pages/downloads/downloads.tsx
+++ b/src/big-picture/src/pages/downloads/downloads.tsx
@@ -58,7 +58,9 @@ export default function Downloads() {
       {downloadingGames.length > 0 && (
         <section style={{ marginBottom: "2rem" }}>
           <h2 style={{ marginBottom: "1rem" }}>Downloading</h2>
-          <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+          >
             {downloadingGames.map((game) => (
               <DownloadItem
                 key={game.id}
@@ -66,7 +68,7 @@ export default function Downloads() {
                 isDownloading={lastPacket?.gameId === game.id}
                 progress={lastPacket?.progress || 0}
                 downloadSpeed={lastPacket?.downloadSpeed || 0}
-                seedingStatus={seedingStatus.find(s => s.gameId === game.id)}
+                seedingStatus={seedingStatus.find((s) => s.gameId === game.id)}
               />
             ))}
           </div>
@@ -76,7 +78,9 @@ export default function Downloads() {
       {queuedGames.length > 0 && (
         <section>
           <h2 style={{ marginBottom: "1rem" }}>Queued</h2>
-          <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+          >
             {queuedGames.map((game) => (
               <DownloadItem
                 key={game.id}
@@ -84,7 +88,7 @@ export default function Downloads() {
                 isDownloading={false}
                 progress={game.download?.progress || 0}
                 downloadSpeed={0}
-                seedingStatus={seedingStatus.find(s => s.gameId === game.id)}
+                seedingStatus={seedingStatus.find((s) => s.gameId === game.id)}
               />
             ))}
           </div>
@@ -102,7 +106,13 @@ interface DownloadItemProps {
   seedingStatus?: SeedingStatus;
 }
 
-function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingStatus }: DownloadItemProps) {
+function DownloadItem({
+  game,
+  isDownloading,
+  progress,
+  downloadSpeed,
+  seedingStatus,
+}: DownloadItemProps) {
   const formatSpeed = (speed: number) => {
     if (speed === 0) return "0 B/s";
     const units = ["B/s", "KB/s", "MB/s", "GB/s"];
@@ -138,7 +148,7 @@ function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingSta
         padding: "1rem",
         backgroundColor: "#2a2a2a",
         borderRadius: "8px",
-        gap: "1rem"
+        gap: "1rem",
       }}
     >
       {game.iconUrl && (
@@ -149,7 +159,7 @@ function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingSta
             width: "64px",
             height: "64px",
             objectFit: "cover",
-            borderRadius: "4px"
+            borderRadius: "4px",
           }}
         />
       )}
@@ -162,7 +172,7 @@ function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingSta
               height: "8px",
               backgroundColor: "#444",
               borderRadius: "4px",
-              overflow: "hidden"
+              overflow: "hidden",
             }}
           >
             <div
@@ -170,7 +180,7 @@ function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingSta
                 height: "100%",
                 width: `${progress * 100}%`,
                 backgroundColor: isDownloading ? "#4CAF50" : "#666",
-                transition: "width 0.3s ease"
+                transition: "width 0.3s ease",
               }}
             />
           </div>
@@ -178,7 +188,9 @@ function DownloadItem({ game, isDownloading, progress, downloadSpeed, seedingSta
             {(progress * 100).toFixed(1)}%
           </span>
         </div>
-        <p style={{ margin: "0.5rem 0 0 0", fontSize: "0.9rem", color: "#aaa" }}>
+        <p
+          style={{ margin: "0.5rem 0 0 0", fontSize: "0.9rem", color: "#aaa" }}
+        >
           {getStatusText()}
         </p>
       </div>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -99,7 +99,7 @@ export const loadState = async () => {
     (async () => {
       await DownloadSourcesChecker.checkForChanges();
     })();
-    
+
     // Only connect to WebSocket if user is logged in
     if (HydraApi.isLoggedIn()) {
       WSClient.connect();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -52,6 +52,8 @@ const hasMissingSeedFiles = async (download: Download): Promise<boolean> => {
 export const loadState = async () => {
   await Lock.acquireLock();
 
+  await db.open();
+
   const userPreferences = await db.get<string, UserPreferences | null>(
     levelKeys.userPreferences,
     {
@@ -97,7 +99,11 @@ export const loadState = async () => {
     (async () => {
       await DownloadSourcesChecker.checkForChanges();
     })();
-    WSClient.connect();
+    
+    // Only connect to WebSocket if user is logged in
+    if (HydraApi.isLoggedIn()) {
+      WSClient.connect();
+    }
   });
 
   const downloads = await downloadsSublevel
@@ -225,12 +231,14 @@ export const loadState = async () => {
   const isTorrent = downloadToResume?.downloader === Downloader.Torrent;
   if (downloadToResume && !isTorrent) {
     // Start Python RPC for seeding only, then resume HTTP download with JS
-    await DownloadManager.startRPC(undefined, downloadsToSeed);
+    if (downloadsToSeed.length > 0) {
+      await DownloadManager.startRPC(undefined, downloadsToSeed);
+    }
     await DownloadManager.startDownload(downloadToResume).catch((err) => {
       // If resume fails, just log it - user can manually retry
       logger.error("Failed to auto-resume download:", err);
     });
-  } else {
+  } else if (downloadToResume || downloadsToSeed.length > 0) {
     // Use Python RPC for everything (torrent or fallback)
     await DownloadManager.startRPC(downloadToResume, downloadsToSeed);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,6 +4046,11 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+baseline-browser-mapping@^2.10.12, baseline-browser-mapping@^2.10.27:
+  version "2.10.27"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz#fee941c2a0b42cdf83c6427e4c830b1d0bdab2c3"
+  integrity sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==
+
 baseline-browser-mapping@^2.8.9:
   version "2.8.16"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz#e17789673e7f4b7654f81ab2ef25e96ab6a895f9"
@@ -4114,6 +4119,17 @@ browserslist@^4.24.0:
     electron-to-chromium "^1.5.227"
     node-releases "^2.0.21"
     update-browserslist-db "^1.1.3"
+
+browserslist@^4.28.2:
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
+  dependencies:
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
 
 buffer-builder@^0.2.0:
   version "0.2.0"
@@ -4269,6 +4285,11 @@ caniuse-lite@^1.0.30001746:
   version "1.0.30001750"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz#c229f82930033abd1502c6f73035356cf528bfbc"
   integrity sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==
+
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001791"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz#dfb93d85c40ad380c57123e72e10f3c575786b51"
+  integrity sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==
 
 chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
@@ -4876,6 +4897,11 @@ electron-to-chromium@^1.5.227:
   version "1.5.235"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.235.tgz#778dac70537ed9e9e0abf25a49cc94b5a23aaa0e"
   integrity sha512-i/7ntLFwOdoHY7sgjlTIDo4Sl8EdoTjWIaKinYOVfC6bOp71bmwenyZthWHcasxgHDNWbWxvG9M3Ia116zIaYQ==
+
+electron-to-chromium@^1.5.328:
+  version "1.5.349"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz#9b9c6a6d84d1107557c18a9336099ce0ee890e5b"
+  integrity sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==
 
 electron-updater@^6.6.2:
   version "6.6.2"
@@ -7121,6 +7147,11 @@ node-releases@^2.0.21:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.23.tgz#2ecf3d7ba571ece05c67c77e5b7b1b6fb9e18cea"
   integrity sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==
 
+node-releases@^2.0.36:
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.38.tgz#791569b9e4424a044e12c3abfad418ed83ce9947"
+  integrity sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==
+
 nopt@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-6.0.0.tgz#245801d8ebf409c6df22ab9d95b65e1309cdb16d"
@@ -9121,6 +9152,14 @@ update-browserslist-db@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz#348377dd245216f9e7060ff50b15a1b740b75420"
   integrity sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
+
+update-browserslist-db@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [X] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [X] I have checked that there are no duplicate pull requests related to this request.
- [X] I have considered, and confirm that this submission is valuable to others.
- [X] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
- Added download section in Big Picture Mode.
- WebSocket connection now only starts if the user is already logged in.
- Download resume logic now only launches Python RPC when there is an actual download or seeding task to resume.
- This avoids startup failures when the app is launched without a logged-in user or without pending downloads.