### PR TITLE
Feature/release calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ hydra-python-rpc/
 /hydra-native/
 native/hydra-native/target/
 .python-version
+.idea/
 
 # Sentry Config File
 .env.sentry-build-plugin

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" afterDir="false" />
-    </list>
+    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -35,23 +31,23 @@
   </component>
   <component name="NextEditCompletionFeaturesState">
     <decayedCancelled>
-      <entry key="MS100" value="1.3861991693257383" />
-      <entry key="MS500" value="2.8640805708026997" />
-      <entry key="S2" value="4.268235303416441" />
-      <entry key="S5" value="4.878292372361544" />
-      <entry key="S10" value="5.283246567088933" />
-      <entry key="S30" value="5.709571690210604" />
-      <entry key="S60" value="5.846868873633666" />
-      <entry key="M2" value="5.924601558348468" />
-      <entry key="M5" value="6.599848081991196" />
-      <entry key="M10" value="17.341352302222738" />
-      <entry key="M15" value="41.62355941330376" />
-      <entry key="M30" value="133.11637918332175" />
-      <entry key="H1" value="288.69057384812623" />
-      <entry key="H2" value="558.4786429825479" />
-      <entry key="H4" value="1008.9498998105257" />
-      <entry key="D1" value="2106.3150759079267" />
-      <entry key="W1" value="2448.992731733052" />
+      <entry key="MS100" value="1.5376475429462497" />
+      <entry key="MS500" value="3.44234365947998" />
+      <entry key="S2" value="4.518998651984505" />
+      <entry key="S5" value="4.79895079433027" />
+      <entry key="S10" value="4.933640015199586" />
+      <entry key="S30" value="6.046251347747689" />
+      <entry key="S60" value="7.526454497962962" />
+      <entry key="M2" value="8.899150090543436" />
+      <entry key="M5" value="10.584365301733992" />
+      <entry key="M10" value="20.954758174044482" />
+      <entry key="M15" value="44.37579953239832" />
+      <entry key="M30" value="134.4735346003757" />
+      <entry key="H1" value="289.7133851394193" />
+      <entry key="H2" value="559.6184557804706" />
+      <entry key="H4" value="1010.4569967699069" />
+      <entry key="D1" value="2110.098016835435" />
+      <entry key="W1" value="2453.790530058454" />
     </decayedCancelled>
     <decayedSelected>
       <entry key="MS100" value="0.0" />
@@ -59,37 +55,37 @@
       <entry key="S2" value="0.0" />
       <entry key="S5" value="0.0" />
       <entry key="S10" value="0.0" />
-      <entry key="S30" value="7.517268322778303E-202" />
-      <entry key="S60" value="2.741763724827187E-101" />
-      <entry key="M2" value="5.236185371840024E-51" />
-      <entry key="M5" value="7.719799221930773E-21" />
-      <entry key="M10" value="8.786371406620993E-11" />
-      <entry key="M15" value="1.9783035069472916E-7" />
-      <entry key="M30" value="4.746783334245212E-4" />
-      <entry key="H1" value="0.03326573935105998" />
-      <entry key="H2" value="0.39156294692989757" />
-      <entry key="H4" value="1.4904422183842112" />
-      <entry key="D1" value="4.741583792655772" />
-      <entry key="W1" value="5.801175792363038" />
+      <entry key="S30" value="1.4228088309459762E-202" />
+      <entry key="S60" value="1.1928155058289464E-101" />
+      <entry key="M2" value="3.45371612300277E-51" />
+      <entry key="M5" value="6.53603930564826E-21" />
+      <entry key="M10" value="8.084699500042772E-11" />
+      <entry key="M15" value="1.8715257384583894E-7" />
+      <entry key="M30" value="4.6169040667197193E-4" />
+      <entry key="H1" value="0.032807482147599425" />
+      <entry key="H2" value="0.3888565769264477" />
+      <entry key="H4" value="1.4852825342812959" />
+      <entry key="D1" value="4.738844064543032" />
+      <entry key="W1" value="5.800696820950948" />
     </decayedSelected>
     <decayedShown>
-      <entry key="MS100" value="1.3347240041138106" />
-      <entry key="MS500" value="2.8425266277349346" />
-      <entry key="S2" value="4.2508956444131645" />
-      <entry key="S5" value="4.8269176113359995" />
-      <entry key="S10" value="5.224711476732655" />
-      <entry key="S30" value="5.675289225032685" />
-      <entry key="S60" value="5.827111294532683" />
-      <entry key="M2" value="5.9139936093468695" />
-      <entry key="M5" value="6.595312757361851" />
-      <entry key="M10" value="17.337591549094164" />
-      <entry key="M15" value="41.618805578871005" />
-      <entry key="M30" value="133.1107254404928" />
-      <entry key="H1" value="288.71832553495716" />
-      <entry key="H2" value="558.8658062627686" />
-      <entry key="H4" value="1010.4367825212739" />
-      <entry key="D1" value="2111.0554919590804" />
-      <entry key="W1" value="2454.7937147403413" />
+      <entry key="MS100" value="1.4895349146902617" />
+      <entry key="MS500" value="3.4222086644728926" />
+      <entry key="S2" value="4.512419941561919" />
+      <entry key="S5" value="4.796154504683406" />
+      <entry key="S10" value="4.93181730458597" />
+      <entry key="S30" value="6.03928077802804" />
+      <entry key="S60" value="7.517617119711125" />
+      <entry key="M2" value="8.892032141945887" />
+      <entry key="M5" value="10.580476940570644" />
+      <entry key="M10" value="20.95127349961537" />
+      <entry key="M15" value="44.37128611368655" />
+      <entry key="M30" value="134.46802746683346" />
+      <entry key="H1" value="289.7407504855829" />
+      <entry key="H2" value="560.0029410782927" />
+      <entry key="H4" value="1011.9387311082008" />
+      <entry key="D1" value="2114.835693664734" />
+      <entry key="W1" value="2459.5910340861806" />
     </decayedShown>
   </component>
   <component name="ProjectColorInfo">{

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="" />
+    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -31,23 +35,23 @@
   </component>
   <component name="NextEditCompletionFeaturesState">
     <decayedCancelled>
-      <entry key="MS100" value="1.0746811955530695" />
-      <entry key="MS500" value="3.0335297058833643" />
-      <entry key="S2" value="4.98086662347777" />
-      <entry key="S5" value="5.5631835977577815" />
-      <entry key="S10" value="5.776408525451845" />
-      <entry key="S30" value="5.924285995913057" />
-      <entry key="S60" value="5.962005596693292" />
-      <entry key="M2" value="6.017766704529044" />
-      <entry key="M5" value="12.765494996790512" />
-      <entry key="M10" value="51.04982238462056" />
-      <entry key="M15" value="97.05341450757211" />
-      <entry key="M30" value="209.7930858656973" />
-      <entry key="H1" value="363.16258615137025" />
-      <entry key="H2" value="626.1946758149811" />
-      <entry key="H4" value="1067.7656358548645" />
-      <entry key="D1" value="2122.3509875132245" />
-      <entry key="W1" value="2446.6379694300217" />
+      <entry key="MS100" value="1.3861991693257383" />
+      <entry key="MS500" value="2.8640805708026997" />
+      <entry key="S2" value="4.268235303416441" />
+      <entry key="S5" value="4.878292372361544" />
+      <entry key="S10" value="5.283246567088933" />
+      <entry key="S30" value="5.709571690210604" />
+      <entry key="S60" value="5.846868873633666" />
+      <entry key="M2" value="5.924601558348468" />
+      <entry key="M5" value="6.599848081991196" />
+      <entry key="M10" value="17.341352302222738" />
+      <entry key="M15" value="41.62355941330376" />
+      <entry key="M30" value="133.11637918332175" />
+      <entry key="H1" value="288.69057384812623" />
+      <entry key="H2" value="558.4786429825479" />
+      <entry key="H4" value="1008.9498998105257" />
+      <entry key="D1" value="2106.3150759079267" />
+      <entry key="W1" value="2448.992731733052" />
     </decayedCancelled>
     <decayedSelected>
       <entry key="MS100" value="0.0" />
@@ -55,37 +59,37 @@
       <entry key="S2" value="0.0" />
       <entry key="S5" value="0.0" />
       <entry key="S10" value="0.0" />
-      <entry key="S30" value="8.517971682327512E-189" />
-      <entry key="S60" value="9.229285824118492E-95" />
-      <entry key="M2" value="9.606917207990474E-48" />
-      <entry key="M5" value="1.5596732342298997E-19" />
-      <entry key="M10" value="3.9493294545596293E-10" />
-      <entry key="M15" value="5.388097661122272E-7" />
-      <entry key="M30" value="7.833767500224175E-4" />
-      <entry key="H1" value="0.0427349120834577" />
-      <entry key="H2" value="0.4438072633588932" />
-      <entry key="H4" value="1.5867611273808555" />
-      <entry key="D1" value="4.791330892168272" />
-      <entry key="W1" value="5.8098318031533065" />
+      <entry key="S30" value="7.517268322778303E-202" />
+      <entry key="S60" value="2.741763724827187E-101" />
+      <entry key="M2" value="5.236185371840024E-51" />
+      <entry key="M5" value="7.719799221930773E-21" />
+      <entry key="M10" value="8.786371406620993E-11" />
+      <entry key="M15" value="1.9783035069472916E-7" />
+      <entry key="M30" value="4.746783334245212E-4" />
+      <entry key="H1" value="0.03326573935105998" />
+      <entry key="H2" value="0.39156294692989757" />
+      <entry key="H4" value="1.4904422183842112" />
+      <entry key="D1" value="4.741583792655772" />
+      <entry key="W1" value="5.801175792363038" />
     </decayedSelected>
     <decayedShown>
-      <entry key="MS100" value="1.0419095742338873" />
-      <entry key="MS500" value="2.954107406809527" />
-      <entry key="S2" value="4.935890534285329" />
-      <entry key="S5" value="5.541889584445667" />
-      <entry key="S10" value="5.765142762193097" />
-      <entry key="S30" value="5.920386321636286" />
-      <entry key="S60" value="5.960037255659264" />
-      <entry key="M2" value="6.016765539753794" />
-      <entry key="M5" value="12.763331277415114" />
-      <entry key="M10" value="51.04301335648014" />
-      <entry key="M15" value="97.04456435351116" />
-      <entry key="M30" value="209.78500260350518" />
-      <entry key="H1" value="363.1987240354261" />
-      <entry key="H2" value="626.6337113056967" />
-      <entry key="H4" value="1069.3487084405817" />
-      <entry key="D1" value="2127.141154397182" />
-      <entry key="W1" value="2452.447610423848" />
+      <entry key="MS100" value="1.3347240041138106" />
+      <entry key="MS500" value="2.8425266277349346" />
+      <entry key="S2" value="4.2508956444131645" />
+      <entry key="S5" value="4.8269176113359995" />
+      <entry key="S10" value="5.224711476732655" />
+      <entry key="S30" value="5.675289225032685" />
+      <entry key="S60" value="5.827111294532683" />
+      <entry key="M2" value="5.9139936093468695" />
+      <entry key="M5" value="6.595312757361851" />
+      <entry key="M10" value="17.337591549094164" />
+      <entry key="M15" value="41.618805578871005" />
+      <entry key="M30" value="133.1107254404928" />
+      <entry key="H1" value="288.71832553495716" />
+      <entry key="H2" value="558.8658062627686" />
+      <entry key="H4" value="1010.4367825212739" />
+      <entry key="D1" value="2111.0554919590804" />
+      <entry key="W1" value="2454.7937147403413" />
     </decayedShown>
   </component>
   <component name="ProjectColorInfo">{

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,15 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/electron.vite.config.1780776253087.mjs" beforeDir="false" afterPath="$PROJECT_DIR$/electron.vite.config.1780776253087.mjs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/preload/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/preload/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,13 @@
   <component name="ChangeListManager">
     <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/electron.vite.config.1780776253087.mjs" beforeDir="false" afterPath="$PROJECT_DIR$/electron.vite.config.1780776253087.mjs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" afterDir="false" />
     </list>
@@ -35,23 +42,23 @@
   </component>
   <component name="NextEditCompletionFeaturesState">
     <decayedCancelled>
-      <entry key="MS100" value="1.3804583914227684" />
-      <entry key="MS500" value="4.195337438708885" />
-      <entry key="S2" value="8.706104119055077" />
-      <entry key="S5" value="10.934183127740226" />
-      <entry key="S10" value="11.896126734576276" />
-      <entry key="S30" value="12.620111249250755" />
-      <entry key="S60" value="12.968064281567774" />
-      <entry key="M2" value="13.866807097307376" />
-      <entry key="M5" value="18.055774489826266" />
-      <entry key="M10" value="28.33276114869794" />
-      <entry key="M15" value="38.46488357481777" />
-      <entry key="M30" value="71.71333825499272" />
-      <entry key="H1" value="164.57388821158094" />
-      <entry key="H2" value="404.2685145572536" />
-      <entry key="H4" value="822.2304182819626" />
-      <entry key="D1" value="1748.4526257916973" />
-      <entry key="W1" value="2018.3473818424852" />
+      <entry key="MS100" value="1.3843708563334336" />
+      <entry key="MS500" value="3.7420420818609514" />
+      <entry key="S2" value="5.858130937118174" />
+      <entry key="S5" value="6.5073226515259455" />
+      <entry key="S10" value="6.74720088304444" />
+      <entry key="S30" value="7.002637803129057" />
+      <entry key="S60" value="10.86944496767147" />
+      <entry key="M2" value="34.23634109488593" />
+      <entry key="M5" value="104.28158916559336" />
+      <entry key="M10" value="176.7825000770166" />
+      <entry key="M15" value="226.52422119375086" />
+      <entry key="M30" value="321.436577623286" />
+      <entry key="H1" value="448.55768538393113" />
+      <entry key="H2" value="695.0307850080695" />
+      <entry key="H4" value="1124.0008062397576" />
+      <entry key="D1" value="2136.53830105214" />
+      <entry key="W1" value="2443.9502528301296" />
     </decayedCancelled>
     <decayedSelected>
       <entry key="MS100" value="0.0" />
@@ -59,37 +66,37 @@
       <entry key="S2" value="0.0" />
       <entry key="S5" value="0.0" />
       <entry key="S10" value="0.0" />
-      <entry key="S30" value="4.150053538845239E-147" />
-      <entry key="S60" value="6.442090917431427E-74" />
-      <entry key="M2" value="2.538127443102746E-37" />
-      <entry key="M5" value="2.3004106523230918E-15" />
-      <entry key="M10" value="4.7963320275385215E-8" />
-      <entry key="M15" value="1.3213748679784315E-5" />
-      <entry key="M30" value="0.003879412579260736" />
-      <entry key="H1" value="0.0950999876937725" />
-      <entry key="H2" value="0.6620537175921472" />
-      <entry key="H4" value="1.9380320908199562" />
-      <entry key="D1" value="4.953715565243258" />
-      <entry key="W1" value="5.837560609168201" />
+      <entry key="S30" value="6.3756516009774064E-177" />
+      <entry key="S60" value="7.984767749269458E-89" />
+      <entry key="M2" value="8.935752765866643E-45" />
+      <entry key="M5" value="2.4013333792131237E-18" />
+      <entry key="M10" value="1.5496470130816418E-9" />
+      <entry key="M15" value="1.3404225900433845E-6" />
+      <entry key="M30" value="0.001235588386519181" />
+      <entry key="H1" value="0.053670344718141486" />
+      <entry key="H2" value="0.49735923981220254" />
+      <entry key="H4" value="1.679768547026817" />
+      <entry key="D1" value="4.837034072494256" />
+      <entry key="W1" value="5.8177165397087185" />
     </decayedSelected>
     <decayedShown>
-      <entry key="MS100" value="1.3109866367679335" />
-      <entry key="MS500" value="4.156509565050009" />
-      <entry key="S2" value="8.684480719627341" />
-      <entry key="S5" value="10.922997365714831" />
-      <entry key="S10" value="11.889977369316364" />
-      <entry key="S30" value="12.617916719579794" />
-      <entry key="S60" value="12.966870203029092" />
-      <entry key="M2" value="13.866017251741008" />
-      <entry key="M5" value="18.055104534947247" />
-      <entry key="M10" value="28.33187835480403" />
-      <entry key="M15" value="38.463944379156665" />
-      <entry key="M30" value="71.71630110867835" />
-      <entry key="H1" value="164.66793675970126" />
-      <entry key="H2" value="404.92888388046293" />
-      <entry key="H4" value="824.1663723932772" />
-      <entry key="D1" value="1753.4055061988938" />
-      <entry key="W1" value="2024.1848025076595" />
+      <entry key="MS100" value="1.2515064828119893" />
+      <entry key="MS500" value="3.661060536129946" />
+      <entry key="S2" value="5.82761668696352" />
+      <entry key="S5" value="6.493929130083304" />
+      <entry key="S10" value="6.740287794693428" />
+      <entry key="S30" value="7.000255393002799" />
+      <entry key="S60" value="10.866856740179317" />
+      <entry key="M2" value="34.2248666616155" />
+      <entry key="M5" value="104.25438274327543" />
+      <entry key="M10" value="176.75656159100828" />
+      <entry key="M15" value="226.50253358578144" />
+      <entry key="M30" value="321.42393265696273" />
+      <entry key="H1" value="448.60311217253667" />
+      <entry key="H2" value="695.5228152446696" />
+      <entry key="H4" value="1125.6766788068073" />
+      <entry key="D1" value="2141.3741614063" />
+      <entry key="W1" value="2449.767778498949" />
     </decayedShown>
   </component>
   <component name="ProjectColorInfo">{

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/src/preload/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/preload/index.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
-    </list>
+    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/preload/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/preload/index.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
     </list>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/header/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/header/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/sidebar/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/sidebar/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/locales/en/translation.json" beforeDir="false" afterPath="$PROJECT_DIR$/src/locales/en/translation.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/main.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/main.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/services/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/services/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/preload/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/preload/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/sidebar/routes.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/sidebar/routes.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/features/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/features/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/main.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/main.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/store.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/store.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/index.ts" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="EmbeddingIndexingInfo">
+    <option name="fileBasedEmbeddingIndicesEnabled" value="true" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="TypeScript File" />
+        <option value="TypeScript JSX File" />
+        <option value="SCSS File" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="McpProjectServerCommands">
+    <commands />
+    <urls />
+  </component>
+  <component name="NextEditCompletionFeaturesState">
+    <decayedCancelled>
+      <entry key="MS100" value="1.5568160620494413" />
+      <entry key="MS500" value="3.4973545144555755" />
+      <entry key="S2" value="5.772933653820631" />
+      <entry key="S5" value="9.778223659426049" />
+      <entry key="S10" value="12.915696965994156" />
+      <entry key="S30" value="16.159995663755467" />
+      <entry key="S60" value="18.288970357131113" />
+      <entry key="M2" value="21.87393365849303" />
+      <entry key="M5" value="27.646458333674676" />
+      <entry key="M10" value="31.840974822859458" />
+      <entry key="M15" value="37.193836373335174" />
+      <entry key="M30" value="69.38499383977472" />
+      <entry key="H1" value="171.38592136836013" />
+      <entry key="H2" value="423.76276458671487" />
+      <entry key="H4" value="842.1990372254384" />
+      <entry key="D1" value="1725.422583070427" />
+      <entry key="W1" value="1976.1208600822806" />
+    </decayedCancelled>
+    <decayedSelected>
+      <entry key="MS100" value="0.0" />
+      <entry key="MS500" value="0.0" />
+      <entry key="S2" value="0.0" />
+      <entry key="S5" value="0.0" />
+      <entry key="S10" value="0.0" />
+      <entry key="S30" value="1.4765044132682765E-130" />
+      <entry key="S60" value="1.2151149794436244E-65" />
+      <entry key="M2" value="3.4858499385997643E-33" />
+      <entry key="M5" value="1.0397369424428997E-13" />
+      <entry key="M10" value="3.224543886559706E-7" />
+      <entry key="M15" value="4.706868632645013E-5" />
+      <entry key="M30" value="0.007321818975511219" />
+      <entry key="H1" value="0.13064926459370985" />
+      <entry key="H2" value="0.7759906402147628" />
+      <entry key="H4" value="2.0981792667195096" />
+      <entry key="D1" value="5.019702794686253" />
+      <entry key="W1" value="5.8486063821520995" />
+    </decayedSelected>
+    <decayedShown>
+      <entry key="MS100" value="1.4777513644808247" />
+      <entry key="MS500" value="3.439358352553395" />
+      <entry key="S2" value="5.730687450055871" />
+      <entry key="S5" value="9.723223691248897" />
+      <entry key="S10" value="12.869959467831544" />
+      <entry key="S30" value="16.138144675256502" />
+      <entry key="S60" value="18.276907193809418" />
+      <entry key="M2" value="21.86746203786116" />
+      <entry key="M5" value="27.64364326370813" />
+      <entry key="M10" value="31.839487851810347" />
+      <entry key="M15" value="37.19283212906292" />
+      <entry key="M30" value="69.3915717565589" />
+      <entry key="H1" value="171.51558786153987" />
+      <entry key="H2" value="424.53700532525164" />
+      <entry key="H4" value="844.2950775079505" />
+      <entry key="D1" value="1730.4414578390108" />
+      <entry key="W1" value="1981.9693288591448" />
+    </decayedShown>
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 8,
+  &quot;fromUser&quot;: false
+}</component>
+  <component name="ProjectId" id="3Ei2Ti5KUTM7qc5fhcQ6wGdevgA" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
+    &quot;codeWithMe.voiceChat.enabledByDefault&quot;: &quot;false&quot;,
+    &quot;com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/release-calendar&quot;,
+    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/js208/Downloads/Hydra-development/hydra&quot;,
+    &quot;list.type.of.created.stylesheet&quot;: &quot;SCSS&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;yarn&quot;,
+    &quot;npm.dev.executor&quot;: &quot;Run&quot;,
+    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;C:\\Users\\js208\\Downloads\\Hydra-development\\hydra\\node_modules\\prettier&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;ml.llm.LLMConfigurable&quot;,
+    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;C:\\Program Files\\JetBrains\\IntelliJ IDEA 2026.1.3\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="RunManager">
+    <configuration name="dev" type="js.build_tools.npm" nameIsGenerated="true">
+      <package-json value="$PROJECT_DIR$/package.json" />
+      <command value="run" />
+      <scripts>
+        <script value="dev" />
+      </scripts>
+      <node-interpreter value="project" />
+      <envs />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-jdk-30f59d01ecdd-37e91769500f-intellij.indexing.shared.core-IU-261.25134.95" />
+        <option value="bundled-js-predefined-d6986cc7102b-31caf2ab9e3c-JavaScript-IU-261.25134.95" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="" />
+      <created>1780647080566</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1780647080566</updated>
+      <workItem from="1780647166927" duration="25071000" />
+      <workItem from="1780737863219" duration="8157000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,31 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/button/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/button/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/divider/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/divider/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/focus-item/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/focus-item/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/grid-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/grid-focus-group/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/horizontal-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/horizontal-focus-group/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-layer/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-layer/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/route-anchor/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/route-anchor/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/scroll-area/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/scroll-area/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/typography/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/typography/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-focus-group/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/pages/library/game-card.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/pages/library/game-card.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation-geometry.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation-geometry.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/page.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/page.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/locales/en/translation.json" beforeDir="false" afterPath="$PROJECT_DIR$/src/locales/en/translation.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/utils/format-countdown.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/utils/format-countdown.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/utils/get-last-updated-label.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/utils/get-last-updated-label.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -58,23 +35,23 @@
   </component>
   <component name="NextEditCompletionFeaturesState">
     <decayedCancelled>
-      <entry key="MS100" value="1.0000042659919073" />
-      <entry key="MS500" value="1.1508542210840234" />
-      <entry key="S2" value="3.682866185075442" />
-      <entry key="S5" value="8.360369439461671" />
-      <entry key="S10" value="12.478255886956058" />
-      <entry key="S30" value="17.086977874723818" />
-      <entry key="S60" value="19.674586148214267" />
-      <entry key="M2" value="23.50554123293859" />
-      <entry key="M5" value="29.46038620526541" />
-      <entry key="M10" value="33.73396028631832" />
-      <entry key="M15" value="39.1106850087327" />
-      <entry key="M30" value="71.30798649051447" />
-      <entry key="H1" value="173.2912933173271" />
-      <entry key="H2" value="425.6460144155076" />
-      <entry key="H4" value="844.0830976150826" />
-      <entry key="D1" value="1727.3830080150897" />
-      <entry key="W1" value="1978.114385289754" />
+      <entry key="MS100" value="1.3804583914227684" />
+      <entry key="MS500" value="4.195337438708885" />
+      <entry key="S2" value="8.706104119055077" />
+      <entry key="S5" value="10.934183127740226" />
+      <entry key="S10" value="11.896126734576276" />
+      <entry key="S30" value="12.620111249250755" />
+      <entry key="S60" value="12.968064281567774" />
+      <entry key="M2" value="13.866807097307376" />
+      <entry key="M5" value="18.055774489826266" />
+      <entry key="M10" value="28.33276114869794" />
+      <entry key="M15" value="38.46488357481777" />
+      <entry key="M30" value="71.71333825499272" />
+      <entry key="H1" value="164.57388821158094" />
+      <entry key="H2" value="404.2685145572536" />
+      <entry key="H4" value="822.2304182819626" />
+      <entry key="D1" value="1748.4526257916973" />
+      <entry key="W1" value="2018.3473818424852" />
     </decayedCancelled>
     <decayedSelected>
       <entry key="MS100" value="0.0" />
@@ -82,37 +59,37 @@
       <entry key="S2" value="0.0" />
       <entry key="S5" value="0.0" />
       <entry key="S10" value="0.0" />
-      <entry key="S30" value="1.3821546053270716E-130" />
-      <entry key="S60" value="1.1756507157004902E-65" />
-      <entry key="M2" value="3.428776335225826E-33" />
-      <entry key="M5" value="1.0328937809580235E-13" />
-      <entry key="M10" value="3.213914995117997E-7" />
-      <entry key="M15" value="4.6965196091612825E-5" />
-      <entry key="M30" value="0.007313765280017183" />
-      <entry key="H1" value="0.13057739045267103" />
-      <entry key="H2" value="0.775777162803691" />
-      <entry key="H4" value="2.0978906390837695" />
-      <entry key="D1" value="5.019587702200899" />
-      <entry key="W1" value="5.848587225148292" />
+      <entry key="S30" value="4.150053538845239E-147" />
+      <entry key="S60" value="6.442090917431427E-74" />
+      <entry key="M2" value="2.538127443102746E-37" />
+      <entry key="M5" value="2.3004106523230918E-15" />
+      <entry key="M10" value="4.7963320275385215E-8" />
+      <entry key="M15" value="1.3213748679784315E-5" />
+      <entry key="M30" value="0.003879412579260736" />
+      <entry key="H1" value="0.0950999876937725" />
+      <entry key="H2" value="0.6620537175921472" />
+      <entry key="H4" value="1.9380320908199562" />
+      <entry key="D1" value="4.953715565243258" />
+      <entry key="W1" value="5.837560609168201" />
     </decayedSelected>
     <decayedShown>
-      <entry key="MS100" value="0.026830176063445003" />
-      <entry key="MS500" value="0.5694373907136285" />
-      <entry key="S2" value="3.3342073810268307" />
-      <entry key="S5" value="8.145528718860023" />
-      <entry key="S10" value="12.341806632269778" />
-      <entry key="S30" value="17.031015259682032" />
-      <entry key="S60" value="19.64482338404342" />
-      <entry key="M2" value="23.490043860738684" />
-      <entry key="M5" value="29.453916118042947" />
-      <entry key="M10" value="33.7306379492562" />
-      <entry key="M15" value="39.108455349537635" />
-      <entry key="M30" value="71.31394297104347" />
-      <entry key="H1" value="173.4205812792092" />
-      <entry key="H2" value="426.4198885347745" />
-      <entry key="H4" value="846.1787727464783" />
-      <entry key="D1" value="1732.4017549063738" />
-      <entry key="W1" value="1983.9628330809298" />
+      <entry key="MS100" value="1.3109866367679335" />
+      <entry key="MS500" value="4.156509565050009" />
+      <entry key="S2" value="8.684480719627341" />
+      <entry key="S5" value="10.922997365714831" />
+      <entry key="S10" value="11.889977369316364" />
+      <entry key="S30" value="12.617916719579794" />
+      <entry key="S60" value="12.966870203029092" />
+      <entry key="M2" value="13.866017251741008" />
+      <entry key="M5" value="18.055104534947247" />
+      <entry key="M10" value="28.33187835480403" />
+      <entry key="M15" value="38.463944379156665" />
+      <entry key="M30" value="71.71630110867835" />
+      <entry key="H1" value="164.66793675970126" />
+      <entry key="H2" value="404.92888388046293" />
+      <entry key="H4" value="824.1663723932772" />
+      <entry key="D1" value="1753.4055061988938" />
+      <entry key="W1" value="2024.1848025076595" />
     </decayedShown>
   </component>
   <component name="ProjectColorInfo">{

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -35,23 +35,23 @@
   </component>
   <component name="NextEditCompletionFeaturesState">
     <decayedCancelled>
-      <entry key="MS100" value="1.3843708563334336" />
-      <entry key="MS500" value="3.7420420818609514" />
-      <entry key="S2" value="5.858130937118174" />
-      <entry key="S5" value="6.5073226515259455" />
-      <entry key="S10" value="6.74720088304444" />
-      <entry key="S30" value="7.002637803129057" />
-      <entry key="S60" value="10.86944496767147" />
-      <entry key="M2" value="34.23634109488593" />
-      <entry key="M5" value="104.28158916559336" />
-      <entry key="M10" value="176.7825000770166" />
-      <entry key="M15" value="226.52422119375086" />
-      <entry key="M30" value="321.436577623286" />
-      <entry key="H1" value="448.55768538393113" />
-      <entry key="H2" value="695.0307850080695" />
-      <entry key="H4" value="1124.0008062397576" />
-      <entry key="D1" value="2136.53830105214" />
-      <entry key="W1" value="2443.9502528301296" />
+      <entry key="MS100" value="1.0746811955530695" />
+      <entry key="MS500" value="3.0335297058833643" />
+      <entry key="S2" value="4.98086662347777" />
+      <entry key="S5" value="5.5631835977577815" />
+      <entry key="S10" value="5.776408525451845" />
+      <entry key="S30" value="5.924285995913057" />
+      <entry key="S60" value="5.962005596693292" />
+      <entry key="M2" value="6.017766704529044" />
+      <entry key="M5" value="12.765494996790512" />
+      <entry key="M10" value="51.04982238462056" />
+      <entry key="M15" value="97.05341450757211" />
+      <entry key="M30" value="209.7930858656973" />
+      <entry key="H1" value="363.16258615137025" />
+      <entry key="H2" value="626.1946758149811" />
+      <entry key="H4" value="1067.7656358548645" />
+      <entry key="D1" value="2122.3509875132245" />
+      <entry key="W1" value="2446.6379694300217" />
     </decayedCancelled>
     <decayedSelected>
       <entry key="MS100" value="0.0" />
@@ -59,37 +59,37 @@
       <entry key="S2" value="0.0" />
       <entry key="S5" value="0.0" />
       <entry key="S10" value="0.0" />
-      <entry key="S30" value="6.3756516009774064E-177" />
-      <entry key="S60" value="7.984767749269458E-89" />
-      <entry key="M2" value="8.935752765866643E-45" />
-      <entry key="M5" value="2.4013333792131237E-18" />
-      <entry key="M10" value="1.5496470130816418E-9" />
-      <entry key="M15" value="1.3404225900433845E-6" />
-      <entry key="M30" value="0.001235588386519181" />
-      <entry key="H1" value="0.053670344718141486" />
-      <entry key="H2" value="0.49735923981220254" />
-      <entry key="H4" value="1.679768547026817" />
-      <entry key="D1" value="4.837034072494256" />
-      <entry key="W1" value="5.8177165397087185" />
+      <entry key="S30" value="8.517971682327512E-189" />
+      <entry key="S60" value="9.229285824118492E-95" />
+      <entry key="M2" value="9.606917207990474E-48" />
+      <entry key="M5" value="1.5596732342298997E-19" />
+      <entry key="M10" value="3.9493294545596293E-10" />
+      <entry key="M15" value="5.388097661122272E-7" />
+      <entry key="M30" value="7.833767500224175E-4" />
+      <entry key="H1" value="0.0427349120834577" />
+      <entry key="H2" value="0.4438072633588932" />
+      <entry key="H4" value="1.5867611273808555" />
+      <entry key="D1" value="4.791330892168272" />
+      <entry key="W1" value="5.8098318031533065" />
     </decayedSelected>
     <decayedShown>
-      <entry key="MS100" value="1.2515064828119893" />
-      <entry key="MS500" value="3.661060536129946" />
-      <entry key="S2" value="5.82761668696352" />
-      <entry key="S5" value="6.493929130083304" />
-      <entry key="S10" value="6.740287794693428" />
-      <entry key="S30" value="7.000255393002799" />
-      <entry key="S60" value="10.866856740179317" />
-      <entry key="M2" value="34.2248666616155" />
-      <entry key="M5" value="104.25438274327543" />
-      <entry key="M10" value="176.75656159100828" />
-      <entry key="M15" value="226.50253358578144" />
-      <entry key="M30" value="321.42393265696273" />
-      <entry key="H1" value="448.60311217253667" />
-      <entry key="H2" value="695.5228152446696" />
-      <entry key="H4" value="1125.6766788068073" />
-      <entry key="D1" value="2141.3741614063" />
-      <entry key="W1" value="2449.767778498949" />
+      <entry key="MS100" value="1.0419095742338873" />
+      <entry key="MS500" value="2.954107406809527" />
+      <entry key="S2" value="4.935890534285329" />
+      <entry key="S5" value="5.541889584445667" />
+      <entry key="S10" value="5.765142762193097" />
+      <entry key="S30" value="5.920386321636286" />
+      <entry key="S60" value="5.960037255659264" />
+      <entry key="M2" value="6.016765539753794" />
+      <entry key="M5" value="12.763331277415114" />
+      <entry key="M10" value="51.04301335648014" />
+      <entry key="M15" value="97.04456435351116" />
+      <entry key="M30" value="209.78500260350518" />
+      <entry key="H1" value="363.1987240354261" />
+      <entry key="H2" value="626.6337113056967" />
+      <entry key="H4" value="1069.3487084405817" />
+      <entry key="D1" value="2127.141154397182" />
+      <entry key="W1" value="2452.447610423848" />
     </decayedShown>
   </component>
   <component name="ProjectColorInfo">{

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,21 +5,62 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/animated-hero-image/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/animated-hero-image/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/button/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/button/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/divider/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/divider/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/focus-item/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/focus-item/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/grid-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/grid-focus-group/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/horizontal-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/horizontal-focus-group/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-history-bridge/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-history-bridge/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-layer/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-layer/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/route-anchor/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/route-anchor/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/scroll-area/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/scroll-area/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/source-anchor/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/source-anchor/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/typography/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/typography/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-focus-group/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/header/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/header/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/virtual-keyboard/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/virtual-keyboard/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/modals/download-game/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/modals/download-game/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/providers/navigation-input.provider.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/providers/navigation-input.provider.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/sidebar/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/sidebar/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/use-big-picture-downloads-page-data.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/use-big-picture-downloads-page-data.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.scss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/styles.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/styles.scss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/page.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/page.scss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/settings/integrations.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/settings/integrations.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/types/focus-item-actions.types.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/types/focus-item-actions.types.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/locales/en/translation.json" beforeDir="false" afterPath="$PROJECT_DIR$/src/locales/en/translation.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/index.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/main.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/main.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/services/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/services/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/services/achievements/parse-achievement-file.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/services/achievements/parse-achievement-file.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/services/crack-calendar.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/services/crack-calendar.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/preload/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/preload/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/avatar/avatar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/avatar/avatar.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/button/button.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/button/button.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/checkbox-field/checkbox-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/checkbox-field/checkbox-field.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/game-card/game-card.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/game-card/game-card.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/sidebar/routes.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/sidebar/routes.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/declaration.d.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/features/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/features/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/radio-field/radio-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/radio-field/radio-field.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/select-field/select-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/select-field/select-field.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/text-field/text-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/text-field/text-field.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/main.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/main.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/store.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/store.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-files-modal/cloud-sync-files-modal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-files-modal/cloud-sync-files-modal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-rename-artifact-modal/cloud-sync-rename-artifact-modal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-rename-artifact-modal/cloud-sync-rename-artifact-modal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/shared/download-directories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/shared/download-directories.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/types/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/index.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -171,6 +212,7 @@
       <updated>1780647080566</updated>
       <workItem from="1780647166927" duration="25071000" />
       <workItem from="1780737863219" duration="8157000" />
+      <workItem from="1780755895943" duration="15333000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,62 +6,31 @@
   <component name="ChangeListManager">
     <list default="true" id="4faaa42d-095c-4a5c-9e9a-d2ea35b5cb66" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/animated-hero-image/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/animated-hero-image/index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/button/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/button/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/divider/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/divider/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/focus-item/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/focus-item/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/grid-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/grid-focus-group/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/horizontal-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/horizontal-focus-group/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-history-bridge/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-history-bridge/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-layer/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/navigation-layer/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/route-anchor/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/route-anchor/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/scroll-area/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/scroll-area/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/source-anchor/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/source-anchor/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/typography/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/typography/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-focus-group/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-focus-group/index.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/vertical-game-card/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/common/virtual-keyboard/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/common/virtual-keyboard/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/modals/download-game/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/modals/download-game/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/providers/navigation-input.provider.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/providers/navigation-input.provider.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/components/pages/library/game-card.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/components/pages/library/game-card.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/layout/navigation.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/downloads.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/use-big-picture-downloads-page-data.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/downloads/use-big-picture-downloads-page-data.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/game/game.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/styles.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar-detail/styles.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation-geometry.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/navigation-geometry.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/page.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/page.scss" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/release-calendar.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/settings/integrations.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/settings/integrations.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/big-picture/src/types/focus-item-actions.types.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/types/focus-item-actions.types.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/locales/en/translation.json" beforeDir="false" afterPath="$PROJECT_DIR$/src/locales/en/translation.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-game.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-month.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/get-crack-calendar-months.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/events/catalogue/search-crack-calendar.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/index.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/services/achievements/parse-achievement-file.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/services/achievements/parse-achievement-file.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/services/crack-calendar.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/services/crack-calendar.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/preload/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/preload/index.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/avatar/avatar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/avatar/avatar.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/button/button.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/button/button.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/checkbox-field/checkbox-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/checkbox-field/checkbox-field.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/game-card/game-card.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/game-card/game-card.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/header/header.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/radio-field/radio-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/radio-field/radio-field.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/select-field/select-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/select-field/select-field.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/components/text-field/text-field.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/components/text-field/text-field.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/features/crack-calendar-slice.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/main.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/main.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/crack-calendar/crack-calendar.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-files-modal/cloud-sync-files-modal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-files-modal/cloud-sync-files-modal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-rename-artifact-modal/cloud-sync-rename-artifact-modal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/pages/game-details/cloud-sync-rename-artifact-modal/cloud-sync-rename-artifact-modal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/shared/download-directories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/shared/download-directories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/utils/format-countdown.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/utils/format-countdown.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/renderer/src/utils/get-last-updated-label.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/renderer/src/utils/get-last-updated-label.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -89,23 +58,23 @@
   </component>
   <component name="NextEditCompletionFeaturesState">
     <decayedCancelled>
-      <entry key="MS100" value="1.5568160620494413" />
-      <entry key="MS500" value="3.4973545144555755" />
-      <entry key="S2" value="5.772933653820631" />
-      <entry key="S5" value="9.778223659426049" />
-      <entry key="S10" value="12.915696965994156" />
-      <entry key="S30" value="16.159995663755467" />
-      <entry key="S60" value="18.288970357131113" />
-      <entry key="M2" value="21.87393365849303" />
-      <entry key="M5" value="27.646458333674676" />
-      <entry key="M10" value="31.840974822859458" />
-      <entry key="M15" value="37.193836373335174" />
-      <entry key="M30" value="69.38499383977472" />
-      <entry key="H1" value="171.38592136836013" />
-      <entry key="H2" value="423.76276458671487" />
-      <entry key="H4" value="842.1990372254384" />
-      <entry key="D1" value="1725.422583070427" />
-      <entry key="W1" value="1976.1208600822806" />
+      <entry key="MS100" value="1.0000042659919073" />
+      <entry key="MS500" value="1.1508542210840234" />
+      <entry key="S2" value="3.682866185075442" />
+      <entry key="S5" value="8.360369439461671" />
+      <entry key="S10" value="12.478255886956058" />
+      <entry key="S30" value="17.086977874723818" />
+      <entry key="S60" value="19.674586148214267" />
+      <entry key="M2" value="23.50554123293859" />
+      <entry key="M5" value="29.46038620526541" />
+      <entry key="M10" value="33.73396028631832" />
+      <entry key="M15" value="39.1106850087327" />
+      <entry key="M30" value="71.30798649051447" />
+      <entry key="H1" value="173.2912933173271" />
+      <entry key="H2" value="425.6460144155076" />
+      <entry key="H4" value="844.0830976150826" />
+      <entry key="D1" value="1727.3830080150897" />
+      <entry key="W1" value="1978.114385289754" />
     </decayedCancelled>
     <decayedSelected>
       <entry key="MS100" value="0.0" />
@@ -113,37 +82,37 @@
       <entry key="S2" value="0.0" />
       <entry key="S5" value="0.0" />
       <entry key="S10" value="0.0" />
-      <entry key="S30" value="1.4765044132682765E-130" />
-      <entry key="S60" value="1.2151149794436244E-65" />
-      <entry key="M2" value="3.4858499385997643E-33" />
-      <entry key="M5" value="1.0397369424428997E-13" />
-      <entry key="M10" value="3.224543886559706E-7" />
-      <entry key="M15" value="4.706868632645013E-5" />
-      <entry key="M30" value="0.007321818975511219" />
-      <entry key="H1" value="0.13064926459370985" />
-      <entry key="H2" value="0.7759906402147628" />
-      <entry key="H4" value="2.0981792667195096" />
-      <entry key="D1" value="5.019702794686253" />
-      <entry key="W1" value="5.8486063821520995" />
+      <entry key="S30" value="1.3821546053270716E-130" />
+      <entry key="S60" value="1.1756507157004902E-65" />
+      <entry key="M2" value="3.428776335225826E-33" />
+      <entry key="M5" value="1.0328937809580235E-13" />
+      <entry key="M10" value="3.213914995117997E-7" />
+      <entry key="M15" value="4.6965196091612825E-5" />
+      <entry key="M30" value="0.007313765280017183" />
+      <entry key="H1" value="0.13057739045267103" />
+      <entry key="H2" value="0.775777162803691" />
+      <entry key="H4" value="2.0978906390837695" />
+      <entry key="D1" value="5.019587702200899" />
+      <entry key="W1" value="5.848587225148292" />
     </decayedSelected>
     <decayedShown>
-      <entry key="MS100" value="1.4777513644808247" />
-      <entry key="MS500" value="3.439358352553395" />
-      <entry key="S2" value="5.730687450055871" />
-      <entry key="S5" value="9.723223691248897" />
-      <entry key="S10" value="12.869959467831544" />
-      <entry key="S30" value="16.138144675256502" />
-      <entry key="S60" value="18.276907193809418" />
-      <entry key="M2" value="21.86746203786116" />
-      <entry key="M5" value="27.64364326370813" />
-      <entry key="M10" value="31.839487851810347" />
-      <entry key="M15" value="37.19283212906292" />
-      <entry key="M30" value="69.3915717565589" />
-      <entry key="H1" value="171.51558786153987" />
-      <entry key="H2" value="424.53700532525164" />
-      <entry key="H4" value="844.2950775079505" />
-      <entry key="D1" value="1730.4414578390108" />
-      <entry key="W1" value="1981.9693288591448" />
+      <entry key="MS100" value="0.026830176063445003" />
+      <entry key="MS500" value="0.5694373907136285" />
+      <entry key="S2" value="3.3342073810268307" />
+      <entry key="S5" value="8.145528718860023" />
+      <entry key="S10" value="12.341806632269778" />
+      <entry key="S30" value="17.031015259682032" />
+      <entry key="S60" value="19.64482338404342" />
+      <entry key="M2" value="23.490043860738684" />
+      <entry key="M5" value="29.453916118042947" />
+      <entry key="M10" value="33.7306379492562" />
+      <entry key="M15" value="39.108455349537635" />
+      <entry key="M30" value="71.31394297104347" />
+      <entry key="H1" value="173.4205812792092" />
+      <entry key="H2" value="426.4198885347745" />
+      <entry key="H4" value="846.1787727464783" />
+      <entry key="D1" value="1732.4017549063738" />
+      <entry key="W1" value="1983.9628330809298" />
     </decayedShown>
   </component>
   <component name="ProjectColorInfo">{

--- a/electron.vite.config.1780776253087.mjs
+++ b/electron.vite.config.1780776253087.mjs
@@ -1,0 +1,139 @@
+// electron.vite.config.ts
+import react from "@vitejs/plugin-react";
+import {
+  defineConfig,
+  externalizeDepsPlugin,
+  loadEnv,
+  swcPlugin
+} from "electron-vite";
+import { resolve } from "path";
+import svgr from "vite-plugin-svgr";
+
+// src/big-picture/vite-scope-big-picture-css.ts
+var BIG_PICTURE_ROOT_SELECTOR = "#big-picture";
+var BIG_PICTURE_PATH_FRAGMENT = "/src/big-picture/";
+var RENDERER_PATH_FRAGMENT = "/src/renderer/";
+var ROOT_SELECTOR_ALIASES = /* @__PURE__ */ new Set([":root", "html", "body", "#root"]);
+var isBigPictureStyle = (filePath) => {
+  if (!filePath) return false;
+  return filePath.replaceAll("\\", "/").includes(BIG_PICTURE_PATH_FRAGMENT);
+};
+var isRendererStyle = (filePath) => {
+  if (!filePath) return false;
+  return filePath.replaceAll("\\", "/").includes(RENDERER_PATH_FRAGMENT);
+};
+var shouldSkipRule = (rule) => {
+  const parent = rule.parent;
+  return parent?.type === "atrule" && "name" in parent && parent.name.toLowerCase().endsWith("keyframes");
+};
+var shouldSkipExclusion = (selector) => {
+  const trimmed = selector.trim();
+  if (!trimmed) return true;
+  if (trimmed === "*") return true;
+  if (ROOT_SELECTOR_ALIASES.has(trimmed)) return true;
+  if (trimmed.includes("::")) return true;
+  return false;
+};
+var scopeSelector = (selector) => {
+  const trimmedSelector = selector.trim();
+  if (!trimmedSelector) return selector;
+  if (trimmedSelector === BIG_PICTURE_ROOT_SELECTOR || trimmedSelector.startsWith(`${BIG_PICTURE_ROOT_SELECTOR} `) || trimmedSelector.startsWith(`${BIG_PICTURE_ROOT_SELECTOR}:`)) {
+    return selector;
+  }
+  if (ROOT_SELECTOR_ALIASES.has(trimmedSelector)) {
+    return BIG_PICTURE_ROOT_SELECTOR;
+  }
+  return `${BIG_PICTURE_ROOT_SELECTOR} ${selector}`;
+};
+var excludeFromBigPicture = (selector) => {
+  if (shouldSkipExclusion(selector)) {
+    return selector;
+  }
+  return `${selector}:where(:not(${BIG_PICTURE_ROOT_SELECTOR} *))`;
+};
+var scopeBigPictureCss = () => ({
+  postcssPlugin: "scope-big-picture-css",
+  Rule(rule) {
+    if (shouldSkipRule(rule)) {
+      return;
+    }
+    if (isBigPictureStyle(rule.source?.input.file)) {
+      rule.selectors = rule.selectors.map(scopeSelector);
+      return;
+    }
+    if (isRendererStyle(rule.source?.input.file)) {
+      rule.selectors = rule.selectors.map(excludeFromBigPicture);
+    }
+  }
+});
+
+// electron.vite.config.ts
+var electron_vite_config_default = defineConfig(({ mode }) => {
+  loadEnv(mode);
+  return {
+    main: {
+      build: {
+        sourcemap: true
+      },
+      resolve: {
+        alias: {
+          "@main": resolve("src/main"),
+          "@locales": resolve("src/locales"),
+          "@resources": resolve("resources"),
+          "@shared": resolve("src/shared")
+        }
+      },
+      plugins: [externalizeDepsPlugin(), swcPlugin()]
+    },
+    preload: {
+      plugins: [externalizeDepsPlugin()]
+    },
+    bigPicture: {
+      root: "src/big-picture",
+      build: {
+        outDir: "out/big-picture",
+        rollupOptions: {
+          input: resolve("src/big-picture/index.html")
+        }
+      },
+      css: {
+        postcss: {
+          plugins: [scopeBigPictureCss()]
+        }
+      },
+      resolve: {
+        alias: {
+          "@locales": resolve("src/locales"),
+          "@shared": resolve("src/shared")
+        }
+      },
+      plugins: [react()]
+    },
+    renderer: {
+      build: {
+        sourcemap: true
+      },
+      css: {
+        postcss: {
+          plugins: [scopeBigPictureCss()]
+        },
+        preprocessorOptions: {
+          scss: {
+            api: "modern"
+          }
+        }
+      },
+      resolve: {
+        alias: {
+          "@renderer": resolve("src/renderer/src"),
+          "@locales": resolve("src/locales"),
+          "@shared": resolve("src/shared")
+        }
+      },
+      plugins: [svgr(), react()]
+    }
+  };
+});
+export {
+  electron_vite_config_default as default
+};

--- a/electron.vite.config.1780776253087.mjs
+++ b/electron.vite.config.1780776253087.mjs
@@ -4,7 +4,7 @@ import {
   defineConfig,
   externalizeDepsPlugin,
   loadEnv,
-  swcPlugin
+  swcPlugin,
 } from "electron-vite";
 import { resolve } from "path";
 import svgr from "vite-plugin-svgr";
@@ -13,7 +13,12 @@ import svgr from "vite-plugin-svgr";
 var BIG_PICTURE_ROOT_SELECTOR = "#big-picture";
 var BIG_PICTURE_PATH_FRAGMENT = "/src/big-picture/";
 var RENDERER_PATH_FRAGMENT = "/src/renderer/";
-var ROOT_SELECTOR_ALIASES = /* @__PURE__ */ new Set([":root", "html", "body", "#root"]);
+var ROOT_SELECTOR_ALIASES = /* @__PURE__ */ new Set([
+  ":root",
+  "html",
+  "body",
+  "#root",
+]);
 var isBigPictureStyle = (filePath) => {
   if (!filePath) return false;
   return filePath.replaceAll("\\", "/").includes(BIG_PICTURE_PATH_FRAGMENT);
@@ -24,7 +29,11 @@ var isRendererStyle = (filePath) => {
 };
 var shouldSkipRule = (rule) => {
   const parent = rule.parent;
-  return parent?.type === "atrule" && "name" in parent && parent.name.toLowerCase().endsWith("keyframes");
+  return (
+    parent?.type === "atrule" &&
+    "name" in parent &&
+    parent.name.toLowerCase().endsWith("keyframes")
+  );
 };
 var shouldSkipExclusion = (selector) => {
   const trimmed = selector.trim();
@@ -37,7 +46,11 @@ var shouldSkipExclusion = (selector) => {
 var scopeSelector = (selector) => {
   const trimmedSelector = selector.trim();
   if (!trimmedSelector) return selector;
-  if (trimmedSelector === BIG_PICTURE_ROOT_SELECTOR || trimmedSelector.startsWith(`${BIG_PICTURE_ROOT_SELECTOR} `) || trimmedSelector.startsWith(`${BIG_PICTURE_ROOT_SELECTOR}:`)) {
+  if (
+    trimmedSelector === BIG_PICTURE_ROOT_SELECTOR ||
+    trimmedSelector.startsWith(`${BIG_PICTURE_ROOT_SELECTOR} `) ||
+    trimmedSelector.startsWith(`${BIG_PICTURE_ROOT_SELECTOR}:`)
+  ) {
     return selector;
   }
   if (ROOT_SELECTOR_ALIASES.has(trimmedSelector)) {
@@ -64,7 +77,7 @@ var scopeBigPictureCss = () => ({
     if (isRendererStyle(rule.source?.input.file)) {
       rule.selectors = rule.selectors.map(excludeFromBigPicture);
     }
-  }
+  },
 });
 
 // electron.vite.config.ts
@@ -73,67 +86,65 @@ var electron_vite_config_default = defineConfig(({ mode }) => {
   return {
     main: {
       build: {
-        sourcemap: true
+        sourcemap: true,
       },
       resolve: {
         alias: {
           "@main": resolve("src/main"),
           "@locales": resolve("src/locales"),
           "@resources": resolve("resources"),
-          "@shared": resolve("src/shared")
-        }
+          "@shared": resolve("src/shared"),
+        },
       },
-      plugins: [externalizeDepsPlugin(), swcPlugin()]
+      plugins: [externalizeDepsPlugin(), swcPlugin()],
     },
     preload: {
-      plugins: [externalizeDepsPlugin()]
+      plugins: [externalizeDepsPlugin()],
     },
     bigPicture: {
       root: "src/big-picture",
       build: {
         outDir: "out/big-picture",
         rollupOptions: {
-          input: resolve("src/big-picture/index.html")
-        }
+          input: resolve("src/big-picture/index.html"),
+        },
       },
       css: {
         postcss: {
-          plugins: [scopeBigPictureCss()]
-        }
+          plugins: [scopeBigPictureCss()],
+        },
       },
       resolve: {
         alias: {
           "@locales": resolve("src/locales"),
-          "@shared": resolve("src/shared")
-        }
+          "@shared": resolve("src/shared"),
+        },
       },
-      plugins: [react()]
+      plugins: [react()],
     },
     renderer: {
       build: {
-        sourcemap: true
+        sourcemap: true,
       },
       css: {
         postcss: {
-          plugins: [scopeBigPictureCss()]
+          plugins: [scopeBigPictureCss()],
         },
         preprocessorOptions: {
           scss: {
-            api: "modern"
-          }
-        }
+            api: "modern",
+          },
+        },
       },
       resolve: {
         alias: {
           "@renderer": resolve("src/renderer/src"),
           "@locales": resolve("src/locales"),
-          "@shared": resolve("src/shared")
-        }
+          "@shared": resolve("src/shared"),
+        },
       },
-      plugins: [svgr(), react()]
-    }
+      plugins: [svgr(), react()],
+    },
   };
 });
-export {
-  electron_vite_config_default as default
-};
+export { electron_vite_config_default as default };

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "react-dom": "^18.2.0",
     "sass-embedded": "^1.80.6",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3",
+    "typescript": "~5.5.4",
     "vite": "6.4.2",
     "vite-plugin-svgr": "^4.5.0"
   },

