### PR TITLE
feat: populate classics from profile games endpoint on sign in

### DIFF
--- a/src/main/services/library-sync/merge-with-remote-games.ts
+++ b/src/main/services/library-sync/merge-with-remote-games.ts
@@ -14,6 +14,7 @@ type ProfileGame = {
   isPinned?: boolean;
   achievementCount: number;
   unlockedAchievementCount: number;
+  platform?: string | null;
 } & ShopAssets;
 
 const getLocalCollectionIds = (
@@ -42,7 +43,17 @@ const getLocalCollectionIds = (
 };
 
 export const mergeWithRemoteGames = async () => {
-  return HydraApi.get<ProfileGame[]>("/profile/games")
+  const fetchGames = Promise.all([
+    HydraApi.get<ProfileGame[]>("/profile/games"),
+    HydraApi.get<ProfileGame[]>("/profile/games", {
+      shop: "launchbox",
+    }).catch(() => [] as ProfileGame[]),
+  ]).then(([defaultGames, classicsGames]) => [
+    ...defaultGames,
+    ...classicsGames,
+  ]);
+
+  return fetchGames
     .then(async (response) => {
       for (const game of response) {
         const gameKey = levelKeys.game(game.shop, game.objectId);
@@ -93,6 +104,7 @@ export const mergeWithRemoteGames = async () => {
             collectionIds: mergedCollectionIds,
             achievementCount: game.achievementCount,
             unlockedAchievementCount: game.unlockedAchievementCount,
+            platform: game.platform ?? localGame.platform,
           });
         } else {
           await gamesSublevel.put(gameKey, {
@@ -113,6 +125,7 @@ export const mergeWithRemoteGames = async () => {
             collectionIds: mergedCollectionIds,
             achievementCount: game.achievementCount,
             unlockedAchievementCount: game.unlockedAchievementCount,
+            platform: game.platform ?? null,
           });
         }
 


### PR DESCRIPTION
Default /profile/games excludes launchbox, so fetch it explicitly with the launchbox shop and merge those entries alongside the regular games. Carries platform through so the console filter works for synced classics even before the local rom scan binds disc paths.

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [ ] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [ ] I have checked that there are no duplicate pull requests related to this request.
- [ ] I have considered, and confirm that this submission is valuable to others.
- [ ] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
