### PR TITLE
feat(catalogue): show 5 page buttons for multi-page jumps

### DIFF
--- a/src/big-picture/src/pages/catalogue/pagination.tsx
+++ b/src/big-picture/src/pages/catalogue/pagination.tsx
@@ -29,24 +29,29 @@ interface CataloguePaginationProps {
 interface VisiblePageRange {
   start: number;
   end: number;
-  isLastThree: boolean;
+  showLeadingJump: boolean;
+  showTrailingJump: boolean;
 }
 
 function getVisiblePageRange(page: number, totalPages: number) {
-  const visiblePages = 3;
-  const isLastThree = totalPages > visiblePages && page >= totalPages - 2;
+  const visiblePages = 5;
   let start = Math.max(1, page - 1);
   let end = start + visiblePages - 1;
 
-  if (isLastThree) {
-    start = Math.max(1, totalPages - 2);
-    end = totalPages;
-  } else if (end > totalPages) {
+  if (end > totalPages) {
     end = totalPages;
     start = Math.max(1, end - visiblePages + 1);
   }
 
-  return { start, end, isLastThree } satisfies VisiblePageRange;
+  const showTrailingJump = end < totalPages;
+  const showLeadingJump = !showTrailingJump && start > 1;
+
+  return {
+    start,
+    end,
+    showLeadingJump,
+    showTrailingJump,
+  } satisfies VisiblePageRange;
 }
 
 function PaginationArrow({
@@ -83,8 +88,8 @@ export function CataloguePagination({
     { length: range.end - range.start + 1 },
     (_, index) => range.start + index
   );
-  const showLeadingJump = range.isLastThree && range.start > 1;
-  const showTrailingJump = !range.isLastThree && page < totalPages - 1;
+  const showLeadingJump = range.showLeadingJump;
+  const showTrailingJump = range.showTrailingJump;
   const itemIds = useMemo(
     () => [
       ...(range.start > 1 ? [CATALOGUE_PAGINATION_FIRST_ID] : []),

--- a/src/renderer/src/pages/catalogue/pagination.tsx
+++ b/src/renderer/src/pages/catalogue/pagination.tsx
@@ -83,19 +83,18 @@ export function Pagination({
 
   if (totalPages <= 1) return null;
 
-  const visiblePages = 3;
-  const isLastThree = totalPages > 3 && page >= totalPages - 2;
+  const visiblePages = 5;
 
   let startPage = Math.max(1, page - 1);
   let endPage = startPage + visiblePages - 1;
 
-  if (isLastThree) {
-    startPage = Math.max(1, totalPages - 2);
-    endPage = totalPages;
-  } else if (endPage > totalPages) {
+  if (endPage > totalPages) {
     endPage = totalPages;
     startPage = Math.max(1, endPage - visiblePages + 1);
   }
+
+  const showLeadingJump = endPage >= totalPages && startPage > 1;
+  const showTrailingJump = endPage < totalPages;
 
   const onJumpChange = (e: ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
@@ -199,7 +198,7 @@ export function Pagination({
         />
       </Button>
 
-      {isLastThree && startPage > 1 && (
+      {showLeadingJump && (
         <>
           <Button
             theme="outline"
@@ -236,7 +235,7 @@ export function Pagination({
         </Button>
       ))}
 
-      {!isLastThree && page < totalPages - 1 && (
+      {showTrailingJump && (
         <>
           <JumpControl
             isOpen={isJumpOpen}


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
Widen the catalogue pagination window from 3 to 5 visible pages so a single click can advance up to 3 pages forward without typing a page number. Replace the isLastThree special-case with showLeadingJump/ showTrailingJump derived from actual hidden-page existence, which also prevents the last-page button from rendering twice at the wider width. Applies to both the desktop and big-picture catalogues.
<img width="513" height="69" alt="image" src="https://github.com/user-attachments/assets/7999c589-6469-408c-bfe7-71b34fe45be2" />