--- a/src/big-picture/src/components/common/animated-hero-image/index.tsx
+++ b/src/big-picture/src/components/common/animated-hero-image/index.tsx
@@ -3,8 +3,10 @@ import "./styles.scss";
 import { motion, type HTMLMotionProps } from "framer-motion";
 import { useCallback, useEffect, useRef } from "react";
 
-export interface AnimatedHeroImageProps
-  extends Omit<HTMLMotionProps<"img">, "src"> {
+export interface AnimatedHeroImageProps extends Omit<
+  HTMLMotionProps<"img">,
+  "src"
+> {
   imageUrl: string;
 }
 

--- a/src/big-picture/src/components/common/button/index.tsx
+++ b/src/big-picture/src/components/common/button/index.tsx
@@ -83,103 +83,128 @@ export const Button = forwardRef<
     },
     ref
   ) => {
-  const isEffectivelyDisabled = disabled || loading;
-  const buttonClassName = cn(
-    "button",
-    variants[variant],
-    sizes[size],
-    className,
-    {
-      "button--disabled": isEffectivelyDisabled,
-    }
-  );
-
-  const buttonStyle = {
-    ...style,
-    ...(color
-      ? {
-          "--button-custom-color": color,
-          "--button-custom-hover-color": `color-mix(in srgb, ${color} 80%, white)`,
-          "--button-custom-text-color": getContrastTextColor(color),
-        }
-      : {}),
-  } as CSSProperties;
-
-  const handleLinkClick = (event: ReactMouseEvent<HTMLElement>) => {
-    if (isEffectivelyDisabled) {
-      event.preventDefault();
-      return;
-    }
-
-    onClick?.(event as never);
-  };
-
-  if (!href) {
-    return (
-      <FocusItem
-        id={focusId}
-        focusable={focusable}
-        navigationState={disabled ? "disabled" : "active"}
-        navigationOverrides={focusNavigationOverrides}
-        asChild
-      >
-        <button
-          ref={ref as React.Ref<HTMLButtonElement>}
-          onClick={(event) => {
-            if (isEffectivelyDisabled) {
-              event.preventDefault();
-              return;
-            }
-
-            onClick?.(event);
-          }}
-          disabled={disabled}
-          aria-busy={loading}
-          aria-disabled={isEffectivelyDisabled}
-          aria-label={size === "icon" ? ariaLabel : undefined}
-          className={buttonClassName}
-          style={buttonStyle}
-          {...props}
-        >
-          {loading && (
-            <div
-              className={`button__icon-container--${iconPosition} button__icon-container`}
-            >
-              <SpinnerIcon size={20} className="button__loading-icon" />
-            </div>
-          )}
-
-          {icon && !loading && (
-            <div
-              className={`button__icon-container--${iconPosition} button__icon-container`}
-            >
-              {icon}
-            </div>
-          )}
-
-          {children && (!loading || typeof children === "string") && (
-            <p className="button__text">{children}</p>
-          )}
-        </button>
-      </FocusItem>
+    const isEffectivelyDisabled = disabled || loading;
+    const buttonClassName = cn(
+      "button",
+      variants[variant],
+      sizes[size],
+      className,
+      {
+        "button--disabled": isEffectivelyDisabled,
+      }
     );
-  }
 
-  const linkContent = (
-    <>
-      {icon && (
-        <div
-          className={`button__icon-container--${iconPosition} button__icon-container`}
+    const buttonStyle = {
+      ...style,
+      ...(color
+        ? {
+            "--button-custom-color": color,
+            "--button-custom-hover-color": `color-mix(in srgb, ${color} 80%, white)`,
+            "--button-custom-text-color": getContrastTextColor(color),
+          }
+        : {}),
+    } as CSSProperties;
+
+    const handleLinkClick = (event: ReactMouseEvent<HTMLElement>) => {
+      if (isEffectivelyDisabled) {
+        event.preventDefault();
+        return;
+      }
+
+      onClick?.(event as never);
+    };
+
+    if (!href) {
+      return (
+        <FocusItem
+          id={focusId}
+          focusable={focusable}
+          navigationState={disabled ? "disabled" : "active"}
+          navigationOverrides={focusNavigationOverrides}
+          asChild
         >
-          {icon}
-        </div>
-      )}
+          <button
+            ref={ref as React.Ref<HTMLButtonElement>}
+            onClick={(event) => {
+              if (isEffectivelyDisabled) {
+                event.preventDefault();
+                return;
+              }
 
-      {children && <p className="button__text">{children}</p>}
-    </>
-  );
+              onClick?.(event);
+            }}
+            disabled={disabled}
+            aria-busy={loading}
+            aria-disabled={isEffectivelyDisabled}
+            aria-label={size === "icon" ? ariaLabel : undefined}
+            className={buttonClassName}
+            style={buttonStyle}
+            {...props}
+          >
+            {loading && (
+              <div
+                className={`button__icon-container--${iconPosition} button__icon-container`}
+              >
+                <SpinnerIcon size={20} className="button__loading-icon" />
+              </div>
+            )}
 
-  if (target === "_blank" || isExternalHref(href)) {
+            {icon && !loading && (
+              <div
+                className={`button__icon-container--${iconPosition} button__icon-container`}
+              >
+                {icon}
+              </div>
+            )}
+
+            {children && (!loading || typeof children === "string") && (
+              <p className="button__text">{children}</p>
+            )}
+          </button>
+        </FocusItem>
+      );
+    }
+
+    const linkContent = (
+      <>
+        {icon && (
+          <div
+            className={`button__icon-container--${iconPosition} button__icon-container`}
+          >
+            {icon}
+          </div>
+        )}
+
+        {children && <p className="button__text">{children}</p>}
+      </>
+    );
+
+    if (target === "_blank" || isExternalHref(href)) {
+      return (
+        <FocusItem
+          id={focusId}
+          focusable={focusable}
+          navigationState={disabled ? "disabled" : "active"}
+          navigationOverrides={focusNavigationOverrides}
+          asChild
+        >
+          <a
+            ref={ref as React.Ref<HTMLAnchorElement>}
+            href={href}
+            target={target}
+            rel={target === "_blank" ? "noreferrer" : undefined}
+            aria-label={size === "icon" ? ariaLabel : undefined}
+            aria-disabled={isEffectivelyDisabled}
+            className={buttonClassName}
+            style={buttonStyle}
+            onClick={handleLinkClick as never}
+          >
+            {linkContent}
+          </a>
+        </FocusItem>
+      );
+    }
+
     return (
       <FocusItem
         id={focusId}
@@ -188,11 +213,9 @@ export const Button = forwardRef<
         navigationOverrides={focusNavigationOverrides}
         asChild
       >
-        <a
+        <Link
           ref={ref as React.Ref<HTMLAnchorElement>}
-          href={href}
-          target={target}
-          rel={target === "_blank" ? "noreferrer" : undefined}
+          to={href}
           aria-label={size === "icon" ? ariaLabel : undefined}
           aria-disabled={isEffectivelyDisabled}
           className={buttonClassName}
@@ -200,31 +223,10 @@ export const Button = forwardRef<
           onClick={handleLinkClick as never}
         >
           {linkContent}
-        </a>
+        </Link>
       </FocusItem>
     );
   }
-
-  return (
-    <FocusItem
-      id={focusId}
-      focusable={focusable}
-      navigationState={disabled ? "disabled" : "active"}
-      navigationOverrides={focusNavigationOverrides}
-      asChild
-    >
-      <Link
-        ref={ref as React.Ref<HTMLAnchorElement>}
-        to={href}
-        aria-label={size === "icon" ? ariaLabel : undefined}
-        aria-disabled={isEffectivelyDisabled}
-        className={buttonClassName}
-        style={buttonStyle}
-        onClick={handleLinkClick as never}
-      >
-        {linkContent}
-      </Link>
-    </FocusItem>
-  );
-}
 );
+
+Button.displayName = "Button";

--- a/src/big-picture/src/components/common/button/index.tsx
+++ b/src/big-picture/src/components/common/button/index.tsx
@@ -3,11 +3,12 @@ import "./styles.scss";
 import { SpinnerIcon } from "@phosphor-icons/react";
 import cn from "classnames";
 import { Link } from "react-router-dom";
