### PR TITLE
feat: add installed indicator to library game cards

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1048,6 +1048,8 @@
     "amount_hours_short": "{{amount}}h",
     "amount_minutes_short": "{{amount}}m",
     "manual_playtime_tooltip": "This playtime has been manually updated",
+    "installed": "Ready",
+    "installed_tooltip": "Executable set, ready to play",
     "all_games": "All Games",
     "sort_by": "Sort by",
     "sort_title_asc": "Title (A-Z)",

--- a/src/renderer/src/pages/library/library-game-card-large.scss
+++ b/src/renderer/src/pages/library/library-game-card-large.scss
@@ -160,6 +160,34 @@
     justify-content: flex-end;
   }
 
+  &__top-right {
+    display: flex;
+    align-items: flex-start;
+    gap: calc(globals.$spacing-unit);
+    margin-left: auto;
+  }
+
+  &__installed-badge {
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: rgba(255, 255, 255, 0.95);
+    border: solid 1px rgba(255, 255, 255, 0.15);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  &__installed-icon {
+    color: #fff;
+    flex-shrink: 0;
+  }
+
   &__playtime {
     background: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(8px);

--- a/src/renderer/src/pages/library/library-game-card-large.tsx
+++ b/src/renderer/src/pages/library/library-game-card-large.tsx
@@ -7,6 +7,7 @@ import {
   TrophyIcon,
   DatabaseIcon,
   FileZipIcon,
+  CheckCircleFillIcon,
 } from "@primer/octicons-react";
 import { memo, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,6 +33,8 @@ export const LibraryGameCardLarge = memo(function LibraryGameCardLarge({
   const { t } = useTranslation("library");
   const { formatPlayTime, handleCardClick, handleContextMenuClick } =
     useGameCard(game, onContextMenu);
+
+  const isInstalled = Boolean(game.executablePath);
 
   const sizeBars = useMemo(() => {
     const items: {
@@ -171,18 +174,35 @@ export const LibraryGameCardLarge = memo(function LibraryGameCardLarge({
             </div>
           )}
 
-          <div className="library-game-card-large__playtime">
-            {game.hasManuallyUpdatedPlaytime ? (
-              <AlertFillIcon
-                size={11}
-                className="library-game-card-large__manual-playtime"
-              />
-            ) : (
-              <ClockIcon size={11} />
+          <div className="library-game-card-large__top-right">
+            {isInstalled && (
+              <div
+                className="library-game-card-large__installed-badge"
+                title={t("installed_tooltip")}
+              >
+                <CheckCircleFillIcon
+                  size={12}
+                  className="library-game-card-large__installed-icon"
+                />
+                <span className="library-game-card-large__installed-text">
+                  {t("installed")}
+                </span>
+              </div>
             )}
-            <span className="library-game-card-large__playtime-text">
-              {formatPlayTime(game.playTimeInMilliseconds)}
-            </span>
+
+            <div className="library-game-card-large__playtime">
+              {game.hasManuallyUpdatedPlaytime ? (
+                <AlertFillIcon
+                  size={11}
+                  className="library-game-card-large__manual-playtime"
+                />
+              ) : (
+                <ClockIcon size={11} />
+              )}
+              <span className="library-game-card-large__playtime-text">
+                {formatPlayTime(game.playTimeInMilliseconds)}
+              </span>
+            </div>
           </div>
         </div>
 

--- a/src/renderer/src/pages/library/library-game-card.scss
+++ b/src/renderer/src/pages/library/library-game-card.scss
@@ -106,6 +106,36 @@
     color: globals.$warning-color;
   }
 
+  &__installed-badge {
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: rgba(255, 255, 255, 0.8);
+    border: solid 1px rgba(255, 255, 255, 0.15);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: all ease 0.2s;
+  }
+
+  &__installed-icon {
+    color: #fff;
+    flex-shrink: 0;
+  }
+
+  &__installed-text {
+    font-size: 12px;
+    display: inline;
+
+    // Hide label on narrow cards, keep the icon as the indicator
+    @container (max-width: 140px) {
+      display: none;
+    }
+  }
+
   &__achievements {
     display: flex;
     flex-direction: column;

--- a/src/renderer/src/pages/library/library-game-card.tsx
+++ b/src/renderer/src/pages/library/library-game-card.tsx
@@ -1,11 +1,13 @@
 import { LibraryGame } from "@types";
 import { useGameCard } from "@renderer/hooks";
 import { memo, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   ClockIcon,
   AlertFillIcon,
   TrophyIcon,
   ImageIcon,
+  CheckCircleFillIcon,
 } from "@primer/octicons-react";
 import "./library-game-card.scss";
 import { logger } from "@renderer/logger";
@@ -28,8 +30,11 @@ export const LibraryGameCard = memo(function LibraryGameCard({
   onMouseLeave,
   onContextMenu,
 }: Readonly<LibraryGameCardProps>) {
+  const { t } = useTranslation("library");
   const { formatPlayTime, handleCardClick, handleContextMenuClick } =
     useGameCard(game, onContextMenu);
+
+  const isInstalled = Boolean(game.executablePath);
 
   const sources = [
     game.customIconUrl, // Level 0
@@ -119,6 +124,21 @@ export const LibraryGameCard = memo(function LibraryGameCard({
               {formatPlayTime(game.playTimeInMilliseconds, true)}
             </span>
           </div>
+
+          {isInstalled && (
+            <div
+              className="library-game-card__installed-badge"
+              title={t("installed_tooltip")}
+            >
+              <CheckCircleFillIcon
+                size={11}
+                className="library-game-card__installed-icon"
+              />
+              <span className="library-game-card__installed-text">
+                {t("installed")}
+              </span>
+            </div>
+          )}
         </div>
 
         {(game.achievementCount ?? 0) > 0 && (


### PR DESCRIPTION
Display a badge on library cards when a game has an executable set, so installed games are visually distinct from non-installed ones. Applied to both the normal and large cards.

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
Modified library page game card to display a badge once the path to the executable is set:
<img width="522" height="382" alt="image" src="https://github.com/user-attachments/assets/18c8bc8c-dadc-4b0e-93f8-6205b274754c" />
<img width="878" height="650" alt="image" src="https://github.com/user-attachments/assets/46f5110c-896c-437d-9267-8bdc16fcd72e" />
