### PR TITLE
fix: point MangoHud links to official repository

### DIFF
--- a/src/big-picture/src/pages/settings/compatibility.tsx
+++ b/src/big-picture/src/pages/settings/compatibility.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { GAMEMODE_SITE_URL, MANGOHUD_SITE_URL } from "@shared";
 
 import { Button, Checkbox, Radio, VerticalFocusGroup } from "../../components";
 import { useUserPreferences } from "../../hooks";
@@ -58,9 +59,6 @@ const DEFAULT_FORM: CompatibilityForm = {
   autoRunGamemode: false,
   autoRunMangohud: false,
 };
-
-const GAMEMODE_SITE_URL = "https://github.com/FeralInteractive/gamemode";
-const MANGOHUD_SITE_URL = "https://mangohud.com";
 
 function getProtonSourceDescription(version: ProtonVersion | null) {
   if (!version) {

--- a/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "@renderer/components";
-import { formatBytes } from "@shared";
+import { formatBytes, GAMEMODE_SITE_URL, MANGOHUD_SITE_URL } from "@shared";
 
 import type {
   CreateSteamShortcutOptions,
@@ -62,8 +62,6 @@ export function GameOptionsModal({
   onNavigateHome,
   initialCategory,
 }: Readonly<GameOptionsModalProps>) {
-  const MANGOHUD_SITE_URL = "https://mangohud.com";
-  const GAMEMODE_SITE_URL = "https://github.com/FeralInteractive/gamemode";
   const { t } = useTranslation("game_details");
 
   const { showSuccessToast, showErrorToast } = useToast();

--- a/src/renderer/src/pages/settings/settings-context-compatibility.tsx
+++ b/src/renderer/src/pages/settings/settings-context-compatibility.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { GAMEMODE_SITE_URL, MANGOHUD_SITE_URL } from "@shared";
 
 import {
   Button,
@@ -18,9 +19,6 @@ import "./settings-behavior.scss";
 import "./settings-general.scss";
 
 export function SettingsContextCompatibility() {
-  const MANGOHUD_SITE_URL = "https://mangohud.com";
-  const GAMEMODE_SITE_URL = "https://github.com/FeralInteractive/gamemode";
-
   const { t } = useTranslation("settings");
   const { t: tGameDetails } = useTranslation("game_details");
   const { updateUserPreferences } = useContext(settingsContext);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -85,3 +85,6 @@ export enum DownloadError {
 }
 
 export const FILE_EXTENSIONS_TO_EXTRACT = [".rar", ".zip", ".7z"];
+
+export const GAMEMODE_SITE_URL = "https://github.com/FeralInteractive/gamemode";
+export const MANGOHUD_SITE_URL = "https://github.com/flightlessmango/MangoHud";


### PR DESCRIPTION
## Summary
- Replace MangoHud links with the official GitHub repository URL
- Update both desktop and Big Picture compatibility settings links

Closes #2283

## Test Plan
- [x] `git diff --check`
- [x] Verified `https://github.com/flightlessmango/MangoHud` returns HTTP 200