-import type {
-  ButtonHTMLAttributes,
-  CSSProperties,
-  MouseEvent as ReactMouseEvent,
-  ReactNode,
+import {
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  forwardRef,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
 } from "react";
 import { getContrastTextColor } from "../../../helpers";
 import { FocusItem } from "..";
@@ -29,8 +30,10 @@ const sizes = {
   large: "button--large",
 };
 
-export interface ButtonProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+export interface ButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> {
   loading?: boolean;
   variant?: keyof typeof variants;
   size?: keyof typeof sizes;
@@ -53,26 +56,33 @@ function isExternalHref(href: string) {
   );
 }
 
-export function Button({
-  loading = false,
-  disabled = false,
-  size = "medium",
-  variant = "primary",
-  iconPosition = "left",
-  href,
-  icon,
-  onClick,
-  children,
-  target,
-  className,
-  color,
-  style,
-  focusId,
-  focusable = true,
-  focusNavigationOverrides,
-  "aria-label": ariaLabel,
-  ...props
-}: Readonly<ButtonProps>) {
+export const Button = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  ButtonProps
+>(
+  (
+    {
+      loading = false,
+      disabled = false,
+      size = "medium",
+      variant = "primary",
+      iconPosition = "left",
+      href,
+      icon,
+      onClick,
+      children,
+      target,
+      className,
+      color,
+      style,
+      focusId,
+      focusable = true,
+      focusNavigationOverrides,
+      "aria-label": ariaLabel,
+      ...props
+    },
+    ref
+  ) => {
   const isEffectivelyDisabled = disabled || loading;
   const buttonClassName = cn(
     "button",
@@ -114,6 +124,7 @@ export function Button({
         asChild
       >
         <button
+          ref={ref as React.Ref<HTMLButtonElement>}
           onClick={(event) => {
             if (isEffectivelyDisabled) {
               event.preventDefault();
@@ -178,6 +189,7 @@ export function Button({
         asChild
       >
         <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
           href={href}
           target={target}
           rel={target === "_blank" ? "noreferrer" : undefined}
@@ -202,6 +214,7 @@ export function Button({
       asChild
     >
       <Link
+        ref={ref as React.Ref<HTMLAnchorElement>}
         to={href}
         aria-label={size === "icon" ? ariaLabel : undefined}
         aria-disabled={isEffectivelyDisabled}
@@ -214,3 +227,4 @@ export function Button({
     </FocusItem>
   );
 }
+);

--- a/src/big-picture/src/components/common/divider/index.tsx
+++ b/src/big-picture/src/components/common/divider/index.tsx
@@ -17,13 +17,15 @@ export const Divider = forwardRef<HTMLDivElement, Readonly<DividerProps>>(
           [`divider-container--${orientation}`]: true,
         })}
       >
-      <div
-        className={cn("divider", {
-          [`divider--${orientation}`]: true,
-        })}
-        style={{ backgroundColor: color }}
-      />
-    </div>
-  );
-}
+        <div
+          className={cn("divider", {
+            [`divider--${orientation}`]: true,
+          })}
+          style={{ backgroundColor: color }}
+        />
+      </div>
+    );
+  }
 );
+
+Divider.displayName = "Divider";

--- a/src/big-picture/src/components/common/divider/index.tsx
+++ b/src/big-picture/src/components/common/divider/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import "./styles.scss";
 
 import cn from "classnames";
@@ -7,16 +8,15 @@ export interface DividerProps {
   color?: string;
 }
 
-export function Divider({
-  orientation = "horizontal",
-  color,
-}: Readonly<DividerProps>) {
-  return (
-    <div
-      className={cn("divider-container", {
-        [`divider-container--${orientation}`]: true,
-      })}
-    >
+export const Divider = forwardRef<HTMLDivElement, Readonly<DividerProps>>(
+  ({ orientation = "horizontal", color }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("divider-container", {
+          [`divider-container--${orientation}`]: true,
+        })}
+      >
       <div
         className={cn("divider", {
           [`divider--${orientation}`]: true,
@@ -26,3 +26,4 @@ export function Divider({
     </div>
   );
 }
+);

--- a/src/big-picture/src/components/common/focus-item/index.tsx
+++ b/src/big-picture/src/components/common/focus-item/index.tsx
@@ -19,9 +19,11 @@ import { useNavigationIsFocused } from "../../../stores";
 import {
   type FocusEvent,
   type ReactNode,
+  forwardRef,
   useCallback,
   useEffect,
   useId,
+  useImperativeHandle,
   useMemo,
   useRef,
 } from "react";
@@ -38,27 +40,33 @@ interface FocusItemProps {
   children: ReactNode;
 }
 
-export function FocusItem({
-  id,
-  actions,
-  focusable = true,
-  navigationState: navigationStateProp = "active",
-  navigationOrder,
-  navigationOverrides,
-  asChild = false,
-  children,
-}: Readonly<FocusItemProps>) {
-  const effectiveNavigationState: NavigationNodeState =
-    !focusable && navigationStateProp === "active"
-      ? "hidden"
-      : navigationStateProp;
+export const FocusItem = forwardRef<HTMLDivElement, FocusItemProps>(
+  (
+    {
+      id,
+      actions,
+      focusable = true,
+      navigationState: navigationStateProp = "active",
+      navigationOrder,
+      navigationOverrides,
+      asChild = false,
+      children,
+    },
+    forwardedRef
+  ) => {
+    const effectiveNavigationState: NavigationNodeState =
+      !focusable && navigationStateProp === "active"
+        ? "hidden"
+        : navigationStateProp;
 
-  const generatedId = useId();
-  const regionId = useFocusRegionId();
-  const layerId = useFocusLayerId();
-  const navigation = NavigationService.getInstance();
-  const navigationItemActions = NavigationItemActionsService.getInstance();
-  const ref = useRef<HTMLDivElement | null>(null);
+    const generatedId = useId();
+    const regionId = useFocusRegionId();
+    const layerId = useFocusLayerId();
+    const navigation = NavigationService.getInstance();
+    const navigationItemActions = NavigationItemActionsService.getInstance();
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    useImperativeHandle(forwardedRef, () => ref.current!);
   const initialNavigationStateRef = useRef(effectiveNavigationState);
   const initialNavigationOrderRef = useRef(navigationOrder);
   const initialNavigationOverridesRef = useRef(navigationOverrides);
@@ -171,3 +179,4 @@ export function FocusItem({
     </FocusItemActionsMetaContext.Provider>
   );
 }
+);

--- a/src/big-picture/src/components/common/focus-item/index.tsx
+++ b/src/big-picture/src/components/common/focus-item/index.tsx
@@ -67,116 +67,118 @@ export const FocusItem = forwardRef<HTMLDivElement, FocusItemProps>(
     const ref = useRef<HTMLDivElement | null>(null);
 
     useImperativeHandle(forwardedRef, () => ref.current!);
-  const initialNavigationStateRef = useRef(effectiveNavigationState);
-  const initialNavigationOrderRef = useRef(navigationOrder);
-  const initialNavigationOverridesRef = useRef(navigationOverrides);
-  const resolvedId = id ?? `focus-item-${generatedId.replaceAll(":", "")}`;
-  const isFocused = useNavigationIsFocused(resolvedId);
+    const initialNavigationStateRef = useRef(effectiveNavigationState);
+    const initialNavigationOrderRef = useRef(navigationOrder);
+    const initialNavigationOverridesRef = useRef(navigationOverrides);
+    const resolvedId = id ?? `focus-item-${generatedId.replaceAll(":", "")}`;
+    const isFocused = useNavigationIsFocused(resolvedId);
 
-  const resolvedActions = useMemo(
-    () => resolveFocusItemActions(actions),
-    [actions]
-  );
+    const resolvedActions = useMemo(
+      () => resolveFocusItemActions(actions),
+      [actions]
+    );
 
-  const actionsMeta = useMemo(
-    () => getFocusItemActionsMeta(resolvedActions),
-    [resolvedActions]
-  );
+    const actionsMeta = useMemo(
+      () => getFocusItemActionsMeta(resolvedActions),
+      [resolvedActions]
+    );
 
-  if (!regionId) {
-    throw new Error("FocusItem must be rendered inside a focus group.");
-  }
+    if (!regionId) {
+      throw new Error("FocusItem must be rendered inside a focus group.");
+    }
 
-  useEffect(() => {
-    return navigation.registerNavigationNode({
-      id: resolvedId,
-      regionId,
-      layerId,
-      navigationState: initialNavigationStateRef.current,
-      navigationOrder: initialNavigationOrderRef.current,
-      navigationOverrides: initialNavigationOverridesRef.current,
-      getElement: () => ref.current,
-    });
-  }, [layerId, navigation, regionId, resolvedId]);
+    useEffect(() => {
+      return navigation.registerNavigationNode({
+        id: resolvedId,
+        regionId,
+        layerId,
+        navigationState: initialNavigationStateRef.current,
+        navigationOrder: initialNavigationOrderRef.current,
+        navigationOverrides: initialNavigationOverridesRef.current,
+        getElement: () => ref.current,
+      });
+    }, [layerId, navigation, regionId, resolvedId]);
 
-  useEffect(() => {
-    navigation.updateNavigationNode(resolvedId, {
-      navigationState: effectiveNavigationState,
+    useEffect(() => {
+      navigation.updateNavigationNode(resolvedId, {
+        navigationState: effectiveNavigationState,
+        navigationOrder,
+        navigationOverrides,
+      });
+    }, [
+      navigation,
+      effectiveNavigationState,
       navigationOrder,
       navigationOverrides,
-    });
-  }, [
-    navigation,
-    effectiveNavigationState,
-    navigationOrder,
-    navigationOverrides,
-    resolvedId,
-  ]);
+      resolvedId,
+    ]);
 
-  useEffect(() => {
-    return navigationItemActions.registerItemActions({
-      itemId: resolvedId,
-      actions: resolvedActions,
-      getElement: () => ref.current,
-    });
-  }, [navigationItemActions, resolvedActions, resolvedId]);
+    useEffect(() => {
+      return navigationItemActions.registerItemActions({
+        itemId: resolvedId,
+        actions: resolvedActions,
+        getElement: () => ref.current,
+      });
+    }, [navigationItemActions, resolvedActions, resolvedId]);
 
-  useEffect(() => {
-    if (!isFocused) return;
+    useEffect(() => {
+      if (!isFocused) return;
 
-    const element = ref.current;
+      const element = ref.current;
 
-    if (!element) return;
+      if (!element) return;
 
-    try {
-      element.focus({ preventScroll: true });
-    } catch {
-      element.focus();
-    }
-  }, [isFocused]);
-
-  const handleDomFocus = useCallback(
-    (_event: FocusEvent<HTMLElement>) => {
-      if (effectiveNavigationState !== "active") {
-        return;
+      try {
+        element.focus({ preventScroll: true });
+      } catch {
+        element.focus();
       }
+    }, [isFocused]);
 
-      if (navigation.getCurrentFocusId() === resolvedId) {
-        return;
-      }
+    const handleDomFocus = useCallback(
+      (_event: FocusEvent<HTMLElement>) => {
+        if (effectiveNavigationState !== "active") {
+          return;
+        }
 
-      navigation.setFocus(resolvedId);
-    },
-    [effectiveNavigationState, navigation, resolvedId]
-  );
+        if (navigation.getCurrentFocusId() === resolvedId) {
+          return;
+        }
 
-  const Component = asChild ? Slot : "div";
+        navigation.setFocus(resolvedId);
+      },
+      [effectiveNavigationState, navigation, resolvedId]
+    );
 
-  return (
-    <FocusItemActionsMetaContext.Provider value={actionsMeta}>
-      <Component
-        id={resolvedId}
-        ref={ref}
-        data-focused={isFocused}
-        data-focus-visible={isFocused || undefined}
-        data-focus-wrapper={!asChild || undefined}
-        data-has-primary={actionsMeta.hasPrimary || undefined}
-        data-has-secondary={actionsMeta.hasSecondary || undefined}
-        data-has-press-x={actionsMeta.hasPressX || undefined}
-        data-has-press-y={actionsMeta.hasPressY || undefined}
-        data-has-hold-a={actionsMeta.hasHoldA || undefined}
-        data-has-hold-b={actionsMeta.hasHoldB || undefined}
-        data-has-hold-x={actionsMeta.hasHoldX || undefined}
-        data-has-hold-y={actionsMeta.hasHoldY || undefined}
-        data-navigation-state={effectiveNavigationState}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-        tabIndex={isFocused ? 0 : -1}
-        onFocus={handleDomFocus}
-        style={asChild ? undefined : { outline: "none" }}
-      >
-        {children}
-      </Component>
-    </FocusItemActionsMetaContext.Provider>
-  );
-}
+    const Component = asChild ? Slot : "div";
+
+    return (
+      <FocusItemActionsMetaContext.Provider value={actionsMeta}>
+        <Component
+          id={resolvedId}
+          ref={ref}
+          data-focused={isFocused}
+          data-focus-visible={isFocused || undefined}
+          data-focus-wrapper={!asChild || undefined}
+          data-has-primary={actionsMeta.hasPrimary || undefined}
+          data-has-secondary={actionsMeta.hasSecondary || undefined}
+          data-has-press-x={actionsMeta.hasPressX || undefined}
+          data-has-press-y={actionsMeta.hasPressY || undefined}
+          data-has-hold-a={actionsMeta.hasHoldA || undefined}
+          data-has-hold-b={actionsMeta.hasHoldB || undefined}
+          data-has-hold-x={actionsMeta.hasHoldX || undefined}
+          data-has-hold-y={actionsMeta.hasHoldY || undefined}
+          data-navigation-state={effectiveNavigationState}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={isFocused ? 0 : -1}
+          onFocus={handleDomFocus}
+          style={asChild ? undefined : { outline: "none" }}
+        >
+          {children}
+        </Component>
+      </FocusItemActionsMetaContext.Provider>
+    );
+  }
 );
+
+FocusItem.displayName = "FocusItem";

--- a/src/big-picture/src/components/common/grid-focus-group/index.tsx
+++ b/src/big-picture/src/components/common/grid-focus-group/index.tsx
@@ -30,10 +30,7 @@ interface GridFocusGroupProps {
   children: ReactNode;
 }
 
-export const GridFocusGroup = forwardRef<
-  HTMLDivElement,
-  GridFocusGroupProps
->(
+export const GridFocusGroup = forwardRef<HTMLDivElement, GridFocusGroupProps>(
   (
     {
       regionId,
@@ -56,57 +53,59 @@ export const GridFocusGroup = forwardRef<
     const ref = useRef<HTMLDivElement | null>(null);
 
     useImperativeHandle(forwardedRef, () => ref.current!);
-  const resolvedRegionId =
-    regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
+    const resolvedRegionId =
+      regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
 
-  useEffect(() => {
-    return navigation.registerRegion({
-      id: resolvedRegionId,
-      parentRegionId,
-      orientation: "grid",
-      layerId,
-      navigationOverrides: initialNavigationOverridesRef.current,
+    useEffect(() => {
+      return navigation.registerRegion({
+        id: resolvedRegionId,
+        parentRegionId,
+        orientation: "grid",
+        layerId,
+        navigationOverrides: initialNavigationOverridesRef.current,
+        autoScrollMode,
+        isPersistent: Boolean(regionId),
+        getElement: () => ref.current,
+        getScrollAnchor: initialGetScrollAnchorRef.current,
+      });
+    }, [
       autoScrollMode,
-      isPersistent: Boolean(regionId),
-      getElement: () => ref.current,
-      getScrollAnchor: initialGetScrollAnchorRef.current,
-    });
-  }, [
-    autoScrollMode,
-    layerId,
-    navigation,
-    parentRegionId,
-    regionId,
-    resolvedRegionId,
-  ]);
+      layerId,
+      navigation,
+      parentRegionId,
+      regionId,
+      resolvedRegionId,
+    ]);
 
-  useEffect(() => {
-    navigation.updateRegion(resolvedRegionId, {
+    useEffect(() => {
+      navigation.updateRegion(resolvedRegionId, {
+        autoScrollMode,
+        getScrollAnchor,
+        navigationOverrides,
+      });
+    }, [
       autoScrollMode,
       getScrollAnchor,
+      navigation,
       navigationOverrides,
-    });
-  }, [
-    autoScrollMode,
-    getScrollAnchor,
-    navigation,
-    navigationOverrides,
-    resolvedRegionId,
-  ]);
+      resolvedRegionId,
+    ]);
 
-  const Component = asChild ? Slot : "div";
+    const Component = asChild ? Slot : "div";
 
-  return (
-    <FocusRegionContext.Provider value={resolvedRegionId}>
-      <Component
-        ref={ref}
-        data-focus-region-id={resolvedRegionId}
-        className={className}
-        style={style}
-      >
-        {children}
-      </Component>
-    </FocusRegionContext.Provider>
-  );
-}
+    return (
+      <FocusRegionContext.Provider value={resolvedRegionId}>
+        <Component
+          ref={ref}
+          data-focus-region-id={resolvedRegionId}
+          className={className}
+          style={style}
+        >
+          {children}
+        </Component>
+      </FocusRegionContext.Provider>
+    );
+  }
 );
+
+GridFocusGroup.displayName = "GridFocusGroup";

--- a/src/big-picture/src/components/common/grid-focus-group/index.tsx
+++ b/src/big-picture/src/components/common/grid-focus-group/index.tsx
@@ -1,3 +1,4 @@
+import { Slot } from "@radix-ui/react-slot";
 import {
   FocusRegionContext,
   useFocusLayerId,
@@ -11,8 +12,10 @@ import {
 import {
   type CSSProperties,
   type ReactNode,
+  forwardRef,
   useEffect,
   useId,
+  useImperativeHandle,
   useRef,
 } from "react";
 
@@ -21,27 +24,38 @@ interface GridFocusGroupProps {
   navigationOverrides?: FocusOverrides;
   autoScrollMode?: FocusAutoScrollMode;
   getScrollAnchor?: () => HTMLElement | null;
+  asChild?: boolean;
   className?: string;
   style?: CSSProperties;
   children: ReactNode;
 }
 
-export function GridFocusGroup({
-  regionId,
-  navigationOverrides,
-  autoScrollMode = "row",
-  getScrollAnchor,
-  className,
-  style,
-  children,
-}: Readonly<GridFocusGroupProps>) {
-  const generatedId = useId();
-  const parentRegionId = useFocusRegionId();
-  const layerId = useFocusLayerId();
-  const navigation = NavigationService.getInstance();
-  const initialNavigationOverridesRef = useRef(navigationOverrides);
-  const initialGetScrollAnchorRef = useRef(getScrollAnchor);
-  const ref = useRef<HTMLDivElement | null>(null);
+export const GridFocusGroup = forwardRef<
+  HTMLDivElement,
+  GridFocusGroupProps
+>(
+  (
+    {
+      regionId,
+      navigationOverrides,
+      autoScrollMode = "row",
+      getScrollAnchor,
+      asChild = false,
+      className,
+      style,
+      children,
+    },
+    forwardedRef
+  ) => {
+    const generatedId = useId();
+    const parentRegionId = useFocusRegionId();
+    const layerId = useFocusLayerId();
+    const navigation = NavigationService.getInstance();
+    const initialNavigationOverridesRef = useRef(navigationOverrides);
+    const initialGetScrollAnchorRef = useRef(getScrollAnchor);
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    useImperativeHandle(forwardedRef, () => ref.current!);
   const resolvedRegionId =
     regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
 
@@ -80,16 +94,19 @@ export function GridFocusGroup({
     resolvedRegionId,
   ]);
 
+  const Component = asChild ? Slot : "div";
+
   return (
     <FocusRegionContext.Provider value={resolvedRegionId}>
-      <div
+      <Component
         ref={ref}
         data-focus-region-id={resolvedRegionId}
         className={className}
         style={style}
       >
         {children}
-      </div>
+      </Component>
     </FocusRegionContext.Provider>
   );
 }
+);

--- a/src/big-picture/src/components/common/horizontal-focus-group/index.tsx
+++ b/src/big-picture/src/components/common/horizontal-focus-group/index.tsx
@@ -58,70 +58,72 @@ export const HorizontalFocusGroup = forwardRef<
     const ref = useRef<HTMLDivElement | null>(null);
 
     useImperativeHandle(forwardedRef, () => ref.current!);
-  const resolvedRegionId =
-    regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
+    const resolvedRegionId =
+      regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
 
-  useEffect(() => {
-    return navigation.registerRegion({
-      id: resolvedRegionId,
-      parentRegionId,
-      orientation: "horizontal",
-      layerId,
-      navigationOrder: initialNavigationOrderRef.current,
-      navigationOverrides: initialNavigationOverridesRef.current,
+    useEffect(() => {
+      return navigation.registerRegion({
+        id: resolvedRegionId,
+        parentRegionId,
+        orientation: "horizontal",
+        layerId,
+        navigationOrder: initialNavigationOrderRef.current,
+        navigationOverrides: initialNavigationOverridesRef.current,
+        autoScrollMode,
+        isPersistent: Boolean(regionId),
+        getElement: () => ref.current,
+        getScrollAnchor: initialGetScrollAnchorRef.current,
+      });
+    }, [
       autoScrollMode,
-      isPersistent: Boolean(regionId),
-      getElement: () => ref.current,
-      getScrollAnchor: initialGetScrollAnchorRef.current,
-    });
-  }, [
-    autoScrollMode,
-    layerId,
-    navigation,
-    parentRegionId,
-    regionId,
-    resolvedRegionId,
-  ]);
+      layerId,
+      navigation,
+      parentRegionId,
+      regionId,
+      resolvedRegionId,
+    ]);
 
-  useEffect(() => {
-    navigation.updateRegion(resolvedRegionId, {
+    useEffect(() => {
+      navigation.updateRegion(resolvedRegionId, {
+        autoScrollMode,
+        getScrollAnchor,
+        navigationOrder,
+        navigationOverrides,
+      });
+    }, [
       autoScrollMode,
       getScrollAnchor,
+      navigation,
       navigationOrder,
       navigationOverrides,
-    });
-  }, [
-    autoScrollMode,
-    getScrollAnchor,
-    navigation,
-    navigationOrder,
-    navigationOverrides,
-    resolvedRegionId,
-  ]);
+      resolvedRegionId,
+    ]);
 
-  const Component = asChild ? Slot : "div";
+    const Component = asChild ? Slot : "div";
 
-  return (
-    <FocusRegionContext.Provider value={resolvedRegionId}>
-      <Component
-        ref={ref}
-        className={className}
-        data-focus-region-id={resolvedRegionId}
-        style={
-          asChild
-            ? style
-            : {
-                display: "flex",
-                alignItems: "center",
-                gap: 16,
-                ...style,
-              }
-        }
-        {...props}
-      >
-        {children}
-      </Component>
-    </FocusRegionContext.Provider>
-  );
-}
+    return (
+      <FocusRegionContext.Provider value={resolvedRegionId}>
+        <Component
+          ref={ref}
+          className={className}
+          data-focus-region-id={resolvedRegionId}
+          style={
+            asChild
+              ? style
+              : {
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 16,
+                  ...style,
+                }
+          }
+          {...props}
+        >
+          {children}
+        </Component>
+      </FocusRegionContext.Provider>
+    );
+  }
 );
+
+HorizontalFocusGroup.displayName = "HorizontalFocusGroup";

--- a/src/big-picture/src/components/common/horizontal-focus-group/index.tsx
+++ b/src/big-picture/src/components/common/horizontal-focus-group/index.tsx
@@ -12,8 +12,10 @@ import {
 import {
   type HTMLAttributes,
   type ReactNode,
+  forwardRef,
   useEffect,
   useId,
+  useImperativeHandle,
   useRef,
 } from "react";
 
@@ -27,26 +29,35 @@ interface HorizontalFocusGroupProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
-export function HorizontalFocusGroup({
-  regionId,
-  navigationOrder,
-  navigationOverrides,
-  autoScrollMode = "region",
-  getScrollAnchor,
-  asChild = false,
-  className,
-  style,
-  children,
-  ...props
-}: Readonly<HorizontalFocusGroupProps>) {
-  const generatedId = useId();
-  const parentRegionId = useFocusRegionId();
-  const layerId = useFocusLayerId();
-  const navigation = NavigationService.getInstance();
-  const initialNavigationOrderRef = useRef(navigationOrder);
-  const initialNavigationOverridesRef = useRef(navigationOverrides);
-  const initialGetScrollAnchorRef = useRef(getScrollAnchor);
-  const ref = useRef<HTMLDivElement | null>(null);
+export const HorizontalFocusGroup = forwardRef<
+  HTMLDivElement,
+  HorizontalFocusGroupProps
+>(
+  (
+    {
+      regionId,
+      navigationOrder,
+      navigationOverrides,
+      autoScrollMode = "region",
+      getScrollAnchor,
+      asChild = false,
+      className,
+      style,
+      children,
+      ...props
+    },
+    forwardedRef
+  ) => {
+    const generatedId = useId();
+    const parentRegionId = useFocusRegionId();
+    const layerId = useFocusLayerId();
+    const navigation = NavigationService.getInstance();
+    const initialNavigationOrderRef = useRef(navigationOrder);
+    const initialNavigationOverridesRef = useRef(navigationOverrides);
+    const initialGetScrollAnchorRef = useRef(getScrollAnchor);
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    useImperativeHandle(forwardedRef, () => ref.current!);
   const resolvedRegionId =
     regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
 
@@ -113,3 +124,4 @@ export function HorizontalFocusGroup({
     </FocusRegionContext.Provider>
   );
 }
+);

--- a/src/big-picture/src/components/common/navigation-history-bridge/index.tsx
+++ b/src/big-picture/src/components/common/navigation-history-bridge/index.tsx
@@ -19,6 +19,9 @@ export function getDefaultPageTitle(pathname: string): string {
     return "Game Details";
   }
 
+  if (segments[0] === "crack-calendar" || segments[0] === "release-calendar")
+    return "Release Calendar";
+
   return capitalize(segments[0]);
 }
 

--- a/src/big-picture/src/components/common/navigation-layer/index.tsx
+++ b/src/big-picture/src/components/common/navigation-layer/index.tsx
@@ -1,6 +1,12 @@
 import { NavigationService } from "../../../services";
 import { FocusLayerContext } from "../../context";
-import { type ReactNode, useEffect, useId } from "react";
+import {
+  type ReactNode,
+  forwardRef,
+  useEffect,
+  useId,
+  useImperativeHandle,
+} from "react";
 
 interface NavigationLayerProps {
   layerId?: string;
@@ -10,17 +16,26 @@ interface NavigationLayerProps {
   children: ReactNode;
 }
 
-export function NavigationLayer({
-  layerId,
-  rootRegionId,
-  initialFocusId,
-  initialFocusRegionId,
-  children,
-}: Readonly<NavigationLayerProps>) {
-  const generatedId = useId();
-  const navigation = NavigationService.getInstance();
-  const resolvedLayerId =
-    layerId ?? `navigation-layer-${generatedId.replaceAll(":", "")}`;
+export const NavigationLayer = forwardRef<
+  void,
+  Readonly<NavigationLayerProps>
+>(
+  (
+    {
+      layerId,
+      rootRegionId,
+      initialFocusId,
+      initialFocusRegionId,
+      children,
+    },
+    forwardedRef
+  ) => {
+    const generatedId = useId();
+    const navigation = NavigationService.getInstance();
+    const resolvedLayerId =
+      layerId ?? `navigation-layer-${generatedId.replaceAll(":", "")}`;
+
+    useImperativeHandle(forwardedRef, () => ({}) as never);
 
   useEffect(() => {
     const unregisterLayer = navigation.registerLayer({
@@ -53,3 +68,4 @@ export function NavigationLayer({
     </FocusLayerContext.Provider>
   );
 }
+);

--- a/src/big-picture/src/components/common/navigation-layer/index.tsx
+++ b/src/big-picture/src/components/common/navigation-layer/index.tsx
@@ -16,18 +16,9 @@ interface NavigationLayerProps {
   children: ReactNode;
 }
 
-export const NavigationLayer = forwardRef<
-  void,
-  Readonly<NavigationLayerProps>
->(
+export const NavigationLayer = forwardRef<void, Readonly<NavigationLayerProps>>(
   (
-    {
-      layerId,
-      rootRegionId,
-      initialFocusId,
-      initialFocusRegionId,
-      children,
-    },
+    { layerId, rootRegionId, initialFocusId, initialFocusRegionId, children },
     forwardedRef
   ) => {
     const generatedId = useId();
@@ -37,35 +28,37 @@ export const NavigationLayer = forwardRef<
 
     useImperativeHandle(forwardedRef, () => ({}) as never);
 
-  useEffect(() => {
-    const unregisterLayer = navigation.registerLayer({
-      id: resolvedLayerId,
-      rootRegionId,
-      isPersistent: Boolean(layerId),
-    });
+    useEffect(() => {
+      const unregisterLayer = navigation.registerLayer({
+        id: resolvedLayerId,
+        rootRegionId,
+        isPersistent: Boolean(layerId),
+      });
 
-    navigation.focusInitialInLayer({
-      layerId: resolvedLayerId,
+      navigation.focusInitialInLayer({
+        layerId: resolvedLayerId,
+        initialFocusId,
+        initialFocusRegionId,
+      });
+
+      return () => {
+        unregisterLayer();
+      };
+    }, [
       initialFocusId,
       initialFocusRegionId,
-    });
+      layerId,
+      navigation,
+      resolvedLayerId,
+      rootRegionId,
+    ]);
 
-    return () => {
-      unregisterLayer();
-    };
-  }, [
-    initialFocusId,
-    initialFocusRegionId,
-    layerId,
-    navigation,
-    resolvedLayerId,
-    rootRegionId,
-  ]);
-
-  return (
-    <FocusLayerContext.Provider value={resolvedLayerId}>
-      {children}
-    </FocusLayerContext.Provider>
-  );
-}
+    return (
+      <FocusLayerContext.Provider value={resolvedLayerId}>
+        {children}
+      </FocusLayerContext.Provider>
+    );
+  }
 );
+
+NavigationLayer.displayName = "NavigationLayer";

--- a/src/big-picture/src/components/common/route-anchor/index.tsx
+++ b/src/big-picture/src/components/common/route-anchor/index.tsx
@@ -20,7 +20,10 @@ export interface RouteAnchorProps extends Omit<
   focusNavigationOverrides?: FocusOverrides;
 }
 
-export const RouteAnchor = forwardRef<HTMLDivElement, Readonly<RouteAnchorProps>>(
+export const RouteAnchor = forwardRef<
+  HTMLDivElement,
+  Readonly<RouteAnchorProps>
+>(
   (
     {
       href,
@@ -42,41 +45,43 @@ export const RouteAnchor = forwardRef<HTMLDivElement, Readonly<RouteAnchorProps>
         ref={ref}
         className={`state-wrapper ${disabled ? "state-wrapper--disabled" : ""} ${active ? "state-wrapper--active" : ""}`}
       >
-      <FocusItem id={focusId} navigationOverrides={focusNavigationOverrides}>
-        <Link to={href} {...props}>
-          <div
-            className={`route-anchor ${active ? "route-anchor--active" : ""} ${!isGameIcon ? "route-anchor--extra-padding" : ""}`}
-          >
+        <FocusItem id={focusId} navigationOverrides={focusNavigationOverrides}>
+          <Link to={href} {...props}>
             <div
-              className={`route-anchor__icon ${isGameIcon ? "route-anchor__icon--large-size" : "route-anchor__icon--small-size"}`}
+              className={`route-anchor ${active ? "route-anchor--active" : ""} ${!isGameIcon ? "route-anchor--extra-padding" : ""}`}
             >
-              {isGameIcon ? (
-                <img
-                  src={icon}
-                  alt={label}
-                  width={32}
-                  height={32}
-                  draggable={false}
-                />
-              ) : (
-                icon
+              <div
+                className={`route-anchor__icon ${isGameIcon ? "route-anchor__icon--large-size" : "route-anchor__icon--small-size"}`}
+              >
+                {isGameIcon ? (
+                  <img
+                    src={icon}
+                    alt={label}
+                    width={32}
+                    height={32}
+                    draggable={false}
+                  />
+                ) : (
+                  icon
+                )}
+              </div>
+              <div className="route-anchor__label">{label}</div>
+
+              {isFavorite && (
+                <div className="route-anchor__favorite">
+                  <HeartStraightIcon
+                    size={18}
+                    weight="fill"
+                    className="route-anchor__favorite__icon"
+                  />
+                </div>
               )}
             </div>
-            <div className="route-anchor__label">{label}</div>
-
-            {isFavorite && (
-              <div className="route-anchor__favorite">
-                <HeartStraightIcon
-                  size={18}
-                  weight="fill"
-                  className="route-anchor__favorite__icon"
-                />
-              </div>
-            )}
-          </div>
-        </Link>
-      </FocusItem>
-    </div>
-  );
-}
+          </Link>
+        </FocusItem>
+      </div>
+    );
+  }
 );
+
+RouteAnchor.displayName = "RouteAnchor";

--- a/src/big-picture/src/components/common/route-anchor/index.tsx
+++ b/src/big-picture/src/components/common/route-anchor/index.tsx
@@ -1,13 +1,15 @@
 import "./styles.scss";
 
 import { HeartStraightIcon } from "@phosphor-icons/react";
-import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { forwardRef, type AnchorHTMLAttributes, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { FocusItem } from "..";
 import type { FocusOverrides } from "../../../services";
 
-export interface RouteAnchorProps
-  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+export interface RouteAnchorProps extends Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> {
   label: string;
   icon: ReactNode | string;
   href: string;
@@ -18,23 +20,28 @@ export interface RouteAnchorProps
   focusNavigationOverrides?: FocusOverrides;
 }
 
-export const RouteAnchor = ({
-  href,
-  label,
-  icon,
-  active = false,
-  disabled = false,
-  isFavorite = false,
-  focusId,
-  focusNavigationOverrides,
-  ...props
-}: Readonly<RouteAnchorProps>) => {
-  const isGameIcon = typeof icon === "string";
+export const RouteAnchor = forwardRef<HTMLDivElement, Readonly<RouteAnchorProps>>(
+  (
+    {
+      href,
+      label,
+      icon,
+      active = false,
+      disabled = false,
+      isFavorite = false,
+      focusId,
+      focusNavigationOverrides,
+      ...props
+    },
+    ref
+  ) => {
+    const isGameIcon = typeof icon === "string";
 
-  return (
-    <div
-      className={`state-wrapper ${disabled ? "state-wrapper--disabled" : ""} ${active ? "state-wrapper--active" : ""}`}
-    >
+    return (
+      <div
+        ref={ref}
+        className={`state-wrapper ${disabled ? "state-wrapper--disabled" : ""} ${active ? "state-wrapper--active" : ""}`}
+      >
       <FocusItem id={focusId} navigationOverrides={focusNavigationOverrides}>
         <Link to={href} {...props}>
           <div
@@ -71,4 +78,5 @@ export const RouteAnchor = ({
       </FocusItem>
     </div>
   );
-};
+}
+);

--- a/src/big-picture/src/components/common/scroll-area/index.tsx
+++ b/src/big-picture/src/components/common/scroll-area/index.tsx
@@ -1,6 +1,12 @@
 import "./styles.scss";
 
-import { type ReactNode, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
+import {
+  type ReactNode,
+  useRef,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import cn from "classnames";
 
 export interface ScrollAreaProps {
@@ -20,32 +26,34 @@ export const ScrollArea = forwardRef<HTMLDivElement, Readonly<ScrollAreaProps>>(
 
     useImperativeHandle(forwardedRef, () => ref.current!);
 
-  useEffect(() => {
-    if (!onScroll) return;
+    useEffect(() => {
+      if (!onScroll) return;
 
-    const el = ref.current;
-    if (!el) return;
+      const el = ref.current;
+      if (!el) return;
 
-    const handleScroll = () => {
-      const { scrollTop, scrollHeight, clientHeight } = el;
-      onScroll({ scrollTop, scrollHeight, clientHeight });
-    };
+      const handleScroll = () => {
+        const { scrollTop, scrollHeight, clientHeight } = el;
+        onScroll({ scrollTop, scrollHeight, clientHeight });
+      };
 
-    el.addEventListener("scroll", handleScroll);
-    return () => el.removeEventListener("scroll", handleScroll);
-  }, [onScroll]);
+      el.addEventListener("scroll", handleScroll);
+      return () => el.removeEventListener("scroll", handleScroll);
+    }, [onScroll]);
 
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "scroll-area",
-        className,
-        !showScrollbar && "scroll-area--hide-scrollbar"
-      )}
-    >
-      {children}
-    </div>
-  );
-}
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "scroll-area",
+          className,
+          !showScrollbar && "scroll-area--hide-scrollbar"
+        )}
+      >
+        {children}
+      </div>
+    );
+  }
 );
+
+ScrollArea.displayName = "ScrollArea";

--- a/src/big-picture/src/components/common/scroll-area/index.tsx
+++ b/src/big-picture/src/components/common/scroll-area/index.tsx
@@ -1,6 +1,6 @@
 import "./styles.scss";
 
-import { type ReactNode, useRef, useEffect } from "react";
+import { type ReactNode, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
 import cn from "classnames";
 
 export interface ScrollAreaProps {
@@ -14,13 +14,11 @@ export interface ScrollAreaProps {
   showScrollbar?: boolean;
 }
 
-export function ScrollArea({
-  children,
-  className,
-  onScroll,
-  showScrollbar = false,
-}: Readonly<ScrollAreaProps>) {
-  const ref = useRef<HTMLDivElement>(null);
+export const ScrollArea = forwardRef<HTMLDivElement, Readonly<ScrollAreaProps>>(
+  ({ children, className, onScroll, showScrollbar = false }, forwardedRef) => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useImperativeHandle(forwardedRef, () => ref.current!);
 
   useEffect(() => {
     if (!onScroll) return;
@@ -50,3 +48,4 @@ export function ScrollArea({
     </div>
   );
 }
+);

--- a/src/big-picture/src/components/common/source-anchor/index.tsx
+++ b/src/big-picture/src/components/common/source-anchor/index.tsx
@@ -10,8 +10,7 @@ const sizes = {
   large: "source-anchor--large",
 };
 
-export interface SourceAnchorProps
-  extends AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface SourceAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   title: string;
   size?: keyof typeof sizes;
   focusId?: string;

--- a/src/big-picture/src/components/common/typography/index.tsx
+++ b/src/big-picture/src/components/common/typography/index.tsx
@@ -98,3 +98,5 @@ export const Typography = forwardRef<
       );
   }
 });
+
+Typography.displayName = "Typography";

--- a/src/big-picture/src/components/common/typography/index.tsx
+++ b/src/big-picture/src/components/common/typography/index.tsx
@@ -1,64 +1,100 @@
 import "./styles.scss";
 
 import cn from "classnames";
-import type { HTMLAttributes } from "react";
+import { forwardRef, type HTMLAttributes } from "react";
 
-export interface TypographyProps
-  extends HTMLAttributes<
-    HTMLHeadingElement | HTMLParagraphElement | HTMLLabelElement
-  > {
+export interface TypographyProps extends HTMLAttributes<
+  HTMLHeadingElement | HTMLParagraphElement | HTMLLabelElement
+> {
   variant?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body" | "label";
 }
 
-export function Typography({
-  children,
-  variant = "body",
-  ...props
-}: Readonly<TypographyProps>) {
+export const Typography = forwardRef<
+  HTMLHeadingElement | HTMLParagraphElement | HTMLLabelElement,
+  TypographyProps
+>(({ children, variant = "body", ...props }, ref) => {
   const { className, ...rest } = props;
 
   switch (variant) {
     case "h1":
       return (
-        <h1 {...rest} className={cn("typography typography--h1", className)}>
+        <h1
+          {...rest}
+          ref={ref as React.Ref<HTMLHeadingElement>}
+          className={cn("typography typography--h1", className)}
+        >
           {children}
         </h1>
       );
     case "h2":
       return (
-        <h2 {...rest} className={cn("typography typography--h2", className)}>
+        <h2
+          {...rest}
+          ref={ref as React.Ref<HTMLHeadingElement>}
+          className={cn("typography typography--h2", className)}
+        >
           {children}
         </h2>
       );
     case "h3":
       return (
-        <h3 {...rest} className={cn("typography typography--h3", className)}>
+        <h3
+          {...rest}
+          ref={ref as React.Ref<HTMLHeadingElement>}
+          className={cn("typography typography--h3", className)}
+        >
           {children}
         </h3>
       );
     case "h4":
       return (
-        <h4 {...rest} className={cn("typography typography--h4", className)}>
+        <h4
+          {...rest}
+          ref={ref as React.Ref<HTMLHeadingElement>}
+          className={cn("typography typography--h4", className)}
+        >
           {children}
         </h4>
       );
     case "h5":
       return (
-        <h5 {...rest} className={cn("typography typography--h5", className)}>
+        <h5
+          {...rest}
+          ref={ref as React.Ref<HTMLHeadingElement>}
+          className={cn("typography typography--h5", className)}
+        >
           {children}
         </h5>
       );
     case "h6":
       return (
-        <h6 {...rest} className={cn("typography typography--h6", className)}>
+        <h6
+          {...rest}
+          ref={ref as React.Ref<HTMLHeadingElement>}
+          className={cn("typography typography--h6", className)}
+        >
           {children}
         </h6>
       );
+    case "label":
+      return (
+        <label
+          {...rest}
+          ref={ref as React.Ref<HTMLLabelElement>}
+          className={cn("typography typography--label", className)}
+        >
+          {children}
+        </label>
+      );
     default:
       return (
-        <p {...rest} className={cn("typography typography--body", className)}>
+        <p
+          {...rest}
+          ref={ref as React.Ref<HTMLParagraphElement>}
+          className={cn("typography typography--body", className)}
+        >
           {children}
         </p>
       );
   }
-}
+});

--- a/src/big-picture/src/components/common/vertical-focus-group/index.tsx
+++ b/src/big-picture/src/components/common/vertical-focus-group/index.tsx
@@ -58,70 +58,72 @@ export const VerticalFocusGroup = forwardRef<
     const ref = useRef<HTMLDivElement | null>(null);
 
     useImperativeHandle(forwardedRef, () => ref.current!);
-  const resolvedRegionId =
-    regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
+    const resolvedRegionId =
+      regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
 
-  useEffect(() => {
-    return navigation.registerRegion({
-      id: resolvedRegionId,
-      parentRegionId,
-      orientation: "vertical",
-      layerId,
-      navigationOrder: initialNavigationOrderRef.current,
-      navigationOverrides: initialNavigationOverridesRef.current,
+    useEffect(() => {
+      return navigation.registerRegion({
+        id: resolvedRegionId,
+        parentRegionId,
+        orientation: "vertical",
+        layerId,
+        navigationOrder: initialNavigationOrderRef.current,
+        navigationOverrides: initialNavigationOverridesRef.current,
+        autoScrollMode,
+        isPersistent: Boolean(regionId),
+        getElement: () => ref.current,
+        getScrollAnchor: initialGetScrollAnchorRef.current,
+      });
+    }, [
       autoScrollMode,
-      isPersistent: Boolean(regionId),
-      getElement: () => ref.current,
-      getScrollAnchor: initialGetScrollAnchorRef.current,
-    });
-  }, [
-    autoScrollMode,
-    layerId,
-    navigation,
-    parentRegionId,
-    regionId,
-    resolvedRegionId,
-  ]);
+      layerId,
+      navigation,
+      parentRegionId,
+      regionId,
+      resolvedRegionId,
+    ]);
 
-  useEffect(() => {
-    navigation.updateRegion(resolvedRegionId, {
+    useEffect(() => {
+      navigation.updateRegion(resolvedRegionId, {
+        autoScrollMode,
+        getScrollAnchor,
+        navigationOrder,
+        navigationOverrides,
+      });
+    }, [
       autoScrollMode,
       getScrollAnchor,
+      navigation,
       navigationOrder,
       navigationOverrides,
-    });
-  }, [
-    autoScrollMode,
-    getScrollAnchor,
-    navigation,
-    navigationOrder,
-    navigationOverrides,
-    resolvedRegionId,
-  ]);
+      resolvedRegionId,
+    ]);
 
-  const Component = asChild ? Slot : "div";
+    const Component = asChild ? Slot : "div";
 
-  return (
-    <FocusRegionContext.Provider value={resolvedRegionId}>
-      <Component
-        ref={ref}
-        className={className}
-        data-focus-region-id={resolvedRegionId}
-        style={
-          asChild
-            ? style
-            : {
-                display: "flex",
-                flexDirection: "column",
-                gap: 16,
-                ...style,
-              }
-        }
-        {...props}
-      >
-        {children}
-      </Component>
-    </FocusRegionContext.Provider>
-  );
-}
+    return (
+      <FocusRegionContext.Provider value={resolvedRegionId}>
+        <Component
+          ref={ref}
+          className={className}
+          data-focus-region-id={resolvedRegionId}
+          style={
+            asChild
+              ? style
+              : {
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 16,
+                  ...style,
+                }
+          }
+          {...props}
+        >
+          {children}
+        </Component>
+      </FocusRegionContext.Provider>
+    );
+  }
 );
+
+VerticalFocusGroup.displayName = "VerticalFocusGroup";

--- a/src/big-picture/src/components/common/vertical-focus-group/index.tsx
+++ b/src/big-picture/src/components/common/vertical-focus-group/index.tsx
@@ -12,8 +12,10 @@ import {
 import {
   type HTMLAttributes,
   type ReactNode,
+  forwardRef,
   useEffect,
   useId,
+  useImperativeHandle,
   useRef,
 } from "react";
 
@@ -27,26 +29,35 @@ interface VerticalFocusGroupProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
-export function VerticalFocusGroup({
-  regionId,
-  navigationOrder,
-  navigationOverrides,
-  autoScrollMode = "auto",
-  getScrollAnchor,
-  asChild = false,
-  className,
-  style,
-  children,
-  ...props
-}: Readonly<VerticalFocusGroupProps>) {
-  const generatedId = useId();
-  const parentRegionId = useFocusRegionId();
-  const layerId = useFocusLayerId();
-  const navigation = NavigationService.getInstance();
-  const initialNavigationOrderRef = useRef(navigationOrder);
-  const initialNavigationOverridesRef = useRef(navigationOverrides);
-  const initialGetScrollAnchorRef = useRef(getScrollAnchor);
-  const ref = useRef<HTMLDivElement | null>(null);
+export const VerticalFocusGroup = forwardRef<
+  HTMLDivElement,
+  VerticalFocusGroupProps
+>(
+  (
+    {
+      regionId,
+      navigationOrder,
+      navigationOverrides,
+      autoScrollMode = "auto",
+      getScrollAnchor,
+      asChild = false,
+      className,
+      style,
+      children,
+      ...props
+    },
+    forwardedRef
+  ) => {
+    const generatedId = useId();
+    const parentRegionId = useFocusRegionId();
+    const layerId = useFocusLayerId();
+    const navigation = NavigationService.getInstance();
+    const initialNavigationOrderRef = useRef(navigationOrder);
+    const initialNavigationOverridesRef = useRef(navigationOverrides);
+    const initialGetScrollAnchorRef = useRef(getScrollAnchor);
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    useImperativeHandle(forwardedRef, () => ref.current!);
   const resolvedRegionId =
     regionId ?? `focus-region-${generatedId.replaceAll(":", "")}`;
 
@@ -113,3 +124,4 @@ export function VerticalFocusGroup({
     </FocusRegionContext.Provider>
   );
 }
+);

--- a/src/big-picture/src/components/common/vertical-game-card/index.tsx
+++ b/src/big-picture/src/components/common/vertical-game-card/index.tsx
@@ -22,6 +22,7 @@ export interface VerticalGameCardProps {
   onClick?: () => void;
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onCoverImageError?: () => void;
+  hideProgressIcon?: boolean;
 }
 
 const DEFAULT_PROGRESS_COLOR = "var(--alert)";
@@ -43,6 +44,7 @@ export function VerticalGameCard({
   onClick,
   onContextMenu,
   onCoverImageError,
+  hideProgressIcon = false,
 }: Readonly<VerticalGameCardProps>) {
   const hasProgress =
     progressLabel != null &&
@@ -108,7 +110,7 @@ export function VerticalGameCard({
             aria-hidden={!hasProgress || undefined}
           >
             <div className="vertical-game-card__progress-label">
-              <ProgressIcon size={16} weight="fill" />
+              {!hideProgressIcon && <ProgressIcon size={16} weight="fill" />}
               <span>{progressLabel ?? "0/0"}</span>
             </div>
 

--- a/src/big-picture/src/components/common/vertical-game-card/index.tsx
+++ b/src/big-picture/src/components/common/vertical-game-card/index.tsx
@@ -32,7 +32,10 @@ function clampProgress(value: number) {
   return Math.min(1, Math.max(0, value));
 }
 
-export const VerticalGameCard = forwardRef<HTMLDivElement, VerticalGameCardProps>(
+export const VerticalGameCard = forwardRef<
+  HTMLDivElement,
+  VerticalGameCardProps
+>(
   (
     {
       coverImageUrl,
@@ -52,83 +55,85 @@ export const VerticalGameCard = forwardRef<HTMLDivElement, VerticalGameCardProps
     },
     ref
   ) => {
-  const hasProgress =
-    progressLabel != null &&
-    progressValue != null &&
-    !Number.isNaN(progressValue);
-  const normalizedProgress = hasProgress ? clampProgress(progressValue) : 0;
-  const isCompleted = hasProgress && normalizedProgress === 1;
+    const hasProgress =
+      progressLabel != null &&
+      progressValue != null &&
+      !Number.isNaN(progressValue);
+    const normalizedProgress = hasProgress ? clampProgress(progressValue) : 0;
+    const isCompleted = hasProgress && normalizedProgress === 1;
 
-  const customProperties = {
-    "--vertical-game-card-progress-color": progressColor,
-    "--vertical-game-card-progress-value": normalizedProgress,
-  } as CSSProperties;
-  const ProgressIcon = isCompleted ? SparkleIcon : TrophyIcon;
+    const customProperties = {
+      "--vertical-game-card-progress-color": progressColor,
+      "--vertical-game-card-progress-value": normalizedProgress,
+    } as CSSProperties;
+    const ProgressIcon = isCompleted ? SparkleIcon : TrophyIcon;
 
-  const handleCardKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-    if (onClick == null) return;
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onClick();
-    }
-  };
+    const handleCardKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+      if (onClick == null) return;
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onClick();
+      }
+    };
 
-  return (
-    <div
-      ref={ref}
-      className={cn("vertical-game-card", className, {
-        "vertical-game-card--completed": isCompleted,
-        "vertical-game-card--force-hovered": forceHovered,
-      })}
-      style={customProperties}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      onKeyDown={onClick != null ? handleCardKeyDown : undefined}
-      role={onClick != null ? "button" : undefined}
-      tabIndex={onClick != null ? 0 : undefined}
-      {...props}
-    >
-      <div className="vertical-game-card__cover">
-        {coverImageUrl ? (
-          <img
-            src={coverImageUrl}
-            alt={gameTitle}
-            draggable={false}
-            onError={onCoverImageError}
-          />
-        ) : (
-          <div
-            className="vertical-game-card__cover-placeholder"
-            aria-hidden="true"
-          />
-        )}
-      </div>
-
-      <div className="vertical-game-card__body">
-        <div className="vertical-game-card__info">
-          <div className="vertical-game-card__text">
-            <h3 className="vertical-game-card__title">{gameTitle}</h3>
-            <p className="vertical-game-card__subtitle">{subtitle}</p>
-          </div>
-
-          <div
-            className={cn("vertical-game-card__progress", {
-              "vertical-game-card__progress--placeholder": !hasProgress,
-            })}
-            aria-hidden={!hasProgress || undefined}
-          >
-            <div className="vertical-game-card__progress-label">
-              {!hideProgressIcon && <ProgressIcon size={16} weight="fill" />}
-              <span>{progressLabel ?? "0/0"}</span>
-            </div>
-
-            <div className="vertical-game-card__progress-track" />
-          </div>
+    return (
+      <div
+        ref={ref}
+        className={cn("vertical-game-card", className, {
+          "vertical-game-card--completed": isCompleted,
+          "vertical-game-card--force-hovered": forceHovered,
+        })}
+        style={customProperties}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onKeyDown={onClick != null ? handleCardKeyDown : undefined}
+        role={onClick != null ? "button" : undefined}
+        tabIndex={onClick != null ? 0 : undefined}
+        {...props}
+      >
+        <div className="vertical-game-card__cover">
+          {coverImageUrl ? (
+            <img
+              src={coverImageUrl}
+              alt={gameTitle}
+              draggable={false}
+              onError={onCoverImageError}
+            />
+          ) : (
+            <div
+              className="vertical-game-card__cover-placeholder"
+              aria-hidden="true"
+            />
+          )}
         </div>
 
-        {action && <div className="vertical-game-card__action">{action}</div>}
+        <div className="vertical-game-card__body">
+          <div className="vertical-game-card__info">
+            <div className="vertical-game-card__text">
+              <h3 className="vertical-game-card__title">{gameTitle}</h3>
+              <p className="vertical-game-card__subtitle">{subtitle}</p>
+            </div>
+
+            <div
+              className={cn("vertical-game-card__progress", {
+                "vertical-game-card__progress--placeholder": !hasProgress,
+              })}
+              aria-hidden={!hasProgress || undefined}
+            >
+              <div className="vertical-game-card__progress-label">
+                {!hideProgressIcon && <ProgressIcon size={16} weight="fill" />}
+                <span>{progressLabel ?? "0/0"}</span>
+              </div>
+
+              <div className="vertical-game-card__progress-track" />
+            </div>
+          </div>
+
+          {action && <div className="vertical-game-card__action">{action}</div>}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
 );
+
+VerticalGameCard.displayName = "VerticalGameCard";

--- a/src/big-picture/src/components/common/vertical-game-card/index.tsx
+++ b/src/big-picture/src/components/common/vertical-game-card/index.tsx
@@ -2,14 +2,15 @@ import "./styles.scss";
 
 import { SparkleIcon, TrophyIcon } from "@phosphor-icons/react";
 import cn from "classnames";
-import type {
-  CSSProperties,
-  KeyboardEvent,
-  MouseEvent as ReactMouseEvent,
-  ReactNode,
+import {
+  type CSSProperties,
+  forwardRef,
+  type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
 } from "react";
 
-export interface VerticalGameCardProps {
+export interface VerticalGameCardProps extends React.HTMLAttributes<HTMLDivElement> {
   coverImageUrl?: string | null;
   gameTitle: string;
   subtitle: string;
@@ -31,21 +32,26 @@ function clampProgress(value: number) {
   return Math.min(1, Math.max(0, value));
 }
 
-export function VerticalGameCard({
-  coverImageUrl,
-  gameTitle,
-  subtitle,
-  progressLabel,
-  progressValue,
-  progressColor = DEFAULT_PROGRESS_COLOR,
-  action,
-  forceHovered = false,
-  className,
-  onClick,
-  onContextMenu,
-  onCoverImageError,
-  hideProgressIcon = false,
-}: Readonly<VerticalGameCardProps>) {
+export const VerticalGameCard = forwardRef<HTMLDivElement, VerticalGameCardProps>(
+  (
+    {
+      coverImageUrl,
+      gameTitle,
+      subtitle,
+      progressLabel,
+      progressValue,
+      progressColor = DEFAULT_PROGRESS_COLOR,
+      action,
+      forceHovered = false,
+      className,
+      onClick,
+      onContextMenu,
+      onCoverImageError,
+      hideProgressIcon = false,
+      ...props
+    },
+    ref
+  ) => {
   const hasProgress =
     progressLabel != null &&
     progressValue != null &&
@@ -69,6 +75,7 @@ export function VerticalGameCard({
 
   return (
     <div
+      ref={ref}
       className={cn("vertical-game-card", className, {
         "vertical-game-card--completed": isCompleted,
         "vertical-game-card--force-hovered": forceHovered,
@@ -79,6 +86,7 @@ export function VerticalGameCard({
       onKeyDown={onClick != null ? handleCardKeyDown : undefined}
       role={onClick != null ? "button" : undefined}
       tabIndex={onClick != null ? 0 : undefined}
+      {...props}
     >
       <div className="vertical-game-card__cover">
         {coverImageUrl ? (
@@ -123,3 +131,4 @@ export function VerticalGameCard({
     </div>
   );
 }
+);

--- a/src/big-picture/src/components/common/virtual-keyboard/index.tsx
+++ b/src/big-picture/src/components/common/virtual-keyboard/index.tsx
@@ -1215,6 +1215,7 @@ export function VirtualKeyboardProvider() {
       <AnimatePresence>
         {target ? (
           <motion.div
+            key="virtual-keyboard-dock"
             ref={dockRef}
             className="virtual-keyboard-dock"
             data-layout-mode={layoutMode}

--- a/src/big-picture/src/components/modals/download-game/index.tsx
+++ b/src/big-picture/src/components/modals/download-game/index.tsx
@@ -91,9 +91,9 @@ function hasActiveLibraryDownload(
 
     return Boolean(
       download &&
-        (download.status === "active" ||
-          download.status === "extracting" ||
-          download.extracting)
+      (download.status === "active" ||
+        download.status === "extracting" ||
+        download.extracting)
     );
   });
 }

--- a/src/big-picture/src/components/pages/library/game-card.tsx
+++ b/src/big-picture/src/components/pages/library/game-card.tsx
@@ -65,15 +65,7 @@ function useLibraryGameCardPresentation(
     }
 
     return getGameImageSources(game);
-  }, [
-    game.coverImageUrl,
-    game.customHeroImageUrl,
-    game.customIconUrl,
-    game.iconUrl,
-    game.libraryHeroImageUrl,
-    game.libraryImageUrl,
-    variant,
-  ]);
+  }, [game, variant]);
   const [imageSourceIndex, setImageSourceIndex] = useState(0);
   const [imageExhausted, setImageExhausted] = useState(false);
   const imageSourcesSignature = imageSources.join("|");

--- a/src/big-picture/src/components/providers/navigation-input.provider.tsx
+++ b/src/big-picture/src/components/providers/navigation-input.provider.tsx
@@ -7,7 +7,15 @@ interface NavigationInputProviderProps {
   children: ReactNode;
 }
 
-type HoldManagedButton = "a" | "b" | "x" | "y" | "start" | "select";
+type HoldManagedButton =
+  | "a"
+  | "b"
+  | "x"
+  | "y"
+  | "start"
+  | "select"
+  | "l1"
+  | "r1";
 type HoldSession = {
   isPressed: boolean;
   holdTriggered: boolean;
@@ -51,6 +59,18 @@ function createInitialHoldSessions(): Record<HoldManagedButton, HoldSession> {
       releaseTimerId: null,
     },
     select: {
+      isPressed: false,
+      holdTriggered: false,
+      timerId: null,
+      releaseTimerId: null,
+    },
+    l1: {
+      isPressed: false,
+      holdTriggered: false,
+      timerId: null,
+      releaseTimerId: null,
+    },
+    r1: {
       isPressed: false,
       holdTriggered: false,
       timerId: null,
@@ -329,6 +349,8 @@ export function NavigationInputProvider({
   const isYPressed = isButtonPressed(GamepadButtonType.BUTTON_Y);
   const isStartPressed = isButtonPressed(GamepadButtonType.START);
   const isSelectPressed = isButtonPressed(GamepadButtonType.BACK);
+  const isL1Pressed = isButtonPressed(GamepadButtonType.LEFT_BUMPER);
+  const isR1Pressed = isButtonPressed(GamepadButtonType.RIGHT_BUMPER);
 
   useEffect(() => {
     const holdSessions = holdSessionsRef.current;
@@ -339,10 +361,17 @@ export function NavigationInputProvider({
       y: isYPressed,
       start: isStartPressed,
       select: isSelectPressed,
+      l1: isL1Pressed,
+      r1: isR1Pressed,
     };
 
     const dispatchHold = (button: HoldManagedButton) => {
-      if (button === "start" || button === "select") {
+      if (
+        button === "start" ||
+        button === "select" ||
+        button === "l1" ||
+        button === "r1"
+      ) {
         return triggerScreenHold(button);
       }
 
@@ -374,7 +403,12 @@ export function NavigationInputProvider({
         return triggerItemPress(button) || triggerScreenPress(button);
       }
 
-      if (button === "start" || button === "select") {
+      if (
+        button === "start" ||
+        button === "select" ||
+        button === "l1" ||
+        button === "r1"
+      ) {
         return triggerScreenPress(button);
       }
 
@@ -445,6 +479,8 @@ export function NavigationInputProvider({
     isYPressed,
     isStartPressed,
     isSelectPressed,
+    isL1Pressed,
+    isR1Pressed,
     triggerItemHold,
     triggerItemPress,
     triggerPrimary,

--- a/src/big-picture/src/layout/header/index.tsx
+++ b/src/big-picture/src/layout/header/index.tsx
@@ -45,11 +45,18 @@ function Header() {
   const pageTitle = useCurrentPageTitle();
   const isOnCataloguePage =
     normalizeBigPicturePathname(pathname) === "/catalogue";
+  const isOnReleaseCalendarPage =
+    normalizeBigPicturePathname(pathname) === "/crack-calendar";
+  const isOnReleaseCalendarDetailPage =
+    normalizeBigPicturePathname(pathname).startsWith("/crack-calendar/");
   const catalogueSearchValue = searchParams.get("title") ?? "";
+  const releaseCalendarSearchValue = searchParams.get("title") ?? "";
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [searchValue, setSearchValue] = useState(() =>
-    isOnCataloguePage ? catalogueSearchValue : ""
-  );
+  const [searchValue, setSearchValue] = useState(() => {
+    if (isOnCataloguePage) return catalogueSearchValue;
+    if (isOnReleaseCalendarPage) return releaseCalendarSearchValue;
+    return "";
+  });
   const currentFocusId = useNavigationStore((state) => state.currentFocusId);
   const virtualKeyboardTarget = useVirtualKeyboardStore(
     (state) => state.target
@@ -132,7 +139,7 @@ function Header() {
 
     setSearchValue(nextValue);
 
-    if (isOnCataloguePage) {
+    if (isOnCataloguePage || isOnReleaseCalendarPage) {
       updateCatalogueTitle(nextValue);
       return;
     }
@@ -148,7 +155,7 @@ function Header() {
   const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (isOnCataloguePage) {
+    if (isOnCataloguePage || isOnReleaseCalendarPage) {
       dismissSearch();
       return;
     }
@@ -293,78 +300,80 @@ function Header() {
             </button>
           </FocusItem>
 
-          <form
-            ref={searchRef}
-            role="search"
-            className={cn("header__search", {
-              "header__search--open": isSearchOpen,
-            })}
-            onSubmit={handleSearchSubmit}
-          >
-            <AnimatePresence initial={false}>
-              {isSearchOpen || isHovered ? (
-                <motion.div
-                  key="left"
-                  initial={{ x: 24, opacity: 0 }}
-                  animate={{ x: 0, opacity: 1 }}
-                  exit={{ x: 24, opacity: 0 }}
-                  transition={{
-                    duration: 0.2,
-                    ease: "easeInOut",
-                    delay: 0.1,
-                  }}
-                  className="header__search-icon header__search-icon--left"
-                >
-                  <MagnifyingGlassIcon size={24} />
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="right"
-                  initial={{ x: -24, opacity: 0 }}
-                  animate={{ x: 0, opacity: 1 }}
-                  exit={{ x: -24, opacity: 0 }}
-                  transition={{
-                    duration: 0.2,
-                    ease: "easeInOut",
-                    delay: 0.1,
-                  }}
-                  className="header__search-icon header__search-icon--right"
-                >
-                  <MagnifyingGlassIcon size={24} />
-                </motion.div>
-              )}
-            </AnimatePresence>
-
-            <FocusItem
-              id={HEADER_SEARCH_INPUT_ID}
-              actions={{ primary: openSearch }}
-              navigationOverrides={searchNavigationOverrides}
-              asChild
+          {!isOnReleaseCalendarDetailPage && (
+            <form
+              ref={searchRef}
+              role="search"
+              className={cn("header__search", {
+                "header__search--open": isSearchOpen,
+              })}
+              onSubmit={handleSearchSubmit}
             >
-              <button
-                ref={searchTriggerRef}
-                type="button"
-                aria-label="Search catalogue"
-                className="header__search-trigger"
-                onClick={openSearch}
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-              />
-            </FocusItem>
+              <AnimatePresence initial={false}>
+                {isSearchOpen || isHovered ? (
+                  <motion.div
+                    key="left"
+                    initial={{ x: 24, opacity: 0 }}
+                    animate={{ x: 0, opacity: 1 }}
+                    exit={{ x: 24, opacity: 0 }}
+                    transition={{
+                      duration: 0.2,
+                      ease: "easeInOut",
+                      delay: 0.1,
+                    }}
+                    className="header__search-icon header__search-icon--left"
+                  >
+                    <MagnifyingGlassIcon size={24} />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="right"
+                    initial={{ x: -24, opacity: 0 }}
+                    animate={{ x: 0, opacity: 1 }}
+                    exit={{ x: -24, opacity: 0 }}
+                    transition={{
+                      duration: 0.2,
+                      ease: "easeInOut",
+                      delay: 0.1,
+                    }}
+                    className="header__search-icon header__search-icon--right"
+                  >
+                    <MagnifyingGlassIcon size={24} />
+                  </motion.div>
+                )}
+              </AnimatePresence>
 
-            <input
-              ref={inputRef}
-              type="text"
-              className="header__search-input typography typography--body"
-              spellCheck={false}
-              autoComplete="off"
-              maxLength={MAX_SEARCH_LENGTH}
-              tabIndex={isSearchOpen ? 0 : -1}
-              placeholder="Looking for anything in particular?"
-              value={searchValue}
-              onChange={(event) => handleSearchChange(event.target.value)}
-            />
-          </form>
+              <FocusItem
+                id={HEADER_SEARCH_INPUT_ID}
+                actions={{ primary: openSearch }}
+                navigationOverrides={searchNavigationOverrides}
+                asChild
+              >
+                <button
+                  ref={searchTriggerRef}
+                  type="button"
+                  aria-label="Search catalogue"
+                  className="header__search-trigger"
+                  onClick={openSearch}
+                  onMouseEnter={() => setIsHovered(true)}
+                  onMouseLeave={() => setIsHovered(false)}
+                />
+              </FocusItem>
+
+              <input
+                ref={inputRef}
+                type="text"
+                className="header__search-input typography typography--body"
+                spellCheck={false}
+                autoComplete="off"
+                maxLength={MAX_SEARCH_LENGTH}
+                tabIndex={isSearchOpen ? 0 : -1}
+                placeholder="Looking for anything in particular?"
+                value={searchValue}
+                onChange={(event) => handleSearchChange(event.target.value)}
+              />
+            </form>
+          )}
         </header>
       </HorizontalFocusGroup>
     </div>

--- a/src/big-picture/src/layout/navigation.ts
+++ b/src/big-picture/src/layout/navigation.ts
@@ -6,10 +6,7 @@ import { HOME_PAGE_REGION_ID } from "../pages/home/navigation";
 import { SETTINGS_PAGE_REGION_ID } from "../pages/settings/navigation";
 import { LIBRARY_PAGE_REGION_ID } from "../components/pages/library/navigation";
 
-import {
-  RELEASE_CALENDAR_PAGE_REGION_ID,
-  RELEASE_CALENDAR_GRID_REGION_ID,
-} from "../pages/release-calendar/navigation";
+import { RELEASE_CALENDAR_GRID_REGION_ID } from "../pages/release-calendar/navigation";
 
 export const BIG_PICTURE_APP_LAYER_ID = "big-picture-app-layer";
 export const BIG_PICTURE_SHELL_REGION_ID = "big-picture-shell";

--- a/src/big-picture/src/layout/navigation.ts
+++ b/src/big-picture/src/layout/navigation.ts
@@ -18,6 +18,7 @@ export const BIG_PICTURE_SIDEBAR_ITEM_IDS = {
   library: "big-picture-sidebar-library",
   downloads: "big-picture-sidebar-downloads",
   settings: "big-picture-sidebar-settings",
+  releaseCalendar: "big-picture-sidebar-release-calendar",
   componentLab: "big-picture-sidebar-component-lab",
 } as const;
 
@@ -89,6 +90,10 @@ export function getBigPictureSidebarItemIdFromPathname(pathname: string) {
 
   if (normalizedPathname.startsWith("/settings")) {
     return BIG_PICTURE_SIDEBAR_ITEM_IDS.settings;
+  }
+
+  if (normalizedPathname.startsWith("/crack-calendar")) {
+    return BIG_PICTURE_SIDEBAR_ITEM_IDS.releaseCalendar;
   }
 
   if (normalizedPathname.startsWith("/library")) {

--- a/src/big-picture/src/layout/navigation.ts
+++ b/src/big-picture/src/layout/navigation.ts
@@ -6,6 +6,11 @@ import { HOME_PAGE_REGION_ID } from "../pages/home/navigation";
 import { SETTINGS_PAGE_REGION_ID } from "../pages/settings/navigation";
 import { LIBRARY_PAGE_REGION_ID } from "../components/pages/library/navigation";
 
+import {
+  RELEASE_CALENDAR_PAGE_REGION_ID,
+  RELEASE_CALENDAR_GRID_REGION_ID,
+} from "../pages/release-calendar/navigation";
+
 export const BIG_PICTURE_APP_LAYER_ID = "big-picture-app-layer";
 export const BIG_PICTURE_SHELL_REGION_ID = "big-picture-shell";
 export const BIG_PICTURE_SIDEBAR_REGION_ID = "big-picture-sidebar";
@@ -126,6 +131,13 @@ export function getBigPictureContentEntryRegionIdFromPathname(
 
   if (normalizedPathname.startsWith("/settings")) {
     return SETTINGS_PAGE_REGION_ID;
+  }
+
+  if (normalizedPathname.startsWith("/crack-calendar")) {
+    if (normalizedPathname.startsWith("/crack-calendar/")) {
+      return "release-calendar-detail";
+    }
+    return RELEASE_CALENDAR_GRID_REGION_ID;
   }
 
   if (getBigPictureGameRouteMatch(normalizedPathname)) {

--- a/src/big-picture/src/layout/sidebar/index.tsx
+++ b/src/big-picture/src/layout/sidebar/index.tsx
@@ -5,6 +5,7 @@ import {
   HouseIcon,
   MagnifyingGlassIcon,
   PuzzlePieceIcon,
+  CalendarDotsIcon,
   SignOutIcon,
   SquaresFourIcon,
 } from "@phosphor-icons/react";
@@ -69,6 +70,12 @@ function SidebarRouter() {
         label: "Catalogue",
         path: `${basePath}/catalogue`,
         icon: SquaresFourIcon,
+      },
+      {
+        key: "releaseCalendar",
+        label: "Release Calendar",
+        path: `${basePath}/crack-calendar`,
+        icon: CalendarDotsIcon,
       },
       {
         key: "library",

--- a/src/big-picture/src/pages/downloads/downloads.tsx
+++ b/src/big-picture/src/pages/downloads/downloads.tsx
@@ -1601,7 +1601,7 @@ export default function Downloads() {
     return previewPlacement.kind === "hero"
       ? getHeroPrimaryFocusId()
       : getDownloadMainFocusId(moveMode.sourceGameId);
-  }, [moveModePreviewPlacement, moveMode?.sourceGameId]);
+  }, [moveMode, moveModePreviewPlacement]);
   const isCrossSectionMoveModePreview = useMemo(() => {
     const previousKind = previousMoveModePlacementKindRef.current;
     const currentKind = moveModePreviewPlacement?.kind ?? null;
@@ -2194,18 +2194,14 @@ export default function Downloads() {
         : []),
     ];
   }, [
-    canPromoteToHero,
     handleCompletedRemoval,
     handleRemovalCancel,
     interactionsLocked,
     menuState.item,
     menuState.section,
-    moveQueuedDownload,
     moveToPaused,
     pauseSeeding,
     resumeSeeding,
-    sendToQueue,
-    startNow,
   ]);
 
   useEffect(() => {

--- a/src/big-picture/src/pages/downloads/downloads.tsx
+++ b/src/big-picture/src/pages/downloads/downloads.tsx
@@ -1539,15 +1539,15 @@ export default function Downloads() {
   const heroPanelState = displayedHeroSnapshot ?? null;
   const heroInteractionDisabled = Boolean(
     interactionsLocked ||
-      isHeroSnapshotTransitioning ||
-      displayedHeroSnapshot?.mode !== "normal"
+    isHeroSnapshotTransitioning ||
+    displayedHeroSnapshot?.mode !== "normal"
   );
   const isHeroOptimisticCommitPending = Boolean(
     optimisticCommitState &&
-      optimisticCommitState.targetPlacement.kind === "hero" &&
-      (displayedHeroSnapshot?.id !== optimisticCommitState.sourceGameId ||
-        displayedHeroSnapshot?.mode !== "normal" ||
-        isHeroSnapshotTransitioning)
+    optimisticCommitState.targetPlacement.kind === "hero" &&
+    (displayedHeroSnapshot?.id !== optimisticCommitState.sourceGameId ||
+      displayedHeroSnapshot?.mode !== "normal" ||
+      isHeroSnapshotTransitioning)
   );
   const mainNavigationOverridesByFocusId = useMemo(() => {
     const heroFocusIds = displayedHeroSnapshot ? [getHeroPrimaryFocusId()] : [];

--- a/src/big-picture/src/pages/downloads/downloads.tsx
+++ b/src/big-picture/src/pages/downloads/downloads.tsx
@@ -937,7 +937,6 @@ export default function Downloads() {
     moveToPaused,
     cancelDownload,
     removeDownload,
-    moveQueuedDownload,
     setQueuedDownloadPosition,
     setPausedDownloadPosition,
     pauseSeeding,

--- a/src/big-picture/src/pages/downloads/use-big-picture-downloads-page-data.ts
+++ b/src/big-picture/src/pages/downloads/use-big-picture-downloads-page-data.ts
@@ -529,9 +529,9 @@ export function useBigPictureDownloadsPageData() {
 
   const hasDownloads = Boolean(
     activeDownload ||
-      queuedDownloads.length ||
-      pausedDownloads.length ||
-      completedDownloads.length
+    queuedDownloads.length ||
+    pausedDownloads.length ||
+    completedDownloads.length
   );
 
   const networkStats = useMemo((): BigPictureDownloadsNetworkStats => {

--- a/src/big-picture/src/pages/game/game.scss
+++ b/src/big-picture/src/pages/game/game.scss
@@ -125,8 +125,7 @@
     }
 
     &[data-focused="true"] {
-      outline: 2px solid #fff;
-      outline-offset: 4px;
+      outline: none;
     }
   }
 
@@ -478,6 +477,15 @@
     align-items: flex-start;
     justify-content: flex-end;
     height: 100%;
+    outline: none !important;
+
+    &:focus,
+    &:focus-visible,
+    &[data-focused="true"],
+    &[data-focus-visible="true"] {
+      outline: none !important;
+    }
+
     background:
       linear-gradient(
         90deg,
@@ -656,8 +664,7 @@
     }
 
     &[data-focused="true"] {
-      outline: 2px solid #fff;
-      outline-offset: 4px;
+      outline: none;
     }
 
     p {

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -978,7 +978,11 @@ export default function Game() {
   }
 
   return (
-    <VerticalFocusGroup regionId={GAME_PAGE_REGION_ID} asChild>
+    <VerticalFocusGroup
+      regionId={GAME_PAGE_REGION_ID}
+      getScrollAnchor={() => pageRef.current}
+      asChild
+    >
       <div ref={pageRef} className="game-page">
         <Hero
           shopDetails={shopDetails}

--- a/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx
+++ b/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAppSelector } from "@renderer/hooks";
@@ -7,17 +7,39 @@ import {
   VerticalFocusGroup,
   ScrollArea,
   Divider,
+  FocusItem,
 } from "../../components";
-import { useHeaderTitle } from "../../hooks";
+import { useHeaderTitle, useNavigationScreenActions } from "../../hooks";
 import { CrackCalendarGame } from "@types";
+import { formatCountdown } from "@renderer/utils/format-countdown";
+import { useNavigationStore } from "../../stores";
+import { NavigationService } from "../../services";
 
 import "./styles.scss";
+
+const SCROLL_STEP = 180;
+const SCROLL_ANIMATION_DURATION = 220;
+const HERO_SECTION_ID = "release-calendar-detail-hero";
+const DESCRIPTION_ID = "release-calendar-detail-description";
+
+function easeOutCubic(progress: number) {
+  return 1 - Math.pow(1 - progress, 3);
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
 
 export default function ReleaseCalendarDetail() {
   const { slug } = useParams();
   const { t } = useTranslation();
   const [game, setGame] = useState<CrackCalendarGame | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+  const scrollAnimationFrameRef = useRef<number | null>(null);
+  const currentFocusId = useNavigationStore((state) => state.currentFocusId);
+  const navigation = NavigationService.getInstance();
 
   const monthCache = useAppSelector((state) => state.crackCalendar.monthCache);
 
@@ -37,12 +59,86 @@ export default function ReleaseCalendarDetail() {
     }
   }, [slug, monthCache]);
 
-  useHeaderTitle(game?.title || t("sidebar.release_calendar"));
+  useHeaderTitle(
+    game?.title || t("release_calendar", { defaultValue: "Release Calendar" })
+  );
+
+  const scrollPageBy = (delta: number) => {
+    const scrollElement = scrollAreaRef.current;
+    if (!scrollElement) return false;
+
+    const nextScrollTop = clamp(
+      scrollElement.scrollTop + delta,
+      0,
+      scrollElement.scrollHeight - scrollElement.clientHeight
+    );
+
+    if (nextScrollTop === scrollElement.scrollTop) return false;
+
+    if (scrollAnimationFrameRef.current !== null) {
+      cancelAnimationFrame(scrollAnimationFrameRef.current);
+    }
+
+    const startScrollTop = scrollElement.scrollTop;
+    const distance = nextScrollTop - startScrollTop;
+    const startTime = performance.now();
+
+    const animate = (now: number) => {
+      const progress = clamp(
+        (now - startTime) / SCROLL_ANIMATION_DURATION,
+        0,
+        1
+      );
+      const easedProgress = easeOutCubic(progress);
+
+      scrollElement.scrollTop = startScrollTop + distance * easedProgress;
+
+      if (progress < 1) {
+        scrollAnimationFrameRef.current = requestAnimationFrame(animate);
+      } else {
+        scrollElement.scrollTop = nextScrollTop;
+        scrollAnimationFrameRef.current = null;
+      }
+    };
+
+    scrollAnimationFrameRef.current = requestAnimationFrame(animate);
+    return true;
+  };
+
+  useNavigationScreenActions(
+    currentFocusId === DESCRIPTION_ID
+      ? {
+          direction: {
+            up: () => {
+              const scrollElement = scrollAreaRef.current;
+              if (scrollElement && scrollElement.scrollTop > 10) {
+                scrollPageBy(-SCROLL_STEP);
+                return;
+              }
+              navigation.setFocus(HERO_SECTION_ID);
+            },
+            down: () => {
+              const scrollElement = scrollAreaRef.current;
+              if (
+                scrollElement &&
+                scrollElement.scrollTop <
+                  scrollElement.scrollHeight - scrollElement.clientHeight - 10
+              ) {
+                scrollPageBy(SCROLL_STEP);
+                return;
+              }
+            },
+          },
+        }
+      : {}
+  );
 
   if (isLoading) {
     return (
       <section className="release-calendar-detail">
-        <Typography variant="body" className="status-message">Loading...</Typography>
+        <Typography variant="body" className="status-message">
+          Loading...
+        </Typography>
       </section>
     );
   }
@@ -50,66 +146,97 @@ export default function ReleaseCalendarDetail() {
   if (!game) {
     return (
       <section className="release-calendar-detail">
-        <Typography variant="body" className="status-message">Game not found</Typography>
+        <Typography variant="body" className="status-message">
+          Game not found
+        </Typography>
       </section>
     );
   }
 
   return (
-    <VerticalFocusGroup regionId="release-calendar-detail" asChild>
+    <VerticalFocusGroup
+      regionId="release-calendar-detail"
+      getScrollAnchor={() => scrollAreaRef.current}
+      asChild
+    >
       <section className="release-calendar-detail">
         <ScrollArea className="detail-scroll-area">
-          <div className="detail-container">
+          <div className="detail-container" ref={scrollAreaRef}>
             <div className="hero-section">
-               <div className="cover-wrapper">
-                 <img src={game.image || ""} alt={game.title} className="cover-image" />
-               </div>
-               <div className="info-panel">
-                 <Typography variant="h1">{game.title}</Typography>
-                 <div className="status-badges">
-                   <div className={`badge ${game.crackStatus === "CRACKED" ? "cracked" : "not-cracked"}`}>
-                     {game.crackStatus}
-                   </div>
-                   {game.countdown !== "Released" && (
-                     <div className="badge upcoming">
-                       {game.countdown}
-                     </div>
-                   )}
-                 </div>
-                 {game.statusNote && (
-                   <Typography variant="body" className="status-note">
-                     {game.statusNote}
-                   </Typography>
-                 )}
+              <FocusItem id={HERO_SECTION_ID} asChild>
+                <div className="cover-wrapper">
+                  <img
+                    src={game.image || ""}
+                    alt={game.title}
+                    className="cover-image"
+                  />
+                </div>
+              </FocusItem>
 
-                 <Divider />
+              <div className="info-panel">
+                <Typography variant="h1">{game.title}</Typography>
+                <div className="status-badges">
+                  <div
+                    className={`badge ${game.crackStatus === "CRACKED" ? "cracked" : "not-cracked"}`}
+                  >
+                    {game.crackStatus}
+                  </div>
 
-                 <div className="details-grid">
-                   <div className="detail-row">
-                     <Typography variant="label">Release Date</Typography>
-                     <Typography variant="body">{game.releaseDate}</Typography>
-                   </div>
-                   <div className="detail-row">
-                     <Typography variant="label">Crack Date</Typography>
-                     <Typography variant="body">{game.crackDate || "N/A"}</Typography>
-                   </div>
-                   <div className="detail-row">
-                     <Typography variant="label">DRM Protection</Typography>
-                     <Typography variant="body">{game.drmProtection || "None"}</Typography>
-                   </div>
-                   <div className="detail-row">
-                     <Typography variant="label">Scene Group</Typography>
-                     <Typography variant="body">{game.sceneGroup || "Unknown"}</Typography>
-                   </div>
-                 </div>
-               </div>
-            </div>
+                  {game.countdown && game.countdown !== "Released" && (
+                    <div className="badge upcoming">
+                      {formatCountdown(game.countdown)}
+                    </div>
+                  )}
+                </div>
+                {game.statusNote && (
+                  <Typography variant="body" className="status-note">
+                    {game.statusNote}
+                  </Typography>
+                )}
 
-            <div className="description-section">
-               <Typography variant="h3">Description</Typography>
-               <Typography variant="body" className="description">
-                 {game.description}
-               </Typography>
+                <div className="details-grid">
+                  <div className="detail-row">
+                    <Typography variant="label">{t("Release Date")}</Typography>
+                    <Typography variant="body">
+                      {game.releaseDate || t("Unknown")}
+                    </Typography>
+                  </div>
+                  <div className="detail-row">
+                    <Typography variant="label">{t("Crack Date")}</Typography>
+                    <Typography variant="body">
+                      {game.crackDate || t("N/A")}
+                    </Typography>
+                  </div>
+                  <div className="detail-row">
+                    <Typography variant="label">{t("DRM Protection")}</Typography>
+                    <Typography variant="body">
+                      {game.drmProtection || t("Unknown")}
+                    </Typography>
+                  </div>
+                  <div className="detail-row">
+                    <Typography variant="label">{t("Scene Group")}</Typography>
+                    <Typography variant="body">
+                      {game.sceneGroup || t("N/A")}
+                    </Typography>
+                  </div>
+                </div>
+
+                {game.description && (
+                  <FocusItem id={DESCRIPTION_ID} asChild>
+                    <Typography variant="body" className="description">
+                      {game.description}
+                    </Typography>
+                  </FocusItem>
+                )}
+
+                <div className="source">
+                  <a href={game.source_url} target="_blank" rel="noreferrer">
+                    <Typography variant="body">
+                      {t("View on isitcracked.com")}
+                    </Typography>
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
         </ScrollArea>

--- a/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx
+++ b/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useAppSelector } from "@renderer/hooks";
+import {
+  Typography,
+  VerticalFocusGroup,
+  ScrollArea,
+  Divider,
+} from "../../components";
+import { useHeaderTitle } from "../../hooks";
+import { CrackCalendarGame } from "@types";
+
+import "./styles.scss";
+
+export default function ReleaseCalendarDetail() {
+  const { slug } = useParams();
+  const { t } = useTranslation();
+  const [game, setGame] = useState<CrackCalendarGame | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const monthCache = useAppSelector((state) => state.crackCalendar.monthCache);
+
+  useEffect(() => {
+    const cachedGame = Object.values(monthCache)
+      .flatMap((month) => month.games)
+      .find((g) => g.slug === slug);
+
+    if (cachedGame) {
+      setGame(cachedGame);
+      setIsLoading(false);
+    } else {
+      window.electron.getCrackCalendarGame(slug!).then((res) => {
+        setGame(res);
+        setIsLoading(false);
+      });
+    }
+  }, [slug, monthCache]);
+
+  useHeaderTitle(game?.title || t("sidebar.release_calendar"));
+
+  if (isLoading) {
+    return (
+      <section className="release-calendar-detail">
+        <Typography variant="body" className="status-message">Loading...</Typography>
+      </section>
+    );
+  }
+
+  if (!game) {
+    return (
+      <section className="release-calendar-detail">
+        <Typography variant="body" className="status-message">Game not found</Typography>
+      </section>
+    );
+  }
+
+  return (
+    <VerticalFocusGroup regionId="release-calendar-detail" asChild>
+      <section className="release-calendar-detail">
+        <ScrollArea className="detail-scroll-area">
+          <div className="detail-container">
+            <div className="hero-section">
+               <div className="cover-wrapper">
+                 <img src={game.image || ""} alt={game.title} className="cover-image" />
+               </div>
+               <div className="info-panel">
+                 <Typography variant="h1">{game.title}</Typography>
+                 <div className="status-badges">
+                   <div className={`badge ${game.crackStatus === "CRACKED" ? "cracked" : "not-cracked"}`}>
+                     {game.crackStatus}
+                   </div>
+                   {game.countdown !== "Released" && (
+                     <div className="badge upcoming">
+                       {game.countdown}
+                     </div>
+                   )}
+                 </div>
+                 {game.statusNote && (
+                   <Typography variant="body" className="status-note">
+                     {game.statusNote}
+                   </Typography>
+                 )}
+
+                 <Divider />
+
+                 <div className="details-grid">
+                   <div className="detail-row">
+                     <Typography variant="label">Release Date</Typography>
+                     <Typography variant="body">{game.releaseDate}</Typography>
+                   </div>
+                   <div className="detail-row">
+                     <Typography variant="label">Crack Date</Typography>
+                     <Typography variant="body">{game.crackDate || "N/A"}</Typography>
+                   </div>
+                   <div className="detail-row">
+                     <Typography variant="label">DRM Protection</Typography>
+                     <Typography variant="body">{game.drmProtection || "None"}</Typography>
+                   </div>
+                   <div className="detail-row">
+                     <Typography variant="label">Scene Group</Typography>
+                     <Typography variant="body">{game.sceneGroup || "Unknown"}</Typography>
+                   </div>
+                 </div>
+               </div>
+            </div>
+
+            <div className="description-section">
+               <Typography variant="h3">Description</Typography>
+               <Typography variant="body" className="description">
+                 {game.description}
+               </Typography>
+            </div>
+          </div>
+        </ScrollArea>
+      </section>
+    </VerticalFocusGroup>
+  );
+}

--- a/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx
+++ b/src/big-picture/src/pages/release-calendar-detail/release-calendar-detail.tsx
@@ -6,7 +6,6 @@ import {
   Typography,
   VerticalFocusGroup,
   ScrollArea,
-  Divider,
   FocusItem,
 } from "../../components";
 import { useHeaderTitle, useNavigationScreenActions } from "../../hooks";
@@ -208,7 +207,9 @@ export default function ReleaseCalendarDetail() {
                     </Typography>
                   </div>
                   <div className="detail-row">
-                    <Typography variant="label">{t("DRM Protection")}</Typography>
+                    <Typography variant="label">
+                      {t("DRM Protection")}
+                    </Typography>
                     <Typography variant="body">
                       {game.drmProtection || t("Unknown")}
                     </Typography>

--- a/src/big-picture/src/pages/release-calendar-detail/styles.scss
+++ b/src/big-picture/src/pages/release-calendar-detail/styles.scss
@@ -1,0 +1,111 @@
+.release-calendar-detail {
+  margin-top: calc(-1 * var(--big-picture-header-height));
+  width: 100%;
+  min-width: 0;
+  height: calc(100% + var(--big-picture-header-height));
+  min-height: calc(100% + var(--big-picture-header-height));
+  overflow: hidden;
+  background: var(--background);
+  color: var(--text);
+}
+
+.status-message {
+  padding: calc(var(--big-picture-header-height) + var(--spacing-unit) * 8) calc(var(--spacing-unit) * 16);
+}
+
+.detail-scroll-area {
+  height: 100%;
+}
+
+.detail-container {
+  padding: calc(var(--big-picture-header-height) + var(--spacing-unit) * 8) calc(var(--spacing-unit) * 16);
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 12);
+}
+
+.hero-section {
+  display: flex;
+  gap: calc(var(--spacing-unit) * 10);
+}
+
+.cover-wrapper {
+  width: 300px;
+  flex-shrink: 0;
+
+  .cover-image {
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    border-radius: 8px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.info-panel {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 4);
+  flex: 1;
+}
+
+.status-badges {
+  display: flex;
+  gap: calc(var(--spacing-unit) * 2);
+}
+
+.badge {
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+
+  &.cracked {
+    background: var(--success);
+    color: #000;
+  }
+
+  &.not-cracked {
+    background: var(--error);
+    color: #fff;
+  }
+
+  &.upcoming {
+    background: var(--primary);
+    color: #000;
+  }
+}
+
+.status-note {
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.details-grid {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 2);
+}
+
+.detail-row {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  align-items: baseline;
+
+  span:first-child {
+    opacity: 0.5;
+  }
+}
+
+.description-section {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 4);
+}
+
+.description {
+  line-height: 1.6;
+  opacity: 0.9;
+  white-space: pre-wrap;
+}

--- a/src/big-picture/src/pages/release-calendar-detail/styles.scss
+++ b/src/big-picture/src/pages/release-calendar-detail/styles.scss
@@ -10,7 +10,8 @@
 }
 
 .status-message {
-  padding: calc(var(--big-picture-header-height) + var(--spacing-unit) * 8) calc(var(--spacing-unit) * 16);
+  padding: calc(var(--big-picture-header-height) + var(--spacing-unit) * 8)
+    calc(var(--spacing-unit) * 16);
 }
 
 .detail-scroll-area {
@@ -18,7 +19,8 @@
 }
 
 .detail-container {
-  padding: calc(var(--big-picture-header-height) + var(--spacing-unit) * 8) calc(var(--spacing-unit) * 16);
+  padding: calc(var(--big-picture-header-height) + var(--spacing-unit) * 8)
+    calc(var(--spacing-unit) * 16);
   display: flex;
   flex-direction: column;
   gap: calc(var(--spacing-unit) * 12);
@@ -27,11 +29,27 @@
 .hero-section {
   display: flex;
   gap: calc(var(--spacing-unit) * 10);
+  outline: none !important;
+
+  &:focus,
+  &:focus-visible,
+  &[data-focused="true"],
+  &[data-focus-visible="true"] {
+    outline: none !important;
+  }
 }
 
 .cover-wrapper {
   width: 300px;
   flex-shrink: 0;
+  outline: none !important;
+
+  &:focus,
+  &:focus-visible,
+  &[data-focused="true"],
+  &[data-focus-visible="true"] {
+    outline: none !important;
+  }
 
   .cover-image {
     width: 100%;
@@ -86,11 +104,16 @@
   display: flex;
   flex-direction: column;
   gap: calc(var(--spacing-unit) * 2);
+  margin-bottom: calc(var(--spacing-unit) * 8);
+  padding: calc(var(--spacing-unit) * 4);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--secondary-border);
+  border-radius: 8px;
 }
 
 .detail-row {
-  display: grid;
-  grid-template-columns: 200px 1fr;
+  display: flex;
+  justify-content: space-between;
   align-items: baseline;
 
   span:first-child {
@@ -98,14 +121,28 @@
   }
 }
 
-.description-section {
-  display: flex;
-  flex-direction: column;
-  gap: calc(var(--spacing-unit) * 4);
-}
-
 .description {
   line-height: 1.6;
   opacity: 0.9;
   white-space: pre-wrap;
+  outline: none !important;
+  margin-bottom: calc(var(--spacing-unit) * 8);
+
+  &:focus,
+  &:focus-visible,
+  &[data-focused="true"],
+  &[data-focus-visible="true"] {
+    outline: none !important;
+  }
+}
+
+.source {
+  a {
+    color: var(--primary);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/src/big-picture/src/pages/release-calendar/navigation-geometry.ts
+++ b/src/big-picture/src/pages/release-calendar/navigation-geometry.ts
@@ -1,0 +1,126 @@
+import type { FocusDirection } from "../../services";
+
+export interface ReleaseCalendarFocusPosition {
+  id: string;
+  rect: DOMRect;
+}
+
+function getPosition(element: HTMLElement | null) {
+  if (!element) return null;
+
+  const rect = element.getBoundingClientRect();
+
+  if (rect.width <= 0 || rect.height <= 0) return null;
+
+  return { id: element.id, rect };
+}
+
+export function getReleaseCalendarFocusPosition(id: string) {
+  return getPosition(globalThis.document.getElementById(id));
+}
+
+export function getActivePositionsInRegion(regionId: string) {
+  const region = globalThis.document.querySelector(
+    `[data-focus-region-id="${regionId}"]`
+  );
+
+  if (!(region instanceof HTMLElement)) return [];
+
+  return Array.from(
+    region.querySelectorAll<HTMLElement>(`[data-navigation-state="active"][id]`)
+  )
+    .map((element) => getPosition(element))
+    .filter((position): position is ReleaseCalendarFocusPosition => !!position);
+}
+
+function getAxisOverlap(
+  startA: number,
+  endA: number,
+  startB: number,
+  endB: number
+) {
+  return Math.max(0, Math.min(endA, endB) - Math.max(startA, startB));
+}
+
+function getCenter(rect: DOMRect) {
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}
+
+function getDirectionalScore(
+  current: DOMRect,
+  candidate: DOMRect,
+  direction: FocusDirection
+) {
+  if (direction === "left" || direction === "right") {
+    const primary =
+      direction === "left"
+        ? current.left - candidate.right
+        : candidate.left - current.right;
+
+    if (primary < 0) return null;
+
+    return {
+      overlap: getAxisOverlap(
+        current.top,
+        current.bottom,
+        candidate.top,
+        candidate.bottom
+      ),
+      primary,
+      cross: Math.abs(getCenter(current).y - getCenter(candidate).y),
+    };
+  }
+
+  const primary =
+    direction === "up"
+      ? current.top - candidate.bottom
+      : candidate.top - current.bottom;
+
+  if (primary < 0) return null;
+
+  return {
+    overlap: getAxisOverlap(
+      current.left,
+      current.right,
+      candidate.left,
+      candidate.right
+    ),
+    primary,
+    cross: Math.abs(getCenter(current).x - getCenter(candidate).x),
+  };
+}
+
+export function getClosestPositionInDirection(
+  current: ReleaseCalendarFocusPosition,
+  candidates: ReleaseCalendarFocusPosition[],
+  direction: FocusDirection
+) {
+  return candidates
+    .filter((candidate) => candidate.id !== current.id)
+    .map((candidate) => ({
+      candidate,
+      score: getDirectionalScore(current.rect, candidate.rect, direction),
+    }))
+    .filter(
+      (
+        scored
+      ): scored is {
+        candidate: ReleaseCalendarFocusPosition;
+        score: { overlap: number; primary: number; cross: number };
+      } => scored.score !== null
+    )
+    .sort((left, right) => {
+      if (left.score.overlap !== right.score.overlap) {
+        return right.score.overlap - left.score.overlap;
+      }
+
+      if (left.score.primary !== right.score.primary) {
+        return left.score.primary - right.score.primary;
+      }
+
+      return left.score.cross - right.score.cross;
+    })[0]?.candidate;
+}

--- a/src/big-picture/src/pages/release-calendar/navigation.ts
+++ b/src/big-picture/src/pages/release-calendar/navigation.ts
@@ -1,6 +1,9 @@
 export const RELEASE_CALENDAR_PAGE_REGION_ID = "release-calendar-page";
-export const RELEASE_CALENDAR_MONTH_TABS_REGION_ID = "release-calendar-month-tabs";
+export const RELEASE_CALENDAR_MONTH_TABS_REGION_ID =
+  "release-calendar-month-tabs";
 export const RELEASE_CALENDAR_GRID_REGION_ID = "release-calendar-grid";
+
+export const RELEASE_CALENDAR_EMPTY_STATE_ID = "release-calendar-empty-state";
 
 export function getReleaseCalendarMonthTabFocusId(month: string) {
   return `release-calendar-month-tab-${month}`;

--- a/src/big-picture/src/pages/release-calendar/navigation.ts
+++ b/src/big-picture/src/pages/release-calendar/navigation.ts
@@ -1,0 +1,11 @@
+export const RELEASE_CALENDAR_PAGE_REGION_ID = "release-calendar-page";
+export const RELEASE_CALENDAR_MONTH_TABS_REGION_ID = "release-calendar-month-tabs";
+export const RELEASE_CALENDAR_GRID_REGION_ID = "release-calendar-grid";
+
+export function getReleaseCalendarMonthTabFocusId(month: string) {
+  return `release-calendar-month-tab-${month}`;
+}
+
+export function getReleaseCalendarGameCardFocusId(slug: string) {
+  return `release-calendar-game-card-${slug}`;
+}

--- a/src/big-picture/src/pages/release-calendar/page.scss
+++ b/src/big-picture/src/pages/release-calendar/page.scss
@@ -81,7 +81,6 @@
   padding-left: calc(var(--spacing-unit) * 4);
 }
 
-
 .vertical-game-card {
   &[data-focused="true"] {
     outline: 2px solid var(--primary);

--- a/src/big-picture/src/pages/release-calendar/page.scss
+++ b/src/big-picture/src/pages/release-calendar/page.scss
@@ -21,6 +21,7 @@
 
 .month-tabs-container {
   display: flex;
+  align-items: center;
   gap: calc(var(--spacing-unit) * 2);
   overflow-x: auto;
   padding-bottom: calc(var(--spacing-unit) * 2);
@@ -31,8 +32,64 @@
   }
 }
 
+.month-arrow {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.month-nav-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--spacing-unit);
+  color: var(--text-secondary);
+}
+
+.bumper-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  min-width: 32px;
+  height: 20px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
 .month-tab {
   white-space: nowrap;
+
+  &[data-focused="true"] {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+    background: var(--primary-hover);
+  }
+}
+
+.last-updated {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-left: auto;
+  align-self: center;
+  white-space: nowrap;
+  padding-left: calc(var(--spacing-unit) * 4);
+}
+
+
+.vertical-game-card {
+  &[data-focused="true"] {
+    outline: 2px solid var(--primary);
+    outline-offset: 4px;
+    transform: scale(1.02);
+    transition: transform 0.2s ease-in-out;
+    z-index: 1;
+  }
 }
 
 .calendar-scroll-area {
@@ -42,9 +99,7 @@
 }
 
 .calendar-content {
-  display: flex;
-  flex-direction: column;
-  gap: calc(var(--spacing-unit) * 12);
+  display: block;
 }
 
 .day-group {
@@ -57,6 +112,12 @@
   margin: 0;
   font-weight: 700;
   text-transform: capitalize;
+  grid-column: 1 / -1;
+  margin-top: calc(var(--spacing-unit) * 8);
+
+  &:first-child {
+    margin-top: 0;
+  }
 }
 
 .game-grid {

--- a/src/big-picture/src/pages/release-calendar/page.scss
+++ b/src/big-picture/src/pages/release-calendar/page.scss
@@ -1,0 +1,87 @@
+.release-calendar-page {
+  margin-top: calc(-1 * var(--big-picture-header-height));
+  width: 100%;
+  min-width: 0;
+  height: calc(100% + var(--big-picture-header-height));
+  min-height: calc(100% + var(--big-picture-header-height));
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--background);
+  color: var(--text);
+}
+
+.release-calendar-container {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 8);
+  padding: calc(var(--spacing-unit) * 8) calc(var(--spacing-unit) * 16);
+  margin-top: calc(var(--spacing-unit) * 18);
+  min-height: fit-content;
+}
+
+.month-tabs-container {
+  display: flex;
+  gap: calc(var(--spacing-unit) * 2);
+  overflow-x: auto;
+  padding-bottom: calc(var(--spacing-unit) * 2);
+  flex-shrink: 0;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.month-tab {
+  white-space: nowrap;
+}
+
+.calendar-scroll-area {
+  flex: 1;
+  min-height: 0;
+  overflow: visible; // Ensure focus outlines aren't cut off
+}
+
+.calendar-content {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 12);
+}
+
+.day-group {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-unit) * 4);
+}
+
+.day-title {
+  margin: 0;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(var(--spacing-unit) * 4);
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1440px) {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: calc(var(--spacing-unit) * 6);
+  }
+
+  @media (min-width: 1920px) {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  @media (min-width: 2560px) {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+}

--- a/src/big-picture/src/pages/release-calendar/release-calendar.tsx
+++ b/src/big-picture/src/pages/release-calendar/release-calendar.tsx
@@ -21,11 +21,15 @@ import {
   RELEASE_CALENDAR_PAGE_REGION_ID,
   RELEASE_CALENDAR_MONTH_TABS_REGION_ID,
   RELEASE_CALENDAR_GRID_REGION_ID,
+  RELEASE_CALENDAR_EMPTY_STATE_ID,
   getReleaseCalendarMonthTabFocusId,
   getReleaseCalendarGameCardFocusId,
 } from "./navigation";
-import { useHeaderTitle } from "../../hooks";
+import { useHeaderTitle, useNavigationScreenActions } from "../../hooks";
 import { IS_DESKTOP } from "../../constants";
+import { getLastUpdatedLabel } from "@renderer/utils/get-last-updated-label";
+import { formatCountdown } from "@renderer/utils/format-countdown";
+import { useReleaseCalendarGridNavigation } from "./use-release-calendar-grid-navigation";
 
 import "./page.scss";
 
@@ -35,7 +39,7 @@ export default function ReleaseCalendar() {
   const [searchParams] = useSearchParams();
   const dispatch = useAppDispatch();
 
-  useHeaderTitle(t("sidebar.release_calendar"));
+  useHeaderTitle(t("release_calendar", { defaultValue: "Release Calendar" }));
 
   const searchQuery = searchParams.get("title") || "";
 
@@ -50,7 +54,10 @@ export default function ReleaseCalendar() {
 
   useEffect(() => {
     dispatch(fetchAvailableMonths()).then((action) => {
-      if (fetchAvailableMonths.fulfilled.match(action) && action.payload.length > 0) {
+      if (
+        fetchAvailableMonths.fulfilled.match(action) &&
+        action.payload.length > 0
+      ) {
         const currentMonthStr = new Date().toISOString().slice(0, 7);
         const monthToSelect = action.payload.includes(currentMonthStr)
           ? currentMonthStr
@@ -66,7 +73,9 @@ export default function ReleaseCalendar() {
   useEffect(() => {
     const unsubscribe = window.electron.onCrackCalendarUpdated(() => {
       if (selectedMonth) {
-        dispatch(fetchCalendarMonth({ month: selectedMonth, bypassCache: true }));
+        dispatch(
+          fetchCalendarMonth({ month: selectedMonth, bypassCache: true })
+        );
       }
     });
 
@@ -84,6 +93,27 @@ export default function ReleaseCalendar() {
   const handleMonthClick = (month: string) => {
     dispatch(fetchCalendarMonth({ month }));
   };
+
+  const handlePrevMonth = () => {
+    const currentIndex = availableMonths.indexOf(selectedMonth!);
+    if (currentIndex > 0) {
+      handleMonthClick(availableMonths[currentIndex - 1]);
+    }
+  };
+
+  const handleNextMonth = () => {
+    const currentIndex = availableMonths.indexOf(selectedMonth!);
+    if (currentIndex < availableMonths.length - 1) {
+      handleMonthClick(availableMonths[currentIndex + 1]);
+    }
+  };
+
+  useNavigationScreenActions({
+    press: {
+      l1: handlePrevMonth,
+      r1: handleNextMonth,
+    },
+  });
 
   const currentMonthData = selectedMonth ? monthCache[selectedMonth] : null;
 
@@ -111,6 +141,28 @@ export default function ReleaseCalendar() {
 
   const basePath = IS_DESKTOP ? "/big-picture" : "";
 
+  const itemIds = useMemo(() => {
+    if (searchQuery) {
+      if (searchResults.length > 0) {
+        return searchResults.map((game) =>
+          getReleaseCalendarGameCardFocusId(game.slug)
+        );
+      }
+      return [RELEASE_CALENDAR_EMPTY_STATE_ID];
+    }
+    if (currentMonthData) {
+      if (currentMonthData.games.length > 0) {
+        return currentMonthData.games.map((game) =>
+          getReleaseCalendarGameCardFocusId(game.slug)
+        );
+      }
+      return [RELEASE_CALENDAR_EMPTY_STATE_ID];
+    }
+    return [];
+  }, [searchQuery, searchResults, currentMonthData]);
+
+  const navigationOverridesByItemId = useReleaseCalendarGridNavigation(itemIds);
+
   return (
     <VerticalFocusGroup regionId={RELEASE_CALENDAR_PAGE_REGION_ID} asChild>
       <section className="release-calendar-page">
@@ -119,6 +171,9 @@ export default function ReleaseCalendar() {
             regionId={RELEASE_CALENDAR_MONTH_TABS_REGION_ID}
             className="month-tabs-container"
           >
+            <div className="month-nav-hint">
+              <span className="bumper-hint">LB</span>
+            </div>
             {availableMonths.map((month) => (
               <FocusItem
                 key={month}
@@ -126,6 +181,7 @@ export default function ReleaseCalendar() {
                 actions={{
                   primary: () => handleMonthClick(month),
                 }}
+                asChild
               >
                 <Button
                   variant={selectedMonth === month ? "primary" : "secondary"}
@@ -136,87 +192,151 @@ export default function ReleaseCalendar() {
                 </Button>
               </FocusItem>
             ))}
+            <div className="month-nav-hint">
+              <span className="bumper-hint">RB</span>
+            </div>
+
+            {currentMonthData?.updated_at && (
+              <span className="last-updated">
+                {getLastUpdatedLabel(currentMonthData.updated_at)}
+              </span>
+            )}
           </HorizontalFocusGroup>
 
           <ScrollArea className="calendar-scroll-area">
-            <div className="calendar-content">
+            <GridFocusGroup
+              regionId={RELEASE_CALENDAR_GRID_REGION_ID}
+              className="calendar-content game-grid"
+            >
               {searchQuery ? (
-                <div className="search-results-container">
+                <>
                   <Typography variant="h3" className="day-title">
                     {t("search_results")}
                   </Typography>
                   {isSearching ? (
                     <Typography variant="body">Searching...</Typography>
                   ) : searchResults.length > 0 ? (
-                    <GridFocusGroup
-                      regionId="release-calendar-search-grid"
-                      className="game-grid"
-                    >
-                      {searchResults.map((game) => (
-                        <FocusItem
-                          key={game.slug}
-                          id={getReleaseCalendarGameCardFocusId(game.slug)}
-                          actions={{
-                            primary: () => navigate(`${basePath}/crack-calendar/${game.slug}`),
-                          }}
-                        >
-                          <VerticalGameCard
-                            gameTitle={game.title}
-                            coverImageUrl={game.image}
-                            subtitle={game.crackStatus === "CRACKED" ? "CRACKED" : "NOT CRACKED"}
-                            progressLabel={game.countdown === "Released" ? "Released" : game.countdown!}
-                            progressValue={game.countdown === "Released" ? 1 : 0}
-                            progressColor={game.crackStatus === "CRACKED" ? "var(--success)" : "var(--error)"}
-                            hideProgressIcon={game.countdown !== "Released"}
-                          />
-                        </FocusItem>
-                      ))}
-                    </GridFocusGroup>
+                    searchResults.map((game) => (
+                      <FocusItem
+                        key={game.slug}
+                        id={getReleaseCalendarGameCardFocusId(game.slug)}
+                        navigationOverrides={
+                          navigationOverridesByItemId[
+                            getReleaseCalendarGameCardFocusId(game.slug)
+                          ]
+                        }
+                        actions={{
+                          primary: () =>
+                            navigate(`${basePath}/crack-calendar/${game.slug}`),
+                        }}
+                        asChild
+                      >
+                        <VerticalGameCard
+                          gameTitle={game.title}
+                          coverImageUrl={game.image}
+                          subtitle={
+                            game.crackStatus === "CRACKED"
+                              ? "CRACKED"
+                              : "NOT CRACKED"
+                          }
+                          progressLabel={
+                            game.countdown === "Released"
+                              ? "Released"
+                              : formatCountdown(game.countdown)
+                          }
+                          progressValue={game.countdown === "Released" ? 1 : 0}
+                          progressColor={
+                            game.crackStatus === "CRACKED"
+                              ? "var(--success)"
+                              : "var(--error)"
+                          }
+                          hideProgressIcon={game.countdown !== "Released"}
+                        />
+                      </FocusItem>
+                    ))
                   ) : (
-                    <Typography variant="body">No results found for "{searchQuery}"</Typography>
-                  )}
-                </div>
-              ) : isLoading && !currentMonthData ? (
-                 <Typography variant="body">Loading...</Typography>
-              ) : groupedGames.length > 0 ? (
-                groupedGames.map(([day, games]) => (
-                  <div key={day} className="day-group">
-                    <Typography variant="h3" className="day-title">
-                      {day} {formatMonth(selectedMonth!).split(" ")[0]}
-                    </Typography>
-                    <GridFocusGroup
-                      regionId={`${RELEASE_CALENDAR_GRID_REGION_ID}-${day}`}
-                      className="game-grid"
+                    <FocusItem
+                      id={RELEASE_CALENDAR_EMPTY_STATE_ID}
+                      navigationOverrides={
+                        navigationOverridesByItemId[
+                          RELEASE_CALENDAR_EMPTY_STATE_ID
+                        ]
+                      }
+                      asChild
                     >
-                      {games.map((game) => (
-                        <FocusItem
-                          key={game.slug}
-                          id={getReleaseCalendarGameCardFocusId(game.slug)}
-                          actions={{
-                            primary: () => navigate(`${basePath}/crack-calendar/${game.slug}`),
-                          }}
-                        >
-                          <VerticalGameCard
-                            gameTitle={game.title}
-                            coverImageUrl={game.image}
-                            subtitle={game.crackStatus === "CRACKED" ? "CRACKED" : "NOT CRACKED"}
-                            progressLabel={game.countdown === "Released" ? "Released" : game.countdown}
-                            progressValue={game.countdown === "Released" ? 1 : 0}
-                            progressColor={game.crackStatus === "CRACKED" ? "var(--success)" : "var(--error)"}
-                            hideProgressIcon={game.countdown !== "Released"}
-                          />
-                        </FocusItem>
-                      ))}
-                    </GridFocusGroup>
-                  </div>
-                ))
+                      <Typography variant="body">
+                        No results found for "{searchQuery}"
+                      </Typography>
+                    </FocusItem>
+                  )}
+                </>
+              ) : isLoading && !currentMonthData ? (
+                <Typography variant="body">Loading...</Typography>
+              ) : groupedGames.length > 0 ? (
+                groupedGames.flatMap(([day, games]) => [
+                  <Typography
+                    key={`title-${day}`}
+                    variant="h3"
+                    className="day-title"
+                  >
+                    {day} {formatMonth(selectedMonth!).split(" ")[0]}
+                  </Typography>,
+                  ...games.map((game) => (
+                    <FocusItem
+                      key={game.slug}
+                      id={getReleaseCalendarGameCardFocusId(game.slug)}
+                      navigationOverrides={
+                        navigationOverridesByItemId[
+                          getReleaseCalendarGameCardFocusId(game.slug)
+                        ]
+                      }
+                      actions={{
+                        primary: () =>
+                          navigate(`${basePath}/crack-calendar/${game.slug}`),
+                      }}
+                      asChild
+                    >
+                      <VerticalGameCard
+                        gameTitle={game.title}
+                        coverImageUrl={game.image}
+                        subtitle={
+                          game.crackStatus === "CRACKED"
+                            ? "CRACKED"
+                            : "NOT CRACKED"
+                        }
+                        progressLabel={
+                          game.countdown === "Released"
+                            ? "Released"
+                            : formatCountdown(game.countdown)
+                        }
+                        progressValue={game.countdown === "Released" ? 1 : 0}
+                        progressColor={
+                          game.crackStatus === "CRACKED"
+                            ? "var(--success)"
+                            : "var(--error)"
+                        }
+                        hideProgressIcon={game.countdown !== "Released"}
+                      />
+                    </FocusItem>
+                  )),
+                ])
               ) : (
-                <Typography variant="body">No games found for this month.</Typography>
+                <FocusItem
+                  id={RELEASE_CALENDAR_EMPTY_STATE_ID}
+                  navigationOverrides={
+                    navigationOverridesByItemId[RELEASE_CALENDAR_EMPTY_STATE_ID]
+                  }
+                  asChild
+                >
+                  <Typography variant="body">
+                    No games found for this month.
+                  </Typography>
+                </FocusItem>
               )}
-            </div>
+            </GridFocusGroup>
           </ScrollArea>
-        </div>
-      </section>
-    </VerticalFocusGroup>
+      </div>
+    </section>
+  </VerticalFocusGroup>
   );
 }

--- a/src/big-picture/src/pages/release-calendar/release-calendar.tsx
+++ b/src/big-picture/src/pages/release-calendar/release-calendar.tsx
@@ -212,7 +212,9 @@ export default function ReleaseCalendar() {
               {searchQuery ? (
                 <>
                   <Typography variant="h3" className="day-title">
-                    {t("search_results")}
+                    {t("search_results", {
+                      defaultValue: "Search results",
+                    })}
                   </Typography>
                   {isSearching ? (
                     <Typography variant="body">Searching...</Typography>

--- a/src/big-picture/src/pages/release-calendar/release-calendar.tsx
+++ b/src/big-picture/src/pages/release-calendar/release-calendar.tsx
@@ -28,6 +28,7 @@ import {
 import { useHeaderTitle, useNavigationScreenActions } from "../../hooks";
 import { IS_DESKTOP } from "../../constants";
 import { getLastUpdatedLabel } from "@renderer/utils/get-last-updated-label";
+import { CrackCalendarGame } from "@types";
 import { formatCountdown } from "@renderer/utils/format-countdown";
 import { useReleaseCalendarGridNavigation } from "./use-release-calendar-grid-navigation";
 
@@ -130,7 +131,7 @@ export default function ReleaseCalendar() {
 
   const groupedGames = useMemo(() => {
     if (!currentMonthData) return [];
-    const groups: Record<string, any[]> = {};
+    const groups: Record<string, CrackCalendarGame[]> = {};
     currentMonthData.games.forEach((game) => {
       const day = game.day || "Unknown";
       if (!groups[day]) groups[day] = [];
@@ -265,7 +266,9 @@ export default function ReleaseCalendar() {
                       asChild
                     >
                       <Typography variant="body">
-                        No results found for "{searchQuery}"
+                        {t("home.no_results_found_for", {
+                          query: searchQuery,
+                        })}
                       </Typography>
                     </FocusItem>
                   )}
@@ -335,8 +338,8 @@ export default function ReleaseCalendar() {
               )}
             </GridFocusGroup>
           </ScrollArea>
-      </div>
-    </section>
-  </VerticalFocusGroup>
+        </div>
+      </section>
+    </VerticalFocusGroup>
   );
 }

--- a/src/big-picture/src/pages/release-calendar/release-calendar.tsx
+++ b/src/big-picture/src/pages/release-calendar/release-calendar.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAppDispatch, useAppSelector } from "@renderer/hooks";
+import {
+  fetchAvailableMonths,
+  fetchCalendarMonth,
+  searchCalendar,
+} from "@renderer/features";
+import {
+  Button,
+  HorizontalFocusGroup,
+  Typography,
+  VerticalFocusGroup,
+  FocusItem,
+  GridFocusGroup,
+  ScrollArea,
+} from "../../components";
+import { VerticalGameCard } from "../../components/common/vertical-game-card";
+import {
+  RELEASE_CALENDAR_PAGE_REGION_ID,
+  RELEASE_CALENDAR_MONTH_TABS_REGION_ID,
+  RELEASE_CALENDAR_GRID_REGION_ID,
+  getReleaseCalendarMonthTabFocusId,
+  getReleaseCalendarGameCardFocusId,
+} from "./navigation";
+import { useHeaderTitle } from "../../hooks";
+import { IS_DESKTOP } from "../../constants";
+
+import "./page.scss";
+
+export default function ReleaseCalendar() {
+  const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const dispatch = useAppDispatch();
+
+  useHeaderTitle(t("sidebar.release_calendar"));
+
+  const searchQuery = searchParams.get("title") || "";
+
+  const {
+    availableMonths,
+    monthCache,
+    selectedMonth,
+    isLoading,
+    searchResults,
+    isSearching,
+  } = useAppSelector((state) => state.crackCalendar);
+
+  useEffect(() => {
+    dispatch(fetchAvailableMonths()).then((action) => {
+      if (fetchAvailableMonths.fulfilled.match(action) && action.payload.length > 0) {
+        const currentMonthStr = new Date().toISOString().slice(0, 7);
+        const monthToSelect = action.payload.includes(currentMonthStr)
+          ? currentMonthStr
+          : action.payload[0];
+
+        if (!selectedMonth) {
+          dispatch(fetchCalendarMonth({ month: monthToSelect }));
+        }
+      }
+    });
+  }, [dispatch]);
+
+  useEffect(() => {
+    const unsubscribe = window.electron.onCrackCalendarUpdated(() => {
+      if (selectedMonth) {
+        dispatch(fetchCalendarMonth({ month: selectedMonth, bypassCache: true }));
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [dispatch, selectedMonth]);
+
+  useEffect(() => {
+    if (searchQuery.trim()) {
+      dispatch(searchCalendar(searchQuery));
+    }
+  }, [dispatch, searchQuery]);
+
+  const handleMonthClick = (month: string) => {
+    dispatch(fetchCalendarMonth({ month }));
+  };
+
+  const currentMonthData = selectedMonth ? monthCache[selectedMonth] : null;
+
+  const formatMonth = (monthStr: string) => {
+    if (!monthStr) return "";
+    const [year, month] = monthStr.split("-");
+    if (!year || !month) return monthStr;
+    const date = new Date(parseInt(year), parseInt(month) - 1);
+    if (isNaN(date.getTime())) return monthStr;
+    const monthName = date.toLocaleString(i18n.language, { month: "short" });
+    const yearShort = year.slice(-2);
+    return `${monthName} ${yearShort}`;
+  };
+
+  const groupedGames = useMemo(() => {
+    if (!currentMonthData) return [];
+    const groups: Record<string, any[]> = {};
+    currentMonthData.games.forEach((game) => {
+      const day = game.day || "Unknown";
+      if (!groups[day]) groups[day] = [];
+      groups[day].push(game);
+    });
+    return Object.entries(groups).sort(([a], [b]) => parseInt(a) - parseInt(b));
+  }, [currentMonthData]);
+
+  const basePath = IS_DESKTOP ? "/big-picture" : "";
+
+  return (
+    <VerticalFocusGroup regionId={RELEASE_CALENDAR_PAGE_REGION_ID} asChild>
+      <section className="release-calendar-page">
+        <div className="release-calendar-container">
+          <HorizontalFocusGroup
+            regionId={RELEASE_CALENDAR_MONTH_TABS_REGION_ID}
+            className="month-tabs-container"
+          >
+            {availableMonths.map((month) => (
+              <FocusItem
+                key={month}
+                id={getReleaseCalendarMonthTabFocusId(month)}
+                actions={{
+                  primary: () => handleMonthClick(month),
+                }}
+              >
+                <Button
+                  variant={selectedMonth === month ? "primary" : "secondary"}
+                  className="month-tab"
+                  onClick={() => handleMonthClick(month)}
+                >
+                  {formatMonth(month)}
+                </Button>
+              </FocusItem>
+            ))}
+          </HorizontalFocusGroup>
+
+          <ScrollArea className="calendar-scroll-area">
+            <div className="calendar-content">
+              {searchQuery ? (
+                <div className="search-results-container">
+                  <Typography variant="h3" className="day-title">
+                    {t("search_results")}
+                  </Typography>
+                  {isSearching ? (
+                    <Typography variant="body">Searching...</Typography>
+                  ) : searchResults.length > 0 ? (
+                    <GridFocusGroup
+                      regionId="release-calendar-search-grid"
+                      className="game-grid"
+                    >
+                      {searchResults.map((game) => (
+                        <FocusItem
+                          key={game.slug}
+                          id={getReleaseCalendarGameCardFocusId(game.slug)}
+                          actions={{
+                            primary: () => navigate(`${basePath}/crack-calendar/${game.slug}`),
+                          }}
+                        >
+                          <VerticalGameCard
+                            gameTitle={game.title}
+                            coverImageUrl={game.image}
+                            subtitle={game.crackStatus === "CRACKED" ? "CRACKED" : "NOT CRACKED"}
+                            progressLabel={game.countdown === "Released" ? "Released" : game.countdown!}
+                            progressValue={game.countdown === "Released" ? 1 : 0}
+                            progressColor={game.crackStatus === "CRACKED" ? "var(--success)" : "var(--error)"}
+                            hideProgressIcon={game.countdown !== "Released"}
+                          />
+                        </FocusItem>
+                      ))}
+                    </GridFocusGroup>
+                  ) : (
+                    <Typography variant="body">No results found for "{searchQuery}"</Typography>
+                  )}
+                </div>
+              ) : isLoading && !currentMonthData ? (
+                 <Typography variant="body">Loading...</Typography>
+              ) : groupedGames.length > 0 ? (
+                groupedGames.map(([day, games]) => (
+                  <div key={day} className="day-group">
+                    <Typography variant="h3" className="day-title">
+                      {day} {formatMonth(selectedMonth!).split(" ")[0]}
+                    </Typography>
+                    <GridFocusGroup
+                      regionId={`${RELEASE_CALENDAR_GRID_REGION_ID}-${day}`}
+                      className="game-grid"
+                    >
+                      {games.map((game) => (
+                        <FocusItem
+                          key={game.slug}
+                          id={getReleaseCalendarGameCardFocusId(game.slug)}
+                          actions={{
+                            primary: () => navigate(`${basePath}/crack-calendar/${game.slug}`),
+                          }}
+                        >
+                          <VerticalGameCard
+                            gameTitle={game.title}
+                            coverImageUrl={game.image}
+                            subtitle={game.crackStatus === "CRACKED" ? "CRACKED" : "NOT CRACKED"}
+                            progressLabel={game.countdown === "Released" ? "Released" : game.countdown}
+                            progressValue={game.countdown === "Released" ? 1 : 0}
+                            progressColor={game.crackStatus === "CRACKED" ? "var(--success)" : "var(--error)"}
+                            hideProgressIcon={game.countdown !== "Released"}
+                          />
+                        </FocusItem>
+                      ))}
+                    </GridFocusGroup>
+                  </div>
+                ))
+              ) : (
+                <Typography variant="body">No games found for this month.</Typography>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+      </section>
+    </VerticalFocusGroup>
+  );
+}

--- a/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts
+++ b/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts
@@ -1,7 +1,6 @@
 import type { FocusOverrides } from "../../services";
 import { BIG_PICTURE_SIDEBAR_ITEM_IDS } from "../../layout";
 import { useEffect, useState } from "react";
-import { useNavigationStore } from "../../stores";
 import {
   RELEASE_CALENDAR_GRID_REGION_ID,
   RELEASE_CALENDAR_MONTH_TABS_REGION_ID,
@@ -163,12 +162,7 @@ export function useReleaseCalendarGridNavigation(itemIds: string[]) {
         RELEASE_CALENDAR_MONTH_TABS_REGION_ID
       );
 
-      setOverridesByItemId(
-        buildOverridesMapFromRows(
-          rows,
-          headerPositions
-        )
-      );
+      setOverridesByItemId(buildOverridesMapFromRows(rows, headerPositions));
     };
 
     function scheduleCompute() {

--- a/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts
+++ b/src/big-picture/src/pages/release-calendar/use-release-calendar-grid-navigation.ts
@@ -1,0 +1,213 @@
+import type { FocusOverrides } from "../../services";
+import { BIG_PICTURE_SIDEBAR_ITEM_IDS } from "../../layout";
+import { useEffect, useState } from "react";
+import { useNavigationStore } from "../../stores";
+import {
+  RELEASE_CALENDAR_GRID_REGION_ID,
+  RELEASE_CALENDAR_MONTH_TABS_REGION_ID,
+} from "./navigation";
+import {
+  type ReleaseCalendarFocusPosition,
+  getActivePositionsInRegion,
+  getReleaseCalendarFocusPosition,
+  getClosestPositionInDirection,
+} from "./navigation-geometry";
+
+interface GridItemPosition extends ReleaseCalendarFocusPosition {
+  top: number;
+  left: number;
+  centerX: number;
+}
+
+const ROW_TOLERANCE_PX = 24;
+
+function groupItemsIntoRows(items: GridItemPosition[]) {
+  const sortedItems = [...items].sort((leftItem, rightItem) => {
+    if (Math.abs(leftItem.top - rightItem.top) > ROW_TOLERANCE_PX) {
+      return leftItem.top - rightItem.top;
+    }
+
+    return leftItem.left - rightItem.left;
+  });
+
+  return sortedItems.reduce<GridItemPosition[][]>((rows, item) => {
+    const lastRow = rows.at(-1);
+
+    if (!lastRow || Math.abs(lastRow[0].top - item.top) > ROW_TOLERANCE_PX) {
+      rows.push([item]);
+      return rows;
+    }
+
+    lastRow.push(item);
+    lastRow.sort((leftItem, rightItem) => leftItem.left - rightItem.left);
+    return rows;
+  }, []);
+}
+
+function getClosestItemByCenterX(
+  items: GridItemPosition[] | undefined,
+  centerX: number
+) {
+  if (!items?.length) return null;
+
+  return [...items].sort((leftItem, rightItem) => {
+    return (
+      Math.abs(leftItem.centerX - centerX) -
+      Math.abs(rightItem.centerX - centerX)
+    );
+  })[0];
+}
+
+function buildFocusOverridesForGridItem(
+  item: GridItemPosition,
+  row: GridItemPosition[],
+  itemIndex: number,
+  rowIndex: number,
+  rows: GridItemPosition[][],
+  headerPositions: ReleaseCalendarFocusPosition[]
+): FocusOverrides {
+  const leftItem = row[itemIndex - 1];
+  const rightItem = row[itemIndex + 1];
+  const upItem = getClosestItemByCenterX(rows[rowIndex - 1], item.centerX);
+  const downItem = getClosestItemByCenterX(rows[rowIndex + 1], item.centerX);
+  const headerItem = getClosestPositionInDirection(item, headerPositions, "up");
+
+  return {
+    left: leftItem
+      ? {
+          type: "item",
+          itemId: leftItem.id,
+        }
+      : {
+          type: "item",
+          itemId: BIG_PICTURE_SIDEBAR_ITEM_IDS.releaseCalendar,
+        },
+    right: rightItem
+      ? {
+          type: "item",
+          itemId: rightItem.id,
+        }
+      : { type: "block" },
+    up: upItem
+      ? {
+          type: "item",
+          itemId: upItem.id,
+        }
+      : headerItem
+        ? {
+            type: "item",
+            itemId: headerItem.id,
+          }
+        : { type: "block" },
+    down: downItem
+      ? {
+          type: "item",
+          itemId: downItem.id,
+        }
+      : { type: "block" },
+  };
+}
+
+function buildOverridesMapFromRows(
+  rows: GridItemPosition[][],
+  headerPositions: ReleaseCalendarFocusPosition[]
+) {
+  const nextOverridesByItemId: Record<string, FocusOverrides> = {};
+
+  rows.forEach((row, rowIndex) => {
+    row.forEach((item, itemIndex) => {
+      nextOverridesByItemId[item.id] = buildFocusOverridesForGridItem(
+        item,
+        row,
+        itemIndex,
+        rowIndex,
+        rows,
+        headerPositions
+      );
+    });
+  });
+
+  return nextOverridesByItemId;
+}
+
+export function useReleaseCalendarGridNavigation(itemIds: string[]) {
+  const [overridesByItemId, setOverridesByItemId] = useState<
+    Record<string, FocusOverrides>
+  >({});
+  const itemIdsKey = itemIds.join("\u0000");
+
+  useEffect(() => {
+    const ids = itemIdsKey ? itemIdsKey.split("\u0000") : [];
+
+    if (ids.length === 0) {
+      setOverridesByItemId({});
+      return;
+    }
+
+    let animationFrameId = 0;
+    const resizeObserver = new ResizeObserver(() => scheduleCompute());
+    const mutationObserver = new MutationObserver(() => scheduleCompute());
+
+    const computeOverrides = () => {
+      const items = ids
+        .map((id) => getReleaseCalendarFocusPosition(id))
+        .filter((position) => !!position)
+        .map((position) => ({
+          ...position,
+          top: position.rect.top,
+          left: position.rect.left,
+          centerX: position.rect.left + position.rect.width / 2,
+        }));
+      const rows = groupItemsIntoRows(items);
+      const headerPositions = getActivePositionsInRegion(
+        RELEASE_CALENDAR_MONTH_TABS_REGION_ID
+      );
+
+      setOverridesByItemId(
+        buildOverridesMapFromRows(
+          rows,
+          headerPositions
+        )
+      );
+    };
+
+    function scheduleCompute() {
+      globalThis.cancelAnimationFrame(animationFrameId);
+      animationFrameId = globalThis.requestAnimationFrame(computeOverrides);
+    }
+
+    scheduleCompute();
+    globalThis.addEventListener("resize", scheduleCompute);
+
+    [
+      RELEASE_CALENDAR_GRID_REGION_ID,
+      RELEASE_CALENDAR_MONTH_TABS_REGION_ID,
+    ].forEach((regionId) => {
+      const element = globalThis.document.querySelector(
+        `[data-focus-region-id="${regionId}"]`
+      );
+
+      if (!(element instanceof HTMLElement)) return;
+
+      resizeObserver.observe(element);
+      mutationObserver.observe(element, { childList: true, subtree: true });
+    });
+
+    ids.forEach((id) => {
+      const element = globalThis.document.getElementById(id);
+
+      if (element) {
+        resizeObserver.observe(element);
+      }
+    });
+
+    return () => {
+      globalThis.cancelAnimationFrame(animationFrameId);
+      globalThis.removeEventListener("resize", scheduleCompute);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [itemIdsKey]);
+
+  return overridesByItemId;
+}

--- a/src/big-picture/src/pages/settings/integrations.tsx
+++ b/src/big-picture/src/pages/settings/integrations.tsx
@@ -35,11 +35,10 @@ type IntegrationPreferenceKey = Extract<
   | "torBoxApiToken"
 >;
 
-interface IntegrationProviderDefinition
-  extends Omit<
-    IntegrationProviderConfig<DebridUser>,
-    "upTarget" | "downTarget"
-  > {
+interface IntegrationProviderDefinition extends Omit<
+  IntegrationProviderConfig<DebridUser>,
+  "upTarget" | "downTarget"
+> {
   featureFlag?: string;
   tokenPreferenceKey: IntegrationPreferenceKey;
 }

--- a/src/big-picture/src/types/focus-item-actions.types.ts
+++ b/src/big-picture/src/types/focus-item-actions.types.ts
@@ -1,4 +1,12 @@
-export type NavigationActionButton = "a" | "b" | "x" | "y" | "start" | "select";
+export type NavigationActionButton =
+  | "a"
+  | "b"
+  | "x"
+  | "y"
+  | "start"
+  | "select"
+  | "l1"
+  | "r1";
 
 export type NavigationActionMode = "press" | "hold";
 export type FocusItemPressButton = "x" | "y";

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -110,11 +110,14 @@
     "decky_plugin_installation_failed": "Failed to install Decky plugin: {{error}}",
     "decky_plugin_installation_error": "Error installing Decky plugin: {{error}}",
     "confirm": "Confirm",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "release_calendar": "Release Calendar"
   },
   "header": {
     "search": "Search games",
     "search_library": "Search library",
+    "search_calendar": "Search calendar",
+    "release_calendar": "Release Calendar",
     "recent_searches": "Recent Searches",
     "suggestions": "Suggestions",
     "clear_history": "Clear",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -8,6 +8,7 @@
   "home": {
     "surprise_me": "Surprise me",
     "no_results": "No results found",
+    "no_results_found_for": "No results found for \"{{query}}\"",
     "start_typing": "Start typing to search...",
     "hot": "Hot now",
     "weekly": "📅 Top games of the week",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,5 +1,7 @@
 {
   "language_name": "English",
+  "release_calendar": "Release Calendar",
+  "search_results": "Search Results",
   "app": {
     "successfully_signed_in": "Successfully signed in"
   },
@@ -128,7 +130,7 @@
     "catalogue": "Catalogue",
     "library": "Library",
     "downloads": "Downloads",
-    "search_results": "Search results",
+    "search_results": "Search Results",
     "settings": "Settings",
     "version_available_install": "Version {{version}} available. Click here to restart and install.",
     "version_available_download": "Version {{version}} available. Click here to download.",

--- a/src/main/events/catalogue/get-crack-calendar-game.ts
+++ b/src/main/events/catalogue/get-crack-calendar-game.ts
@@ -8,6 +8,4 @@ const getCrackCalendarGame = async (
   return getGameDetail(slug);
 };
 
-registerEvent("get-crack-calendar-game", getCrackCalendarGame, {
-  needsAuth: false,
-});
+registerEvent("get-crack-calendar-game", getCrackCalendarGame);

--- a/src/main/events/catalogue/get-crack-calendar-game.ts
+++ b/src/main/events/catalogue/get-crack-calendar-game.ts
@@ -1,0 +1,13 @@
+import { getGameDetail } from "@main/services";
+import { registerEvent } from "../register-event";
+
+const getCrackCalendarGame = async (
+  _event: Electron.IpcMainInvokeEvent,
+  slug: string
+) => {
+  return getGameDetail(slug);
+};
+
+registerEvent("get-crack-calendar-game", getCrackCalendarGame, {
+  needsAuth: false,
+});

--- a/src/main/events/catalogue/get-crack-calendar-month.ts
+++ b/src/main/events/catalogue/get-crack-calendar-month.ts
@@ -1,0 +1,13 @@
+import { getCalendarMonth } from "@main/services";
+import { registerEvent } from "../register-event";
+
+const getCrackCalendarMonth = async (
+  _event: Electron.IpcMainInvokeEvent,
+  month: string
+) => {
+  return getCalendarMonth(month);
+};
+
+registerEvent("get-crack-calendar-month", getCrackCalendarMonth, {
+  needsAuth: false,
+});

--- a/src/main/events/catalogue/get-crack-calendar-month.ts
+++ b/src/main/events/catalogue/get-crack-calendar-month.ts
@@ -8,6 +8,4 @@ const getCrackCalendarMonth = async (
   return getCalendarMonth(month);
 };
 
-registerEvent("get-crack-calendar-month", getCrackCalendarMonth, {
-  needsAuth: false,
-});
+registerEvent("get-crack-calendar-month", getCrackCalendarMonth);

--- a/src/main/events/catalogue/get-crack-calendar-months.ts
+++ b/src/main/events/catalogue/get-crack-calendar-months.ts
@@ -1,0 +1,10 @@
+import { getAvailableMonths } from "@main/services";
+import { registerEvent } from "../register-event";
+
+const getCrackCalendarMonths = async (_event: Electron.IpcMainInvokeEvent) => {
+  return getAvailableMonths();
+};
+
+registerEvent("get-crack-calendar-months", getCrackCalendarMonths, {
+  needsAuth: false,
+});

--- a/src/main/events/catalogue/get-crack-calendar-months.ts
+++ b/src/main/events/catalogue/get-crack-calendar-months.ts
@@ -5,6 +5,4 @@ const getCrackCalendarMonths = async (_event: Electron.IpcMainInvokeEvent) => {
   return getAvailableMonths();
 };
 
-registerEvent("get-crack-calendar-months", getCrackCalendarMonths, {
-  needsAuth: false,
-});
+registerEvent("get-crack-calendar-months", getCrackCalendarMonths);

--- a/src/main/events/catalogue/index.ts
+++ b/src/main/events/catalogue/index.ts
@@ -2,3 +2,7 @@ import "./get-game-assets";
 import "./get-game-shop-details";
 import "./get-game-stats";
 import "./get-random-game";
+import "./get-crack-calendar-months";
+import "./get-crack-calendar-month";
+import "./get-crack-calendar-game";
+import "./search-crack-calendar";

--- a/src/main/events/catalogue/search-crack-calendar.ts
+++ b/src/main/events/catalogue/search-crack-calendar.ts
@@ -8,6 +8,4 @@ const searchCrackCalendar = async (
   return searchGames(query);
 };
 
-registerEvent("search-crack-calendar", searchCrackCalendar, {
-  needsAuth: false,
-});
+registerEvent("search-crack-calendar", searchCrackCalendar);

--- a/src/main/events/catalogue/search-crack-calendar.ts
+++ b/src/main/events/catalogue/search-crack-calendar.ts
@@ -1,0 +1,13 @@
+import { searchGames } from "@main/services";
+import { registerEvent } from "../register-event";
+
+const searchCrackCalendar = async (
+  _event: Electron.IpcMainInvokeEvent,
+  query: string
+) => {
+  return searchGames(query);
+};
+
+registerEvent("search-crack-calendar", searchCrackCalendar, {
+  needsAuth: false,
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, net, protocol } from "electron";
+import { app, BrowserWindow, net, protocol, session } from "electron";
 import updater from "electron-updater";
 import i18n from "i18next";
 import path from "node:path";
@@ -154,6 +154,20 @@ app.whenReady().then(async () => {
 
   WindowManager.createNotificationWindow();
   WindowManager.createSystemTray(language || "en");
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    const isSteamGridDB = details.url.includes("steamgriddb.com");
+    if (isSteamGridDB) {
+      callback({
+        responseHeaders: {
+          ...details.responseHeaders,
+          "Access-Control-Allow-Origin": ["*"],
+        },
+      });
+    } else {
+      callback({ responseHeaders: details.responseHeaders });
+    }
+  });
 
   if (deepLinkArg) {
     handleDeepLinkPath(deepLinkArg);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,6 +23,7 @@ import {
   DownloadOrchestrator,
   WSClient,
   WindowManager,
+  initCrackCalendarSocket,
   logger,
 } from "@main/services";
 import { migrateDownloadSources } from "./helpers/migrate-download-sources";
@@ -100,6 +101,7 @@ export const loadState = async () => {
       await DownloadSourcesChecker.checkForChanges();
     })();
     WSClient.connect();
+    initCrackCalendarSocket();
   });
 
   const downloadToResume =

--- a/src/main/services/achievements/parse-achievement-file.ts
+++ b/src/main/services/achievements/parse-achievement-file.ts
@@ -318,9 +318,8 @@ const processRld = (unlockedAchievements: any): UnlockedAchievement[] => {
 
     if (unlockedAchievement?.State) {
       const unlocked = new DataView(
-        new Uint8Array(
-          Buffer.from(unlockedAchievement.State.toString(), "hex")
-        ).buffer
+        new Uint8Array(Buffer.from(unlockedAchievement.State.toString(), "hex"))
+          .buffer
       ).getUint32(0, true);
 
       if (unlocked === 1) {

--- a/src/main/services/crack-calendar.ts
+++ b/src/main/services/crack-calendar.ts
@@ -78,7 +78,9 @@ export const initCrackCalendarSocket = () => {
   });
 
   ws.on("close", () => {
-    logger.info("Crack calendar WebSocket closed, reconnecting in 5 seconds...");
+    logger.info(
+      "Crack calendar WebSocket closed, reconnecting in 5 seconds..."
+    );
     setTimeout(initCrackCalendarSocket, 5000);
   });
 

--- a/src/main/services/crack-calendar.ts
+++ b/src/main/services/crack-calendar.ts
@@ -1,0 +1,89 @@
+import axios from "axios";
+import { WebSocket } from "ws";
+import { WindowManager } from "./window-manager";
+import { logger } from "./logger";
+import type { CrackCalendarGame, CrackCalendarMonth } from "@types";
+
+const API_BASE_URL = "https://hydra-calendar-api.jagsinghwork0.workers.dev";
+const WS_URL = "wss://hydra-calendar-api.jagsinghwork0.workers.dev/v1/live";
+
+export const getAvailableMonths = async (): Promise<string[]> => {
+  return axios
+    .get(`${API_BASE_URL}/v1/months`)
+    .then((response) => response.data.months || [])
+    .catch((err) => {
+      logger.error("Failed to fetch available months:", err);
+      return [];
+    });
+};
+
+export const getCalendarMonth = async (
+  month: string
+): Promise<CrackCalendarMonth | null> => {
+  return axios
+    .get(`${API_BASE_URL}/v1/month/${month}`)
+    .then((response) => response.data)
+    .catch((err) => {
+      logger.error(`Failed to fetch calendar for month ${month}:`, err);
+      return null;
+    });
+};
+
+export const getGameDetail = async (
+  slug: string
+): Promise<CrackCalendarGame | null> => {
+  return axios
+    .get(`${API_BASE_URL}/v1/game/${slug}`)
+    .then((response) => response.data)
+    .catch((err) => {
+      logger.error(`Failed to fetch game detail for ${slug}:`, err);
+      return null;
+    });
+};
+
+export const searchGames = async (
+  query: string
+): Promise<CrackCalendarGame[]> => {
+  return axios
+    .get(`${API_BASE_URL}/v1/search`, { params: { q: query } })
+    .then((response) => response.data.results || [])
+    .catch((err) => {
+      logger.error(`Failed to search games for query ${query}:`, err);
+      return [];
+    });
+};
+
+let ws: WebSocket | null = null;
+
+export const initCrackCalendarSocket = () => {
+  if (ws) {
+    ws.close();
+  }
+
+  ws = new WebSocket(WS_URL);
+
+  ws.on("open", () => {
+    logger.info("Crack calendar WebSocket connected");
+  });
+
+  ws.on("message", (data) => {
+    try {
+      const message = JSON.parse(data.toString());
+      if (message.type === "calendar_update") {
+        WindowManager.mainWindow?.webContents.send("crack-calendar-updated");
+      }
+    } catch (err) {
+      logger.error("Failed to parse crack calendar WebSocket message:", err);
+    }
+  });
+
+  ws.on("close", () => {
+    logger.info("Crack calendar WebSocket closed, reconnecting in 5 seconds...");
+    setTimeout(initCrackCalendarSocket, 5000);
+  });
+
+  ws.on("error", (err) => {
+    logger.error("Crack calendar WebSocket error:", err);
+    ws?.close();
+  });
+};

--- a/src/main/services/index.ts
+++ b/src/main/services/index.ts
@@ -26,3 +26,4 @@ export * from "./download-sources-checker";
 export * from "./notifications/local-notifications";
 export * from "./power-save-blocker";
 export * from "./native-addon";
+export * from "./crack-calendar";

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -918,8 +918,7 @@ contextBridge.exposeInMainWorld("electron", {
   onCrackCalendarUpdated: (callback: () => void) => {
     const listener = (_event: Electron.IpcRendererEvent) => callback();
     ipcRenderer.on("crack-calendar-updated", listener);
-    return () =>
-      ipcRenderer.removeListener("crack-calendar-updated", listener);
+    return () => ipcRenderer.removeListener("crack-calendar-updated", listener);
   },
 
   // Add these to the electron object in contextBridge.exposeInMainWorld

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,6 +23,8 @@ import type {
   ProtonVersion,
   TorrentFilesResponse,
   DownloadLayoutState,
+  CrackCalendarGame,
+  CrackCalendarMonth,
 } from "@types";
 import type { AuthPage } from "@shared";
 import type { AxiosProgressEvent } from "axios";
@@ -900,6 +902,25 @@ contextBridge.exposeInMainWorld("electron", {
     ipcRenderer.invoke("resumeGameTransfer", shop, objectId),
   cancelGameTransfer: (shop: GameShop, objectId: string) =>
     ipcRenderer.invoke("cancelGameTransfer", shop, objectId),
+
+  getCrackCalendarMonths: (): Promise<string[]> =>
+    ipcRenderer.invoke("get-crack-calendar-months"),
+
+  getCrackCalendarMonth: (month: string): Promise<CrackCalendarMonth | null> =>
+    ipcRenderer.invoke("get-crack-calendar-month", month),
+
+  getCrackCalendarGame: (slug: string): Promise<CrackCalendarGame | null> =>
+    ipcRenderer.invoke("get-crack-calendar-game", slug),
+
+  searchCrackCalendar: (query: string): Promise<CrackCalendarGame[]> =>
+    ipcRenderer.invoke("search-crack-calendar", query),
+
+  onCrackCalendarUpdated: (callback: () => void) => {
+    const listener = (_event: Electron.IpcRendererEvent) => callback();
+    ipcRenderer.on("crack-calendar-updated", listener);
+    return () =>
+      ipcRenderer.removeListener("crack-calendar-updated", listener);
+  },
 
   // Add these to the electron object in contextBridge.exposeInMainWorld
   on: (channel: string, listener: (...args: any[]) => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -146,7 +146,6 @@ contextBridge.exposeInMainWorld("electron", {
       );
   },
 
-
   /* User preferences */
   getUserPreferences: () => ipcRenderer.invoke("getUserPreferences"),
   updateUserPreferences: (preferences: Partial<UserPreferences>) =>
@@ -904,8 +903,7 @@ contextBridge.exposeInMainWorld("electron", {
   cancelGameTransfer: (shop: GameShop, objectId: string) =>
     ipcRenderer.invoke("cancelGameTransfer", shop, objectId),
 
-  getCrackCalendarMonths: () =>
-    ipcRenderer.invoke("get-crack-calendar-months"),
+  getCrackCalendarMonths: () => ipcRenderer.invoke("get-crack-calendar-months"),
   getCrackCalendarMonth: (month: string): Promise<CrackCalendarMonth | null> =>
     ipcRenderer.invoke("get-crack-calendar-month", month),
   getCrackCalendarGame: (slug: string): Promise<CrackCalendarGame | null> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -146,19 +146,6 @@ contextBridge.exposeInMainWorld("electron", {
       );
   },
 
-  /* Crack Calendar */
-  getCrackCalendarMonths: () => ipcRenderer.invoke("getCrackCalendarMonths"),
-  getCrackCalendarMonth: (month: string) =>
-    ipcRenderer.invoke("getCrackCalendarMonth", month),
-  searchCrackCalendar: (query: string) =>
-    ipcRenderer.invoke("searchCrackCalendar", query),
-  getCrackCalendarGame: (slug: string) =>
-    ipcRenderer.invoke("getCrackCalendarGame", slug),
-  onCrackCalendarUpdated: (cb: () => void) => {
-    const listener = () => cb();
-    ipcRenderer.on("crackCalendarUpdated", listener);
-    return () => ipcRenderer.removeListener("crackCalendarUpdated", listener);
-  },
 
   /* User preferences */
   getUserPreferences: () => ipcRenderer.invoke("getUserPreferences"),
@@ -917,18 +904,14 @@ contextBridge.exposeInMainWorld("electron", {
   cancelGameTransfer: (shop: GameShop, objectId: string) =>
     ipcRenderer.invoke("cancelGameTransfer", shop, objectId),
 
-  getCrackCalendarMonths: (): Promise<string[]> =>
+  getCrackCalendarMonths: () =>
     ipcRenderer.invoke("get-crack-calendar-months"),
-
   getCrackCalendarMonth: (month: string): Promise<CrackCalendarMonth | null> =>
     ipcRenderer.invoke("get-crack-calendar-month", month),
-
   getCrackCalendarGame: (slug: string): Promise<CrackCalendarGame | null> =>
     ipcRenderer.invoke("get-crack-calendar-game", slug),
-
   searchCrackCalendar: (query: string): Promise<CrackCalendarGame[]> =>
     ipcRenderer.invoke("search-crack-calendar", query),
-
   onCrackCalendarUpdated: (callback: () => void) => {
     const listener = (_event: Electron.IpcRendererEvent) => callback();
     ipcRenderer.on("crack-calendar-updated", listener);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -146,6 +146,20 @@ contextBridge.exposeInMainWorld("electron", {
       );
   },
 
+  /* Crack Calendar */
+  getCrackCalendarMonths: () => ipcRenderer.invoke("getCrackCalendarMonths"),
+  getCrackCalendarMonth: (month: string) =>
+    ipcRenderer.invoke("getCrackCalendarMonth", month),
+  searchCrackCalendar: (query: string) =>
+    ipcRenderer.invoke("searchCrackCalendar", query),
+  getCrackCalendarGame: (slug: string) =>
+    ipcRenderer.invoke("getCrackCalendarGame", slug),
+  onCrackCalendarUpdated: (cb: () => void) => {
+    const listener = () => cb();
+    ipcRenderer.on("crackCalendarUpdated", listener);
+    return () => ipcRenderer.removeListener("crackCalendarUpdated", listener);
+  },
+
   /* User preferences */
   getUserPreferences: () => ipcRenderer.invoke("getUserPreferences"),
   updateUserPreferences: (preferences: Partial<UserPreferences>) =>

--- a/src/renderer/src/components/avatar/avatar.tsx
+++ b/src/renderer/src/components/avatar/avatar.tsx
@@ -3,14 +3,13 @@ import cn from "classnames";
 
 import "./avatar.scss";
 
-export interface AvatarProps
-  extends Omit<
-    React.DetailedHTMLProps<
-      React.ImgHTMLAttributes<HTMLImageElement>,
-      HTMLImageElement
-    >,
-    "src"
-  > {
+export interface AvatarProps extends Omit<
+  React.DetailedHTMLProps<
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    HTMLImageElement
+  >,
+  "src"
+> {
   size: number;
   src?: string | null;
 }

--- a/src/renderer/src/components/button/button.tsx
+++ b/src/renderer/src/components/button/button.tsx
@@ -4,11 +4,10 @@ import { PlacesType, Tooltip } from "react-tooltip";
 import "./button.scss";
 import { useId } from "react";
 
-export interface ButtonProps
-  extends React.DetailedHTMLProps<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    HTMLButtonElement
-  > {
+export interface ButtonProps extends React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> {
   tooltip?: string;
   tooltipPlace?: PlacesType;
   theme?: "primary" | "outline" | "dark" | "danger";

--- a/src/renderer/src/components/checkbox-field/checkbox-field.tsx
+++ b/src/renderer/src/components/checkbox-field/checkbox-field.tsx
@@ -2,11 +2,10 @@ import { useId } from "react";
 import { CheckIcon } from "@primer/octicons-react";
 import "./checkbox-field.scss";
 
-export interface CheckboxFieldProps
-  extends React.DetailedHTMLProps<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    HTMLInputElement
-  > {
+export interface CheckboxFieldProps extends React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> {
   label: string | React.ReactNode;
 }
 

--- a/src/renderer/src/components/game-card/game-card.tsx
+++ b/src/renderer/src/components/game-card/game-card.tsx
@@ -11,11 +11,10 @@ import { StarRating } from "../star-rating/star-rating";
 import { useCallback, useState } from "react";
 import { useFormat } from "@renderer/hooks";
 
-export interface GameCardProps
-  extends React.DetailedHTMLProps<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    HTMLButtonElement
-  > {
+export interface GameCardProps extends React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> {
   game: ShopAssets;
 }
 

--- a/src/renderer/src/components/header/header.tsx
+++ b/src/renderer/src/components/header/header.tsx
@@ -149,7 +149,8 @@ export function Header() {
     if (location.pathname.startsWith("/notifications")) return headerTitle;
     if (location.pathname.startsWith("/crack-calendar/"))
       return (
-        headerTitle || t("release_calendar", { defaultValue: "Release Calendar" })
+        headerTitle ||
+        t("release_calendar", { defaultValue: "Release Calendar" })
       );
     if (location.pathname.startsWith("/library"))
       return headerTitle || t("library");

--- a/src/renderer/src/components/header/header.tsx
+++ b/src/renderer/src/components/header/header.tsx
@@ -26,7 +26,12 @@ import {
 import "./header.scss";
 import { AutoUpdateSubHeader } from "./auto-update-sub-header";
 import { ScanGamesModal } from "./scan-games-modal";
-import { setFilters, setLibrarySearchQuery } from "@renderer/features";
+import {
+  setFilters,
+  setLibrarySearchQuery,
+  setCalendarSearchQuery,
+  searchCalendar,
+} from "@renderer/features";
 import cn from "classnames";
 import { SearchDropdown } from "@renderer/components";
 import { buildGameDetailsPath } from "@renderer/helpers";
@@ -39,6 +44,7 @@ const pathTitle: Record<string, string> = {
   "/library": "library",
   "/downloads": "downloads",
   "/settings": "settings",
+  "/crack-calendar": "release_calendar",
 };
 
 export function Header() {
@@ -62,11 +68,18 @@ export function Header() {
     (state) => state.library.searchQuery
   );
 
+  const calendarSearchValue = useAppSelector(
+    (state) => state.crackCalendar.searchQuery
+  );
+
   const isOnLibraryPage = location.pathname.startsWith("/library");
   const isOnCataloguePage = location.pathname.startsWith("/catalogue");
+  const isOnCrackCalendarPage = location.pathname === "/crack-calendar";
 
   const searchValue = isOnLibraryPage
     ? librarySearchValue
+    : isOnCrackCalendarPage
+    ? calendarSearchValue
     : catalogueSearchValue;
 
   const [localSearchValue, setLocalSearchValue] = useState(searchValue);
@@ -86,6 +99,15 @@ export function Header() {
     () =>
       debounce((value: string) => {
         dispatch(setFilters({ title: value }));
+      }, 250),
+    [dispatch]
+  );
+
+  const debouncedCrackCalendarSearch = useMemo(
+    () =>
+      debounce((value: string) => {
+        dispatch(setCalendarSearchQuery(value));
+        dispatch(searchCalendar(value));
       }, 250),
     [dispatch]
   );
@@ -125,6 +147,8 @@ export function Header() {
     if (location.pathname.startsWith("/achievements")) return headerTitle;
     if (location.pathname.startsWith("/profile")) return headerTitle;
     if (location.pathname.startsWith("/notifications")) return headerTitle;
+    if (location.pathname.startsWith("/crack-calendar/"))
+      return headerTitle || t("release_calendar");
     if (location.pathname.startsWith("/library"))
       return headerTitle || t("library");
     if (location.pathname.startsWith("/search")) return t("search_results");
@@ -192,6 +216,9 @@ export function Header() {
 
     if (isOnLibraryPage) {
       dispatch(setLibrarySearchQuery(value.slice(0, 255)));
+    } else if (isOnCrackCalendarPage) {
+      dispatch(setCalendarSearchQuery(value.slice(0, 255)));
+      dispatch(searchCalendar(value.slice(0, 255)));
     } else {
       dispatch(setFilters({ title: value.slice(0, 255) }));
     }
@@ -206,9 +233,15 @@ export function Header() {
 
     if (isOnLibraryPage) {
       debouncedCatalogueSearch.cancel();
+      debouncedCrackCalendarSearch.cancel();
       debouncedLibrarySearch(normalizedValue);
+    } else if (isOnCrackCalendarPage) {
+      debouncedLibrarySearch.cancel();
+      debouncedCatalogueSearch.cancel();
+      debouncedCrackCalendarSearch(normalizedValue);
     } else {
       debouncedLibrarySearch.cancel();
+      debouncedCrackCalendarSearch.cancel();
       debouncedCatalogueSearch(normalizedValue);
     }
   };
@@ -251,6 +284,9 @@ export function Header() {
 
     if (isOnLibraryPage) {
       dispatch(setLibrarySearchQuery(""));
+    } else if (isOnCrackCalendarPage) {
+      dispatch(setCalendarSearchQuery(""));
+      dispatch(searchCalendar(""));
     } else {
       dispatch(setFilters({ title: "" }));
     }
@@ -390,44 +426,52 @@ export function Header() {
             </button>
           )}
 
-          <div
-            ref={searchContainerRef}
-            className={cn("header__search", {
-              "header__search--focused": isFocused,
-            })}
-          >
-            <button
-              type="button"
-              className="header__action-button"
-              onClick={focusInput}
+          {!location.pathname.startsWith("/crack-calendar/") && (
+            <div
+              ref={searchContainerRef}
+              className={cn("header__search", {
+                "header__search--focused": isFocused,
+              })}
             >
-              <SearchIcon />
-            </button>
-
-            <input
-              ref={inputRef}
-              type="text"
-              name="search"
-              placeholder={isOnLibraryPage ? t("search_library") : t("search")}
-              value={localSearchValue}
-              className="header__search-input"
-              onChange={(event) => handleInputChange(event.target.value)}
-              onFocus={handleFocus}
-              onBlur={handleBlur}
-              onKeyDown={handleKeyDown}
-            />
-
-            {localSearchValue && (
               <button
                 type="button"
-                onMouseDown={handleClearSearchMouseDown}
-                onClick={handleClearSearch}
                 className="header__action-button"
+                onClick={focusInput}
               >
-                <XIcon />
+                <SearchIcon />
               </button>
-            )}
-          </div>
+
+              <input
+                ref={inputRef}
+                type="text"
+                name="search"
+                placeholder={
+                  isOnLibraryPage
+                    ? t("search_library")
+                    : isOnCrackCalendarPage
+                    ? t("search_calendar")
+                    : t("search")
+                }
+                value={localSearchValue}
+                className="header__search-input"
+                onChange={(event) => handleInputChange(event.target.value)}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+              />
+
+              {localSearchValue && (
+                <button
+                  type="button"
+                  onMouseDown={handleClearSearchMouseDown}
+                  onClick={handleClearSearch}
+                  className="header__action-button"
+                >
+                  <XIcon />
+                </button>
+              )}
+            </div>
+          )}
         </section>
       </header>
 

--- a/src/renderer/src/components/header/header.tsx
+++ b/src/renderer/src/components/header/header.tsx
@@ -79,8 +79,8 @@ export function Header() {
   const searchValue = isOnLibraryPage
     ? librarySearchValue
     : isOnCrackCalendarPage
-    ? calendarSearchValue
-    : catalogueSearchValue;
+      ? calendarSearchValue
+      : catalogueSearchValue;
 
   const [localSearchValue, setLocalSearchValue] = useState(searchValue);
   const deferredSearchValue = useDeferredValue(localSearchValue);
@@ -148,12 +148,18 @@ export function Header() {
     if (location.pathname.startsWith("/profile")) return headerTitle;
     if (location.pathname.startsWith("/notifications")) return headerTitle;
     if (location.pathname.startsWith("/crack-calendar/"))
-      return headerTitle || t("release_calendar");
+      return (
+        headerTitle || t("release_calendar", { defaultValue: "Release Calendar" })
+      );
     if (location.pathname.startsWith("/library"))
       return headerTitle || t("library");
     if (location.pathname.startsWith("/search")) return t("search_results");
 
-    return t(pathTitle[location.pathname]);
+    const translationKey = pathTitle[location.pathname];
+    if (translationKey === "release_calendar")
+      return t(translationKey, { defaultValue: "Release Calendar" });
+
+    return t(translationKey);
   }, [location.pathname, headerTitle, t]);
 
   const totalItems = historyItems.length + suggestions.length;
@@ -449,8 +455,8 @@ export function Header() {
                   isOnLibraryPage
                     ? t("search_library")
                     : isOnCrackCalendarPage
-                    ? t("search_calendar")
-                    : t("search")
+                      ? t("search_calendar")
+                      : t("search")
                 }
                 value={localSearchValue}
                 className="header__search-input"

--- a/src/renderer/src/components/radio-field/radio-field.tsx
+++ b/src/renderer/src/components/radio-field/radio-field.tsx
@@ -4,8 +4,10 @@ import cn from "classnames";
 
 import "./radio-field.scss";
 
-export interface RadioFieldProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+export interface RadioFieldProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type"
+> {
   label: React.ReactNode;
   className?: string;
   labelClassName?: string;

--- a/src/renderer/src/components/select-field/select-field.tsx
+++ b/src/renderer/src/components/select-field/select-field.tsx
@@ -2,11 +2,10 @@ import { useId, useState } from "react";
 import "./select-field.scss";
 import cn from "classnames";
 
-export interface SelectProps
-  extends React.DetailedHTMLProps<
-    React.SelectHTMLAttributes<HTMLSelectElement>,
-    HTMLSelectElement
-  > {
+export interface SelectProps extends React.DetailedHTMLProps<
+  React.SelectHTMLAttributes<HTMLSelectElement>,
+  HTMLSelectElement
+> {
   theme?: "primary" | "dark";
   label?: string;
   options?: { key: string; value: string; label: string }[];

--- a/src/renderer/src/components/sidebar/routes.tsx
+++ b/src/renderer/src/components/sidebar/routes.tsx
@@ -4,6 +4,7 @@ import {
   GearIcon,
   HomeIcon,
   BookIcon,
+  CalendarIcon,
 } from "@primer/octicons-react";
 
 export const routes = [
@@ -16,6 +17,11 @@ export const routes = [
     path: "/catalogue",
     nameKey: "catalogue",
     render: () => <AppsIcon />,
+  },
+  {
+    path: "/crack-calendar",
+    nameKey: "release_calendar",
+    render: () => <CalendarIcon />,
   },
   {
     path: "/library",

--- a/src/renderer/src/components/text-field/text-field.tsx
+++ b/src/renderer/src/components/text-field/text-field.tsx
@@ -4,11 +4,10 @@ import { useTranslation } from "react-i18next";
 import cn from "classnames";
 import "./text-field.scss";
 
-export interface TextFieldProps
-  extends React.DetailedHTMLProps<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    HTMLInputElement
-  > {
+export interface TextFieldProps extends React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> {
   theme?: "primary" | "dark";
   label?: string | React.ReactNode;
   hint?: string | React.ReactNode;

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -509,6 +509,9 @@ declare global {
 
     /* Profile */
     getMe: () => Promise<UserDetails | null>;
+    updateProfile: (
+      updateProfile: UpdateProfileRequest
+    ) => Promise<UserProfile>;
     updateProfile: (updateProfile: UpdateProfileProps) => Promise<UserProfile>;
     getProfileImageMetadata: (
       path: string

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -331,7 +331,7 @@ declare global {
     /* Download sources */
     addDownloadSource: (url: string) => Promise<DownloadSource>;
     removeDownloadSource: (
-      removeAll = false,
+      removeAll?: boolean,
       downloadSourceId?: string
     ) => Promise<void>;
     getDownloadSources: () => Promise<DownloadSource[]>;

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -509,9 +509,6 @@ declare global {
 
     /* Profile */
     getMe: () => Promise<UserDetails | null>;
-    updateProfile: (
-      updateProfile: UpdateProfileRequest
-    ) => Promise<UserProfile>;
     updateProfile: (updateProfile: UpdateProfileProps) => Promise<UserProfile>;
     getProfileImageMetadata: (
       path: string

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -39,6 +39,8 @@ import type {
   CreateSteamShortcutOptions,
   TorrentFilesResponse,
   DownloadLayoutState,
+  CrackCalendarGame,
+  CrackCalendarMonth,
 } from "@types";
 import type { AxiosProgressEvent } from "axios";
 
@@ -127,6 +129,13 @@ declare global {
       shop: GameShop,
       cb: (achievements: UserAchievement[]) => void
     ) => () => Electron.IpcRenderer;
+
+    /* Crack Calendar */
+    getCrackCalendarMonths(): Promise<CrackCalendarMonth[]>;
+    getCrackCalendarMonth(month: string): Promise<CrackCalendarMonth>;
+    searchCrackCalendar(query: string): Promise<CrackCalendarGame[]>;
+    getCrackCalendarGame(slug: string): Promise<CrackCalendarGame>;
+    onCrackCalendarUpdated(cb: () => void): () => void;
 
     /* Library */
     toggleAutomaticCloudSync: (

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -131,7 +131,7 @@ declare global {
     ) => () => Electron.IpcRenderer;
 
     /* Crack Calendar */
-    getCrackCalendarMonths(): Promise<CrackCalendarMonth[]>;
+    getCrackCalendarMonths(): Promise<string[]>;
     getCrackCalendarMonth(month: string): Promise<CrackCalendarMonth>;
     searchCrackCalendar(query: string): Promise<CrackCalendarGame[]>;
     getCrackCalendarGame(slug: string): Promise<CrackCalendarGame>;

--- a/src/renderer/src/features/crack-calendar-slice.ts
+++ b/src/renderer/src/features/crack-calendar-slice.ts
@@ -22,7 +22,7 @@ const initialState: CrackCalendarState = {
   searchQuery: "",
 };
 
-export const fetchAvailableMonths = createAsyncThunk(
+export const fetchAvailableMonths = createAsyncThunk<string[]>(
   "crackCalendar/fetchAvailableMonths",
   async () => {
     return window.electron.getCrackCalendarMonths();

--- a/src/renderer/src/features/crack-calendar-slice.ts
+++ b/src/renderer/src/features/crack-calendar-slice.ts
@@ -1,0 +1,99 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { CrackCalendarGame, CrackCalendarMonth } from "@types";
+
+interface CrackCalendarState {
+  availableMonths: string[];
+  monthCache: Record<string, CrackCalendarMonth>;
+  selectedMonth: string | null;
+  isLoading: boolean;
+  searchResults: CrackCalendarGame[];
+  isSearching: boolean;
+  searchQuery: string;
+}
+
+const initialState: CrackCalendarState = {
+  availableMonths: [],
+  monthCache: {},
+  selectedMonth: null,
+  isLoading: false,
+  searchResults: [],
+  isSearching: false,
+  searchQuery: "",
+};
+
+export const fetchAvailableMonths = createAsyncThunk(
+  "crackCalendar/fetchAvailableMonths",
+  async () => {
+    return window.electron.getCrackCalendarMonths();
+  }
+);
+
+export const fetchCalendarMonth = createAsyncThunk(
+  "crackCalendar/fetchCalendarMonth",
+  async (
+    { month, bypassCache }: { month: string; bypassCache?: boolean },
+    { getState }
+  ) => {
+    const state = getState() as { crackCalendar: CrackCalendarState };
+    if (!bypassCache && state.crackCalendar.monthCache[month]) {
+      return state.crackCalendar.monthCache[month];
+    }
+    return window.electron.getCrackCalendarMonth(month);
+  }
+);
+
+export const searchCalendar = createAsyncThunk(
+  "crackCalendar/searchCalendar",
+  async (query: string) => {
+    if (!query) return [];
+    return window.electron.searchCrackCalendar(query);
+  }
+);
+
+export const crackCalendarSlice = createSlice({
+  name: "crackCalendar",
+  initialState,
+  reducers: {
+    setSelectedMonth: (state, action: PayloadAction<string>) => {
+      state.selectedMonth = action.payload;
+    },
+    setIsSearching: (state, action: PayloadAction<boolean>) => {
+      state.isSearching = action.payload;
+    },
+    setCalendarSearchQuery: (state, action: PayloadAction<string>) => {
+      state.searchQuery = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchAvailableMonths.fulfilled, (state, action) => {
+        state.availableMonths = Array.isArray(action.payload) ? action.payload : [];
+      })
+      .addCase(fetchCalendarMonth.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(fetchCalendarMonth.fulfilled, (state, action) => {
+        state.isLoading = false;
+        if (action.payload) {
+          state.monthCache[action.payload.month] = action.payload;
+          state.selectedMonth = action.payload.month;
+        }
+      })
+      .addCase(fetchCalendarMonth.rejected, (state) => {
+        state.isLoading = false;
+      })
+      .addCase(searchCalendar.pending, (state) => {
+        state.isSearching = true;
+      })
+      .addCase(searchCalendar.fulfilled, (state, action) => {
+        state.isSearching = false;
+        state.searchResults = Array.isArray(action.payload) ? action.payload : [];
+      })
+      .addCase(searchCalendar.rejected, (state) => {
+        state.isSearching = false;
+      });
+  },
+});
+
+export const { setSelectedMonth, setIsSearching, setCalendarSearchQuery } = crackCalendarSlice.actions;

--- a/src/renderer/src/features/crack-calendar-slice.ts
+++ b/src/renderer/src/features/crack-calendar-slice.ts
@@ -68,7 +68,9 @@ export const crackCalendarSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchAvailableMonths.fulfilled, (state, action) => {
-        state.availableMonths = Array.isArray(action.payload) ? action.payload : [];
+        state.availableMonths = Array.isArray(action.payload)
+          ? action.payload
+          : [];
       })
       .addCase(fetchCalendarMonth.pending, (state) => {
         state.isLoading = true;
@@ -88,7 +90,9 @@ export const crackCalendarSlice = createSlice({
       })
       .addCase(searchCalendar.fulfilled, (state, action) => {
         state.isSearching = false;
-        state.searchResults = Array.isArray(action.payload) ? action.payload : [];
+        state.searchResults = Array.isArray(action.payload)
+          ? action.payload
+          : [];
       })
       .addCase(searchCalendar.rejected, (state) => {
         state.isSearching = false;
@@ -96,4 +100,5 @@ export const crackCalendarSlice = createSlice({
   },
 });
 
-export const { setSelectedMonth, setIsSearching, setCalendarSearchQuery } = crackCalendarSlice.actions;
+export const { setSelectedMonth, setIsSearching, setCalendarSearchQuery } =
+  crackCalendarSlice.actions;

--- a/src/renderer/src/features/index.ts
+++ b/src/renderer/src/features/index.ts
@@ -8,3 +8,4 @@ export * from "./game-running.slice";
 export * from "./subscription-slice";
 export * from "./catalogue-search";
 export * from "./collections-slice";
+export * from "./crack-calendar-slice";

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -140,7 +140,10 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="game/:shop/:objectId/achievements"
               element={<BigPictureGameAchievements />}
             />
-            <Route path="crack-calendar" element={<BigPictureReleaseCalendar />} />
+            <Route
+              path="crack-calendar"
+              element={<BigPictureReleaseCalendar />}
+            />
             <Route
               path="crack-calendar/:slug"
               element={<BigPictureReleaseCalendarDetail />}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -33,6 +33,8 @@ import Achievements from "./pages/achievements/achievements";
 import ThemeEditor from "./pages/theme-editor/theme-editor";
 import Library from "./pages/library/library";
 import Notifications from "./pages/notifications/notifications";
+import CrackCalendar from "./pages/crack-calendar/crack-calendar";
+import CrackCalendarDetail from "./pages/crack-calendar/crack-calendar-detail";
 import { AchievementNotification } from "./pages/achievements/notification/achievement-notification";
 import { AchievementNotificationOverlay } from "./components/achievements/notification/achievement-notification-overlay";
 import GameLauncher from "./pages/game-launcher/game-launcher";
@@ -45,6 +47,8 @@ import BigPictureSettings from "../../big-picture/src/pages/settings/settings";
 import BigPictureLibrary from "../../big-picture/src/pages/library/page";
 import BigPictureGame from "../../big-picture/src/pages/game/game";
 import BigPictureGameAchievements from "../../big-picture/src/pages/game-achievements/game-achievements";
+import BigPictureReleaseCalendar from "../../big-picture/src/pages/release-calendar/release-calendar";
+import BigPictureReleaseCalendarDetail from "../../big-picture/src/pages/release-calendar-detail/release-calendar-detail";
 
 console.log = logger.log;
 
@@ -110,6 +114,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             <Route path="/profile/:userId" element={<Profile />} />
             <Route path="/achievements" element={<Achievements />} />
             <Route path="/notifications" element={<Notifications />} />
+            <Route path="/crack-calendar" element={<CrackCalendar />} />
+            <Route
+              path="/crack-calendar/:slug"
+              element={<CrackCalendarDetail />}
+            />
           </Route>
 
           <Route path="/theme-editor" element={<ThemeEditor />} />
@@ -130,6 +139,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             <Route
               path="game/:shop/:objectId/achievements"
               element={<BigPictureGameAchievements />}
+            />
+            <Route path="crack-calendar" element={<BigPictureReleaseCalendar />} />
+            <Route
+              path="crack-calendar/:slug"
+              element={<BigPictureReleaseCalendarDetail />}
             />
           </Route>
         </Routes>

--- a/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss
@@ -3,6 +3,7 @@
   background-color: var(--body-background-color);
   color: var(--text-color);
   min-height: 100%;
+  overflow-y: auto;
 }
 
 .backButton {
@@ -56,6 +57,12 @@
   font-size: 32px;
 }
 
+.statusBadges {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
 .crackBadge {
   padding: 4px 12px;
   border-radius: 6px;
@@ -63,7 +70,6 @@
   font-weight: bold;
   text-transform: uppercase;
   width: fit-content;
-  margin-bottom: 12px;
 
   &.cracked {
     background-color: #2e7d32;
@@ -77,6 +83,11 @@
 
   &.other {
     background-color: #f9a825;
+    color: black;
+  }
+
+  &.upcoming {
+    background-color: white;
     color: black;
   }
 }

--- a/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar-detail.module.scss
@@ -1,0 +1,149 @@
+.container {
+  padding: 24px;
+  background-color: var(--body-background-color);
+  color: var(--text-color);
+  min-height: 100%;
+}
+
+.backButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  padding: 8px 0;
+  margin-bottom: 24px;
+  font-size: 16px;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.layout {
+  display: flex;
+  gap: 40px;
+}
+
+.coverSection {
+  flex: 0 0 35%;
+  max-width: 350px;
+}
+
+.coverImage {
+  width: 100%;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.imagePlaceholder {
+  width: 100%;
+  aspect-ratio: 2/3;
+  border-radius: 12px;
+  background: linear-gradient(45deg, #222, #333);
+}
+
+.infoSection {
+  flex: 1;
+}
+
+.title {
+  margin: 0 0 16px 0;
+  font-size: 32px;
+}
+
+.crackBadge {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: bold;
+  text-transform: uppercase;
+  width: fit-content;
+  margin-bottom: 12px;
+
+  &.cracked {
+    background-color: #2e7d32;
+    color: white;
+  }
+
+  &.notCracked {
+    background-color: #c62828;
+    color: white;
+  }
+
+  &.other {
+    background-color: #f9a825;
+    color: black;
+  }
+}
+
+.statusNote {
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 24px;
+}
+
+.infoGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 32px;
+  padding: 20px;
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--element-border-color);
+  border-radius: 8px;
+}
+
+.infoRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.value {
+  font-weight: 500;
+}
+
+.description {
+  font-size: 15px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.8);
+  margin-bottom: 32px;
+}
+
+.source {
+  a {
+    color: var(--highlight-color);
+    text-decoration: none;
+    font-size: 14px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.skeletonLayout {
+  display: flex;
+  gap: 40px;
+}
+
+.skeletonInfo {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 100px;
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+import cn from "classnames";
+
+import { useAppSelector, useAppDispatch } from "@renderer/hooks";
+import { setHeaderTitle } from "@renderer/features";
+import type { CrackCalendarGame } from "@types";
+
+import styles from "./crack-calendar-detail.module.scss";
+
+export default function CrackCalendarDetail() {
+  const { t } = useTranslation();
+  const { slug } = useParams();
+  const dispatch = useAppDispatch();
+  const { monthCache } = useAppSelector((state) => state.crackCalendar);
+
+  const [game, setGame] = useState<CrackCalendarGame | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const cachedGame = Object.values(monthCache)
+      .flatMap((month) => (Array.isArray(month.games) ? month.games : []))
+      .find((g) => g.slug === slug);
+
+    if (cachedGame) {
+      setGame(cachedGame);
+      dispatch(setHeaderTitle(cachedGame.title));
+      setIsLoading(false);
+    } else if (slug) {
+      window.electron.getCrackCalendarGame(slug).then((fetchedGame) => {
+        setGame(fetchedGame);
+        if (fetchedGame) dispatch(setHeaderTitle(fetchedGame.title));
+        setIsLoading(false);
+      });
+    }
+
+    return () => {
+      dispatch(setHeaderTitle(""));
+    };
+  }, [slug, monthCache, dispatch]);
+
+  if (isLoading) {
+    return (
+      <SkeletonTheme baseColor="#202020" highlightColor="#444">
+        <div className={styles.container}>
+          <div className={styles.skeletonLayout}>
+            <Skeleton height={400} width={280} />
+            <div className={styles.skeletonInfo}>
+              <Skeleton height={40} width={300} />
+              <Skeleton height={20} width={100} />
+              <Skeleton count={5} />
+            </div>
+          </div>
+        </div>
+      </SkeletonTheme>
+    );
+  }
+
+  if (!game) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.emptyState}>{t("Game not found")}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.layout}>
+        <div className={styles.coverSection}>
+          {game.image ? (
+            <img src={game.image} alt={game.title} className={styles.coverImage} />
+          ) : (
+            <div className={styles.imagePlaceholder} />
+          )}
+        </div>
+
+        <div className={styles.infoSection}>
+          <h1 className={styles.title}>{game.title}</h1>
+
+          <div className={cn(styles.crackBadge, {
+            [styles.cracked]: game.crackStatus === "CRACKED",
+            [styles.notCracked]: game.crackStatus === "NOT CRACKED",
+            [styles.other]: game.crackStatus !== "CRACKED" && game.crackStatus !== "NOT CRACKED",
+          })}>
+            {game.crackStatus}
+          </div>
+
+          {game.statusNote && (
+            <p className={styles.statusNote}>
+              <em>{game.statusNote}</em>
+            </p>
+          )}
+
+          <div className={styles.infoGrid}>
+            <div className={styles.infoRow}>
+              <span className={styles.label}>{t("Release Date")}</span>
+              <span className={styles.value}>{game.releaseDate || t("Unknown")}</span>
+            </div>
+            <div className={styles.infoRow}>
+              <span className={styles.label}>{t("Crack Date")}</span>
+              <span className={styles.value}>{game.crackDate || t("N/A")}</span>
+            </div>
+            <div className={styles.infoRow}>
+              <span className={styles.label}>{t("DRM Protection")}</span>
+              <span className={styles.value}>{game.drmProtection || t("Unknown")}</span>
+            </div>
+            <div className={styles.infoRow}>
+              <span className={styles.label}>{t("Scene Group")}</span>
+              <span className={styles.value}>{game.sceneGroup || t("N/A")}</span>
+            </div>
+          </div>
+
+          {game.description && (
+            <div className={styles.description}>
+              <p>{game.description}</p>
+            </div>
+          )}
+
+          <div className={styles.source}>
+            <a href={game.source_url} target="_blank" rel="noreferrer">
+              {t("View on isitcracked.com")}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar-detail.tsx
@@ -7,6 +7,7 @@ import cn from "classnames";
 import { useAppSelector, useAppDispatch } from "@renderer/hooks";
 import { setHeaderTitle } from "@renderer/features";
 import type { CrackCalendarGame } from "@types";
+import { formatCountdown } from "@renderer/utils/format-countdown";
 
 import styles from "./crack-calendar-detail.module.scss";
 
@@ -71,7 +72,11 @@ export default function CrackCalendarDetail() {
       <div className={styles.layout}>
         <div className={styles.coverSection}>
           {game.image ? (
-            <img src={game.image} alt={game.title} className={styles.coverImage} />
+            <img
+              src={game.image}
+              alt={game.title}
+              className={styles.coverImage}
+            />
           ) : (
             <div className={styles.imagePlaceholder} />
           )}
@@ -80,12 +85,24 @@ export default function CrackCalendarDetail() {
         <div className={styles.infoSection}>
           <h1 className={styles.title}>{game.title}</h1>
 
-          <div className={cn(styles.crackBadge, {
-            [styles.cracked]: game.crackStatus === "CRACKED",
-            [styles.notCracked]: game.crackStatus === "NOT CRACKED",
-            [styles.other]: game.crackStatus !== "CRACKED" && game.crackStatus !== "NOT CRACKED",
-          })}>
-            {game.crackStatus}
+          <div className={styles.statusBadges}>
+            <div
+              className={cn(styles.crackBadge, {
+                [styles.cracked]: game.crackStatus === "CRACKED",
+                [styles.notCracked]: game.crackStatus === "NOT CRACKED",
+                [styles.other]:
+                  game.crackStatus !== "CRACKED" &&
+                  game.crackStatus !== "NOT CRACKED",
+              })}
+            >
+              {game.crackStatus}
+            </div>
+
+            {game.countdown && game.countdown !== "Released" && (
+              <div className={cn(styles.crackBadge, styles.upcoming)}>
+                {formatCountdown(game.countdown)}
+              </div>
+            )}
           </div>
 
           {game.statusNote && (
@@ -97,7 +114,9 @@ export default function CrackCalendarDetail() {
           <div className={styles.infoGrid}>
             <div className={styles.infoRow}>
               <span className={styles.label}>{t("Release Date")}</span>
-              <span className={styles.value}>{game.releaseDate || t("Unknown")}</span>
+              <span className={styles.value}>
+                {game.releaseDate || t("Unknown")}
+              </span>
             </div>
             <div className={styles.infoRow}>
               <span className={styles.label}>{t("Crack Date")}</span>
@@ -105,11 +124,15 @@ export default function CrackCalendarDetail() {
             </div>
             <div className={styles.infoRow}>
               <span className={styles.label}>{t("DRM Protection")}</span>
-              <span className={styles.value}>{game.drmProtection || t("Unknown")}</span>
+              <span className={styles.value}>
+                {game.drmProtection || t("Unknown")}
+              </span>
             </div>
             <div className={styles.infoRow}>
               <span className={styles.label}>{t("Scene Group")}</span>
-              <span className={styles.value}>{game.sceneGroup || t("N/A")}</span>
+              <span className={styles.value}>
+                {game.sceneGroup || t("N/A")}
+              </span>
             </div>
           </div>
 

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
@@ -1,0 +1,205 @@
+.container {
+  padding: 24px;
+  background-color: var(--body-background-color);
+  color: var(--text-color);
+  min-height: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+
+  h1 {
+    margin: 0;
+    font-size: 24px;
+  }
+}
+
+.searchBar {
+  width: 300px;
+}
+
+.monthSelector {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.navButton {
+  min-width: 40px;
+  padding: 8px;
+}
+
+.monthTabs {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  flex: 1;
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 2px;
+  }
+}
+
+.monthTab {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.gameGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 20px;
+}
+
+.gameCard {
+  background-color: transparent;
+  width: 100%;
+  color: #fff;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+
+  &:hover {
+    .coverWrapper {
+      transform: translateY(-4px);
+    }
+  }
+}
+
+.coverWrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 2/3;
+  overflow: hidden;
+  border: 1px solid var(--element-border-color);
+  border-radius: 8px;
+  transition: transform 0.2s;
+}
+
+.gameImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.imagePlaceholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 50%, rgba(255, 255, 255, 0.1) 100%);
+}
+
+.badges {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+
+.crackBadge {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &.cracked {
+    color: #4caf50;
+    border-color: rgba(76, 175, 80, 0.3);
+  }
+
+  &.notCracked {
+    color: #f44336;
+    border-color: rgba(244, 67, 54, 0.3);
+  }
+
+  &.other {
+    color: #ffc107;
+    border-color: rgba(255, 193, 7, 0.3);
+  }
+}
+
+.releasePill {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: bold;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &.released {
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  &.upcoming {
+    color: var(--highlight-color);
+    border-color: var(--highlight-color);
+  }
+}
+
+.gameDetails {
+  display: flex;
+  flex-direction: column;
+}
+
+.gameTitle {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.dayGroup {
+  margin-bottom: 40px;
+}
+
+.dayHeader {
+  font-size: 18px;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--element-border-color);
+}
+
+.emptyState {
+  text-align: center;
+  padding: 48px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.loadingGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 20px;
+
+  span {
+    aspect-ratio: 2/3;
+    border-radius: 8px;
+  }
+}

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
@@ -58,6 +58,13 @@
   flex-shrink: 0;
 }
 
+.lastUpdated {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.4);
+  margin-left: auto;
+  align-self: center;
+}
+
 .gameGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
@@ -102,7 +109,12 @@
 .imagePlaceholder {
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 50%, rgba(255, 255, 255, 0.1) 100%);
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.05) 50%,
+    rgba(255, 255, 255, 0.1) 100%
+  );
 }
 
 .badges {

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
@@ -72,14 +72,18 @@
 }
 
 .gameCard {
+  all: unset;
+
   background-color: transparent;
   width: 100%;
   color: #fff;
   overflow: hidden;
   position: relative;
+
   display: flex;
   flex-direction: column;
   gap: 8px;
+
   cursor: pointer;
   transition: transform 0.2s;
 
@@ -87,6 +91,11 @@
     .coverWrapper {
       transform: translateY(-4px);
     }
+  }
+
+  &:focus-visible {
+    outline: 2px solid #ffffff40;
+    outline-offset: 4px;
   }
 }
 

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.module.scss
@@ -197,8 +197,19 @@
   -webkit-box-orient: vertical;
 }
 
+.content {
+  flex: 1;
+  width: 100%;
+}
+
+.dayGroups,
+.calendarMode {
+  width: 100%;
+}
+
 .dayGroup {
   margin-bottom: 40px;
+  width: 100%;
 }
 
 .dayHeader {

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
@@ -157,17 +157,10 @@ export default function CrackCalendar() {
     const handleCardClick = () => navigate(`/crack-calendar/${game.slug}`);
 
     return (
-      <article
-        key={game.slug}
+      <button
+        type="button"
         className={styles.gameCard}
         onClick={handleCardClick}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            handleCardClick();
-          }
-        }}
-        role="button"
-        tabIndex={0}
       >
         <div className={styles.coverWrapper}>
           {game.image ? (
@@ -204,7 +197,7 @@ export default function CrackCalendar() {
         <div className={styles.gameDetails}>
           <span className={styles.gameTitle}>{game.title}</span>
         </div>
-      </article>
+      </button>
     );
   };
 

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
@@ -8,6 +8,8 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@primer/octicons-react";
 import { useAppDispatch, useAppSelector } from "@renderer/hooks";
 import { fetchAvailableMonths, fetchCalendarMonth } from "@renderer/features";
 import { Button } from "@renderer/components";
+import { getLastUpdatedLabel } from "@renderer/utils/get-last-updated-label";
+import { formatCountdown } from "@renderer/utils/format-countdown";
 
 import styles from "./crack-calendar.module.scss";
 
@@ -39,7 +41,10 @@ export default function CrackCalendar() {
 
   useEffect(() => {
     dispatch(fetchAvailableMonths()).then((action) => {
-      if (fetchAvailableMonths.fulfilled.match(action) && action.payload.length > 0) {
+      if (
+        fetchAvailableMonths.fulfilled.match(action) &&
+        action.payload.length > 0
+      ) {
         const currentMonthStr = new Date().toISOString().slice(0, 7);
         const monthToSelect = action.payload.includes(currentMonthStr)
           ? currentMonthStr
@@ -55,7 +60,9 @@ export default function CrackCalendar() {
   useEffect(() => {
     const unsubscribe = window.electron.onCrackCalendarUpdated(() => {
       if (selectedMonth) {
-        dispatch(fetchCalendarMonth({ month: selectedMonth, bypassCache: true }));
+        dispatch(
+          fetchCalendarMonth({ month: selectedMonth, bypassCache: true })
+        );
       }
     });
 
@@ -83,6 +90,68 @@ export default function CrackCalendar() {
   };
 
   const currentMonthData = selectedMonth ? monthCache[selectedMonth] : null;
+
+  const dayGroups = useMemo(() => {
+    if (!currentMonthData) return [];
+
+    const gamesByDay: Record<string, any[]> = {};
+    currentMonthData.games.forEach((game) => {
+      const day = game.day || "Unknown";
+      if (!gamesByDay[day]) gamesByDay[day] = [];
+      gamesByDay[day].push(game);
+    });
+
+    if (
+      Array.isArray(currentMonthData.days) &&
+      currentMonthData.days.length > 0
+    ) {
+      const dayNumbersFromApi = new Set(
+        currentMonthData.days.map((d) => d.dayNumber)
+      );
+      const gameDays = Object.keys(gamesByDay);
+
+      const allDayNumbers = Array.from(
+        new Set([...dayNumbersFromApi, ...gameDays])
+      ).sort((a, b) => {
+        const numA = parseInt(a);
+        const numB = parseInt(b);
+        if (isNaN(numA)) return 1;
+        if (isNaN(numB)) return -1;
+        return numA - numB;
+      });
+
+      return allDayNumbers
+        .map((dayNum) => {
+          const dayInfo = currentMonthData.days.find(
+            (d) => d.dayNumber === dayNum
+          );
+          const games = gamesByDay[dayNum] || [];
+
+          return {
+            dayNumber: dayNum,
+            dayName: dayInfo?.dayName || "",
+            releases: dayInfo?.releases || String(games.length),
+            games,
+          };
+        })
+        .filter((group) => group.games.length > 0);
+    }
+
+    return Object.entries(gamesByDay)
+      .sort(([a], [b]) => {
+        const numA = parseInt(a);
+        const numB = parseInt(b);
+        if (isNaN(numA)) return 1;
+        if (isNaN(numB)) return -1;
+        return numA - numB;
+      })
+      .map(([day, games]) => ({
+        dayNumber: day,
+        dayName: "",
+        releases: String(games.length),
+        games,
+      }));
+  }, [currentMonthData]);
 
   const renderGameCard = (game: any) => (
     <article
@@ -114,7 +183,7 @@ export default function CrackCalendar() {
               [styles.upcoming]: game.countdown !== "Released",
             })}
           >
-            {game.countdown}
+            {formatCountdown(game.countdown)}
           </div>
         </div>
       </div>
@@ -127,38 +196,49 @@ export default function CrackCalendar() {
   return (
     <SkeletonTheme baseColor="#202020" highlightColor="#444">
       <div className={styles.container}>
-        {!searchQuery && Array.isArray(availableMonths) && availableMonths.length > 0 && (
-          <div className={styles.monthSelector}>
-            <Button
-              className={styles.navButton}
-              onClick={handlePrevMonth}
-              disabled={selectedMonth === availableMonths[0] || isLoading}
-              theme="outline"
-            >
-              <ChevronLeftIcon />
-            </Button>
-            <div className={styles.monthTabs}>
-              {availableMonths.map((month) => (
-                <Button
-                  key={month}
-                  theme={selectedMonth === month ? "primary" : "outline"}
-                  onClick={() => handleMonthClick(month)}
-                  className={styles.monthTab}
-                >
-                  {formatMonth(month)}
-                </Button>
-              ))}
+        {!searchQuery &&
+          Array.isArray(availableMonths) &&
+          availableMonths.length > 0 && (
+            <div className={styles.monthSelector}>
+              <Button
+                className={styles.navButton}
+                onClick={handlePrevMonth}
+                disabled={selectedMonth === availableMonths[0] || isLoading}
+                theme="outline"
+              >
+                <ChevronLeftIcon />
+              </Button>
+              <div className={styles.monthTabs}>
+                {availableMonths.map((month) => (
+                  <Button
+                    key={month}
+                    theme={selectedMonth === month ? "primary" : "outline"}
+                    onClick={() => handleMonthClick(month)}
+                    className={styles.monthTab}
+                  >
+                    {formatMonth(month)}
+                  </Button>
+                ))}
+              </div>
+              <Button
+                className={styles.navButton}
+                onClick={handleNextMonth}
+                disabled={
+                  selectedMonth ===
+                    availableMonths[availableMonths.length - 1] || isLoading
+                }
+                theme="outline"
+              >
+                <ChevronRightIcon />
+              </Button>
+
+              {currentMonthData?.updated_at && (
+                <span className={styles.lastUpdated}>
+                  {getLastUpdatedLabel(currentMonthData.updated_at)}
+                </span>
+              )}
             </div>
-            <Button
-              className={styles.navButton}
-              onClick={handleNextMonth}
-              disabled={selectedMonth === availableMonths[availableMonths.length - 1] || isLoading}
-              theme="outline"
-            >
-              <ChevronRightIcon />
-            </Button>
-          </div>
-        )}
+          )}
 
         <div className={styles.content}>
           {searchQuery ? (
@@ -185,25 +265,28 @@ export default function CrackCalendar() {
                     <Skeleton key={i} height={105} />
                   ))}
                 </div>
-              ) : currentMonthData && Array.isArray(currentMonthData.days) ? (
+              ) : dayGroups.length > 0 ? (
                 <div className={styles.dayGroups}>
-                  {currentMonthData.days
-                    .filter((day) => day.releases !== "0")
-                    .map((day) => (
-                      <div key={day.fullDate} className={styles.dayGroup}>
-                        <h2 className={styles.dayHeader}>
-                          {day.dayName}, {day.dayNumber} - {day.releases} Releases
-                        </h2>
-                        <div className={styles.gameGrid}>
-                          {Array.isArray(currentMonthData.games) && currentMonthData.games
-                            .filter((game) => game.day === day.dayNumber)
-                            .map(renderGameCard)}
-                        </div>
+                  {dayGroups.map((group) => (
+                    <div
+                      key={group.dayNumber + group.dayName}
+                      className={styles.dayGroup}
+                    >
+                      <h2 className={styles.dayHeader}>
+                        {group.dayName}
+                        {group.dayName ? ", " : ""}
+                        {group.dayNumber} - {group.releases} Releases
+                      </h2>
+                      <div className={styles.gameGrid}>
+                        {group.games.map(renderGameCard)}
                       </div>
-                    ))}
+                    </div>
+                  ))}
                 </div>
               ) : (
-                <div className={styles.emptyState}>{t("Select a month to see releases")}</div>
+                <div className={styles.emptyState}>
+                  {t("Select a month to see releases")}
+                </div>
               )}
             </div>
           )}

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
@@ -153,45 +153,60 @@ export default function CrackCalendar() {
       }));
   }, [currentMonthData]);
 
-  const renderGameCard = (game: any) => (
-    <article
-      key={game.slug}
-      className={styles.gameCard}
-      onClick={() => navigate(`/crack-calendar/${game.slug}`)}
-    >
-      <div className={styles.coverWrapper}>
-        {game.image ? (
-          <img src={game.image} alt={game.title} className={styles.gameImage} />
-        ) : (
-          <div className={styles.imagePlaceholder} />
-        )}
-        <div className={styles.badges}>
-          <div
-            className={cn(styles.crackBadge, {
-              [styles.cracked]: game.crackStatus === "CRACKED",
-              [styles.notCracked]: game.crackStatus === "NOT CRACKED",
-              [styles.other]:
-                game.crackStatus !== "CRACKED" &&
-                game.crackStatus !== "NOT CRACKED",
-            })}
-          >
-            {game.crackStatus}
-          </div>
-          <div
-            className={cn(styles.releasePill, {
-              [styles.released]: game.countdown === "Released",
-              [styles.upcoming]: game.countdown !== "Released",
-            })}
-          >
-            {formatCountdown(game.countdown)}
+  const renderGameCard = (game: any) => {
+    const handleCardClick = () => navigate(`/crack-calendar/${game.slug}`);
+
+    return (
+      <article
+        key={game.slug}
+        className={styles.gameCard}
+        onClick={handleCardClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            handleCardClick();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        <div className={styles.coverWrapper}>
+          {game.image ? (
+            <img
+              src={game.image}
+              alt={game.title}
+              className={styles.gameImage}
+            />
+          ) : (
+            <div className={styles.imagePlaceholder} />
+          )}
+          <div className={styles.badges}>
+            <div
+              className={cn(styles.crackBadge, {
+                [styles.cracked]: game.crackStatus === "CRACKED",
+                [styles.notCracked]: game.crackStatus === "NOT CRACKED",
+                [styles.other]:
+                  game.crackStatus !== "CRACKED" &&
+                  game.crackStatus !== "NOT CRACKED",
+              })}
+            >
+              {game.crackStatus}
+            </div>
+            <div
+              className={cn(styles.releasePill, {
+                [styles.released]: game.countdown === "Released",
+                [styles.upcoming]: game.countdown !== "Released",
+              })}
+            >
+              {formatCountdown(game.countdown)}
+            </div>
           </div>
         </div>
-      </div>
-      <div className={styles.gameDetails}>
-        <span className={styles.gameTitle}>{game.title}</span>
-      </div>
-    </article>
-  );
+        <div className={styles.gameDetails}>
+          <span className={styles.gameTitle}>{game.title}</span>
+        </div>
+      </article>
+    );
+  };
 
   return (
     <SkeletonTheme baseColor="#202020" highlightColor="#444">

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
@@ -250,7 +250,10 @@ export default function CrackCalendar() {
 
         <div className={styles.content}>
           {searchQuery ? (
-            <div className={styles.searchResults}>
+            <div className={styles.dayGroup}>
+              <h2 className={styles.dayHeader}>
+                {t("search_results", { defaultValue: "Search results" })}
+              </h2>
               {isSearching ? (
                 <div className={styles.loadingGrid}>
                   {Array.from({ length: 12 }).map((_, i) => (

--- a/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
+++ b/src/renderer/src/pages/crack-calendar/crack-calendar.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+import cn from "classnames";
+import { ChevronLeftIcon, ChevronRightIcon } from "@primer/octicons-react";
+
+import { useAppDispatch, useAppSelector } from "@renderer/hooks";
+import { fetchAvailableMonths, fetchCalendarMonth } from "@renderer/features";
+import { Button } from "@renderer/components";
+
+import styles from "./crack-calendar.module.scss";
+
+export default function CrackCalendar() {
+  const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const formatMonth = (monthStr: string) => {
+    if (!monthStr) return "";
+    const [year, month] = monthStr.split("-");
+    if (!year || !month) return monthStr;
+    const date = new Date(parseInt(year), parseInt(month) - 1);
+    if (isNaN(date.getTime())) return monthStr;
+    const monthName = date.toLocaleString(i18n.language, { month: "short" });
+    const yearShort = year.slice(-2);
+    return `${monthName} ${yearShort}`;
+  };
+
+  const {
+    availableMonths,
+    monthCache,
+    selectedMonth,
+    isLoading,
+    searchResults,
+    isSearching,
+    searchQuery,
+  } = useAppSelector((state) => state.crackCalendar);
+
+  useEffect(() => {
+    dispatch(fetchAvailableMonths()).then((action) => {
+      if (fetchAvailableMonths.fulfilled.match(action) && action.payload.length > 0) {
+        const currentMonthStr = new Date().toISOString().slice(0, 7);
+        const monthToSelect = action.payload.includes(currentMonthStr)
+          ? currentMonthStr
+          : action.payload[0];
+
+        if (!selectedMonth) {
+          dispatch(fetchCalendarMonth({ month: monthToSelect }));
+        }
+      }
+    });
+  }, [dispatch]);
+
+  useEffect(() => {
+    const unsubscribe = window.electron.onCrackCalendarUpdated(() => {
+      if (selectedMonth) {
+        dispatch(fetchCalendarMonth({ month: selectedMonth, bypassCache: true }));
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [dispatch, selectedMonth]);
+
+  const handleMonthClick = (month: string) => {
+    dispatch(fetchCalendarMonth({ month }));
+  };
+
+  const handlePrevMonth = () => {
+    const currentIndex = availableMonths.indexOf(selectedMonth!);
+    if (currentIndex > 0) {
+      handleMonthClick(availableMonths[currentIndex - 1]);
+    }
+  };
+
+  const handleNextMonth = () => {
+    const currentIndex = availableMonths.indexOf(selectedMonth!);
+    if (currentIndex < availableMonths.length - 1) {
+      handleMonthClick(availableMonths[currentIndex + 1]);
+    }
+  };
+
+  const currentMonthData = selectedMonth ? monthCache[selectedMonth] : null;
+
+  const renderGameCard = (game: any) => (
+    <article
+      key={game.slug}
+      className={styles.gameCard}
+      onClick={() => navigate(`/crack-calendar/${game.slug}`)}
+    >
+      <div className={styles.coverWrapper}>
+        {game.image ? (
+          <img src={game.image} alt={game.title} className={styles.gameImage} />
+        ) : (
+          <div className={styles.imagePlaceholder} />
+        )}
+        <div className={styles.badges}>
+          <div
+            className={cn(styles.crackBadge, {
+              [styles.cracked]: game.crackStatus === "CRACKED",
+              [styles.notCracked]: game.crackStatus === "NOT CRACKED",
+              [styles.other]:
+                game.crackStatus !== "CRACKED" &&
+                game.crackStatus !== "NOT CRACKED",
+            })}
+          >
+            {game.crackStatus}
+          </div>
+          <div
+            className={cn(styles.releasePill, {
+              [styles.released]: game.countdown === "Released",
+              [styles.upcoming]: game.countdown !== "Released",
+            })}
+          >
+            {game.countdown}
+          </div>
+        </div>
+      </div>
+      <div className={styles.gameDetails}>
+        <span className={styles.gameTitle}>{game.title}</span>
+      </div>
+    </article>
+  );
+
+  return (
+    <SkeletonTheme baseColor="#202020" highlightColor="#444">
+      <div className={styles.container}>
+        {!searchQuery && Array.isArray(availableMonths) && availableMonths.length > 0 && (
+          <div className={styles.monthSelector}>
+            <Button
+              className={styles.navButton}
+              onClick={handlePrevMonth}
+              disabled={selectedMonth === availableMonths[0] || isLoading}
+              theme="outline"
+            >
+              <ChevronLeftIcon />
+            </Button>
+            <div className={styles.monthTabs}>
+              {availableMonths.map((month) => (
+                <Button
+                  key={month}
+                  theme={selectedMonth === month ? "primary" : "outline"}
+                  onClick={() => handleMonthClick(month)}
+                  className={styles.monthTab}
+                >
+                  {formatMonth(month)}
+                </Button>
+              ))}
+            </div>
+            <Button
+              className={styles.navButton}
+              onClick={handleNextMonth}
+              disabled={selectedMonth === availableMonths[availableMonths.length - 1] || isLoading}
+              theme="outline"
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+        )}
+
+        <div className={styles.content}>
+          {searchQuery ? (
+            <div className={styles.searchResults}>
+              {isSearching ? (
+                <div className={styles.loadingGrid}>
+                  {Array.from({ length: 12 }).map((_, i) => (
+                    <Skeleton key={i} height={105} />
+                  ))}
+                </div>
+              ) : Array.isArray(searchResults) && searchResults.length > 0 ? (
+                <div className={styles.gameGrid}>
+                  {searchResults.map(renderGameCard)}
+                </div>
+              ) : (
+                <div className={styles.emptyState}>{t("No games found")}</div>
+              )}
+            </div>
+          ) : (
+            <div className={styles.calendarMode}>
+              {isLoading ? (
+                <div className={styles.loadingGrid}>
+                  {Array.from({ length: 12 }).map((_, i) => (
+                    <Skeleton key={i} height={105} />
+                  ))}
+                </div>
+              ) : currentMonthData && Array.isArray(currentMonthData.days) ? (
+                <div className={styles.dayGroups}>
+                  {currentMonthData.days
+                    .filter((day) => day.releases !== "0")
+                    .map((day) => (
+                      <div key={day.fullDate} className={styles.dayGroup}>
+                        <h2 className={styles.dayHeader}>
+                          {day.dayName}, {day.dayNumber} - {day.releases} Releases
+                        </h2>
+                        <div className={styles.gameGrid}>
+                          {Array.isArray(currentMonthData.games) && currentMonthData.games
+                            .filter((game) => game.day === day.dayNumber)
+                            .map(renderGameCard)}
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              ) : (
+                <div className={styles.emptyState}>{t("Select a month to see releases")}</div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </SkeletonTheme>
+  );
+}

--- a/src/renderer/src/pages/game-details/cloud-sync-files-modal/cloud-sync-files-modal.tsx
+++ b/src/renderer/src/pages/game-details/cloud-sync-files-modal/cloud-sync-files-modal.tsx
@@ -9,8 +9,10 @@ import { formatBytes } from "@shared";
 import { useToast } from "@renderer/hooks";
 import { useForm } from "react-hook-form";
 
-export interface CloudSyncFilesModalProps
-  extends Omit<ModalProps, "children" | "title"> {}
+export interface CloudSyncFilesModalProps extends Omit<
+  ModalProps,
+  "children" | "title"
+> {}
 
 export enum FileMappingMethod {
   Automatic = "AUTOMATIC",

--- a/src/renderer/src/pages/game-details/cloud-sync-rename-artifact-modal/cloud-sync-rename-artifact-modal.tsx
+++ b/src/renderer/src/pages/game-details/cloud-sync-rename-artifact-modal/cloud-sync-rename-artifact-modal.tsx
@@ -12,8 +12,10 @@ import { useToast } from "@renderer/hooks";
 
 import "./cloud-sync-rename-artifact-modal.scss";
 
-export interface CloudSyncRenameArtifactModalProps
-  extends Omit<ModalProps, "children" | "title"> {
+export interface CloudSyncRenameArtifactModalProps extends Omit<
+  ModalProps,
+  "children" | "title"
+> {
   artifact: GameArtifact | null;
 }
 

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -10,6 +10,7 @@ import {
   subscriptionSlice,
   catalogueSearchSlice,
   collectionsSlice,
+  crackCalendarSlice,
 } from "@renderer/features";
 
 export const store = configureStore({
@@ -24,6 +25,7 @@ export const store = configureStore({
     subscription: subscriptionSlice.reducer,
     catalogueSearch: catalogueSearchSlice.reducer,
     collections: collectionsSlice.reducer,
+    crackCalendar: crackCalendarSlice.reducer,
   },
 });
 

--- a/src/renderer/src/utils/format-countdown.ts
+++ b/src/renderer/src/utils/format-countdown.ts
@@ -1,0 +1,6 @@
+export const formatCountdown = (countdown: string | null | undefined): string => {
+  if (!countdown) return "";
+
+  // Matches "D-26UNRELEASED", "D+0UNCRACKED" and similar, inserting a space
+  return countdown.replace(/^([a-z][+-]\d+)([a-z]+)$/i, "$1 $2");
+};

--- a/src/renderer/src/utils/format-countdown.ts
+++ b/src/renderer/src/utils/format-countdown.ts
@@ -1,4 +1,6 @@
-export const formatCountdown = (countdown: string | null | undefined): string => {
+export const formatCountdown = (
+  countdown: string | null | undefined
+): string => {
   if (!countdown) return "";
 
   // Matches "D-26UNRELEASED", "D+0UNCRACKED" and similar, inserting a space

--- a/src/renderer/src/utils/get-last-updated-label.ts
+++ b/src/renderer/src/utils/get-last-updated-label.ts
@@ -1,0 +1,13 @@
+export const getLastUpdatedLabel = (updatedAt: string): string => {
+  const date = new Date(updatedAt);
+  if (isNaN(date.getTime())) return "Last updated: unknown";
+
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMinutes < 60) return `Last updated ${diffMinutes} minute${diffMinutes !== 1 ? "s" : ""} ago`;
+  if (diffHours < 24) return `Last updated ${diffHours} hour${diffHours !== 1 ? "s" : ""} ago`;
+  return `Last updated ${diffDays} day${diffDays !== 1 ? "s" : ""} ago`;
+};

--- a/src/renderer/src/utils/get-last-updated-label.ts
+++ b/src/renderer/src/utils/get-last-updated-label.ts
@@ -7,7 +7,9 @@ export const getLastUpdatedLabel = (updatedAt: string): string => {
   const diffHours = Math.floor(diffMs / 3600000);
   const diffDays = Math.floor(diffMs / 86400000);
 
-  if (diffMinutes < 60) return `Last updated ${diffMinutes} minute${diffMinutes !== 1 ? "s" : ""} ago`;
-  if (diffHours < 24) return `Last updated ${diffHours} hour${diffHours !== 1 ? "s" : ""} ago`;
+  if (diffMinutes < 60)
+    return `Last updated ${diffMinutes} minute${diffMinutes !== 1 ? "s" : ""} ago`;
+  if (diffHours < 24)
+    return `Last updated ${diffHours} hour${diffHours !== 1 ? "s" : ""} ago`;
   return `Last updated ${diffDays} day${diffDays !== 1 ? "s" : ""} ago`;
 };

--- a/src/shared/download-directories.ts
+++ b/src/shared/download-directories.ts
@@ -37,8 +37,7 @@ type DownloadDirectoryPreferences = Pick<
   "downloadsPath" | "downloadDirectories" | "optionalDownloadsPaths"
 >;
 
-interface DownloadDirectoryRecordWithTimestamp
-  extends DownloadDirectoryPreference {
+interface DownloadDirectoryRecordWithTimestamp extends DownloadDirectoryPreference {
   timestamp: number;
   originalIndex: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -502,6 +502,35 @@ export type UserGameDetails = ShopAssets & {
   }[];
 };
 
+export interface CrackCalendarGame {
+  slug: string;
+  title: string;
+  image: string | null;
+  month: string | null;
+  day: string | null;
+  countdown: string | null;
+  calendarStatus: string | null;
+  crackStatus: string | null;
+  statusNote: string | null;
+  releaseDate: string | null;
+  crackDate: string | null;
+  drmProtection: string | null;
+  sceneGroup: string | null;
+  description: string | null;
+  source_url: string;
+}
+
+export interface CrackCalendarMonth {
+  month: string;
+  days: {
+    dayNumber: string;
+    dayName: string;
+    fullDate: string;
+    releases: string;
+  }[];
+  games: CrackCalendarGame[];
+}
+
 export * from "./game.types";
 export * from "./steam.types";
 export * from "./download.types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -529,6 +529,7 @@ export interface CrackCalendarMonth {
     releases: string;
   }[];
   games: CrackCalendarGame[];
+  updated_at: string;
 }
 
 export * from "./game.types";


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**
- [x] I have read the [[Hydra documentation](https://docs.hydralauncher.gg/getting-started.html)](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

---

**Fill in the PR content:**

## Release Calendar

Adds a dedicated **Release Calendar** page to Hydra Launcher, giving users a built-in way to track upcoming game releases and monitor their crack status without leaving the app.

### What's new

- **Release Calendar page** - A new section accessible from the main navigation/sidebar, displaying upcoming games organized by release date, with crack status indicators showing whether each title has been cracked yet.
- **Month navigation** - Users can move forward and backward between months to browse upcoming releases across different time periods.
- **Big Picture Mode support** - The calendar is fully usable in Big Picture Mode, with controller-friendly month navigation mapped to shoulder buttons:
  - **L1/LB** → Previous month
  - **R1/RB** → Next month
- **Search integration** - The header search works in the calendar context, with a dedicated `Search calendar` placeholder.
- **Navigation integration** - Release Calendar is exposed in Hydra's sidebar alongside Catalogue, Library, Downloads, and Settings.
- **Localization** - New translation strings added (`Release Calendar`, `Search calendar`) via Hydra's existing i18n system.

### Screenshots

> *(Desktop — Calendar page, Search, Game Info)*

<img width="959" height="539" alt="Screenshot 2026-06-06 214247" src="https://github.com/user-attachments/assets/286a7884-d879-4790-a609-624d56c6ea1c" />
<img width="959" height="539" alt="Screenshot 2026-06-06 214257" src="https://github.com/user-attachments/assets/2042debb-72d0-4bf4-8be2-5a5df34b17cd" />
<img width="959" height="539" alt="Screenshot 2026-06-06 214326" src="https://github.com/user-attachments/assets/8e2264ec-38dc-4cf9-9c20-df6a50915863" />


> *(Big Picture Mode — Calendar page, Search)*

<img width="959" height="539" alt="Screenshot 2026-06-06 214326" src="https://github.com/user-attachments/assets/9b141e5d-8fcc-4a61-a656-a2e200a6243a" />
<img width="959" height="539" alt="Screenshot 2026-06-06 214343" src="https://github.com/user-attachments/assets/25b293a6-34c2-4926-8343-2753a3518653" />


### Why this is useful

Users currently have no way to track upcoming release schedules or crack status inside Hydra and must rely on external sites. This feature makes upcoming releases and their crack status a first-class experience, especially for Big Picture/TV users who benefit from the controller-native month navigation.

### Planned future additions

- 🔔 **Crack notifications** - Users will be able to set a notify flag on any upcoming game and receive an in-app notification the moment it gets cracked.
- 🔗 **Download redirect** - Once a game is cracked, a direct link to its download options in Hydra will be surfaced automatically.

---

**Label to apply:** `[feature]`