### PR TITLE
Add Steam-like Big Picture monitor and audio routing

### DIFF
--- a/native/hydra-native/src/lib.rs
+++ b/native/hydra-native/src/lib.rs
@@ -35,6 +35,14 @@ pub struct NativeProcessPayload {
     pub cwd: Option<String>,
 }
 
+#[napi(object)]
+pub struct NativeDisplayBounds {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
 #[napi]
 pub fn process_profile_image(
     image_path: String,
@@ -204,6 +212,537 @@ pub fn list_processes() -> Vec<NativeProcessPayload> {
     });
 
     processes
+}
+
+#[napi]
+pub fn set_primary_display_by_bounds(bounds: NativeDisplayBounds) -> napi::Result<bool> {
+    #[cfg(target_os = "windows")]
+    {
+        return display_config::set_primary_display_by_bounds(bounds)
+            .map_err(Error::from_reason);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = bounds;
+        Ok(false)
+    }
+}
+
+#[napi]
+pub fn get_display_source_name_by_bounds(
+    bounds: NativeDisplayBounds,
+) -> napi::Result<Option<String>> {
+    #[cfg(target_os = "windows")]
+    {
+        return display_config::get_display_source_name_by_bounds(bounds)
+            .map_err(Error::from_reason);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = bounds;
+        Ok(None)
+    }
+}
+
+#[napi]
+pub fn get_primary_display_source_name() -> napi::Result<Option<String>> {
+    #[cfg(target_os = "windows")]
+    {
+        return display_config::get_primary_display_source_name()
+            .map_err(Error::from_reason);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(None)
+    }
+}
+
+#[napi]
+pub fn set_primary_display_by_source_name(source_name: String) -> napi::Result<bool> {
+    #[cfg(target_os = "windows")]
+    {
+        return display_config::set_primary_display_by_source_name(&source_name)
+            .map_err(Error::from_reason);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = source_name;
+        Ok(false)
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod display_config {
+    use std::collections::HashMap;
+    use std::mem::size_of;
+
+    use super::NativeDisplayBounds;
+
+    const ERROR_SUCCESS: i32 = 0;
+    const DISPLAYCONFIG_PATH_ACTIVE: u32 = 0x00000001;
+    const DISPLAYCONFIG_PATH_MODE_IDX_INVALID: u32 = 0xffffffff;
+    const QDC_ALL_PATHS: u32 = 0x00000001;
+    const QDC_ONLY_ACTIVE_PATHS: u32 = 0x00000002;
+    const SDC_USE_SUPPLIED_DISPLAY_CONFIG: u32 = 0x00000020;
+    const SDC_APPLY: u32 = 0x00000080;
+    const SDC_SAVE_TO_DATABASE: u32 = 0x00000200;
+    const SDC_ALLOW_CHANGES: u32 = 0x00000400;
+    const DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME: u32 = 1;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct Luid {
+        low_part: u32,
+        high_part: i32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigRational {
+        numerator: u32,
+        denominator: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfig2DRegion {
+        width: u32,
+        height: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct PointL {
+        x: i32,
+        y: i32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct RectL {
+        left: i32,
+        top: i32,
+        right: i32,
+        bottom: i32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigPathInfo {
+        source_info: DisplayConfigPathSourceInfo,
+        target_info: DisplayConfigPathTargetInfo,
+        flags: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigPathSourceInfo {
+        adapter_id: Luid,
+        id: u32,
+        mode_info_idx: u32,
+        status_flags: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigPathTargetInfo {
+        adapter_id: Luid,
+        id: u32,
+        mode_info_idx: u32,
+        output_technology: u32,
+        rotation: u32,
+        scaling: u32,
+        refresh_rate: DisplayConfigRational,
+        scan_line_ordering: u32,
+        target_available: i32,
+        status_flags: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigTargetMode {
+        target_video_signal_info: DisplayConfigVideoSignalInfo,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigVideoSignalInfo {
+        pixel_rate: u64,
+        h_sync_freq: DisplayConfigRational,
+        v_sync_freq: DisplayConfigRational,
+        active_size: DisplayConfig2DRegion,
+        total_size: DisplayConfig2DRegion,
+        video_standard: u32,
+        scan_line_ordering: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigSourceMode {
+        width: u32,
+        height: u32,
+        pixel_format: u32,
+        position: PointL,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigDesktopImageInfo {
+        path_source_size: PointL,
+        desktop_image_region: RectL,
+        desktop_image_clip: RectL,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    union DisplayConfigModeInfoData {
+        target_mode: DisplayConfigTargetMode,
+        source_mode: DisplayConfigSourceMode,
+        desktop_image_info: DisplayConfigDesktopImageInfo,
+    }
+
+    impl Default for DisplayConfigModeInfoData {
+        fn default() -> Self {
+            Self {
+                source_mode: DisplayConfigSourceMode::default(),
+            }
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigModeInfo {
+        info_type: u32,
+        id: u32,
+        adapter_id: Luid,
+        data: DisplayConfigModeInfoData,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct DisplayConfigDeviceInfoHeader {
+        r#type: u32,
+        size: u32,
+        adapter_id: Luid,
+        id: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct DisplayConfigSourceDeviceName {
+        header: DisplayConfigDeviceInfoHeader,
+        view_gdi_device_name: [u16; 32],
+    }
+
+    impl Default for DisplayConfigSourceDeviceName {
+        fn default() -> Self {
+            Self {
+                header: DisplayConfigDeviceInfoHeader::default(),
+                view_gdi_device_name: [0; 32],
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct ActiveDisplay {
+        source_name: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    }
+
+    #[link(name = "user32")]
+    unsafe extern "system" {
+        fn GetDisplayConfigBufferSizes(
+            flags: u32,
+            num_path_array_elements: *mut u32,
+            num_mode_info_array_elements: *mut u32,
+        ) -> i32;
+
+        fn QueryDisplayConfig(
+            flags: u32,
+            num_path_array_elements: *mut u32,
+            path_info_array: *mut DisplayConfigPathInfo,
+            num_mode_info_array_elements: *mut u32,
+            mode_info_array: *mut DisplayConfigModeInfo,
+            current_topology_id: *mut u32,
+        ) -> i32;
+
+        fn SetDisplayConfig(
+            num_path_array_elements: u32,
+            path_array: *const DisplayConfigPathInfo,
+            num_mode_info_array_elements: u32,
+            mode_info_array: *const DisplayConfigModeInfo,
+            flags: u32,
+        ) -> i32;
+
+        fn DisplayConfigGetDeviceInfo(
+            request_packet: *mut DisplayConfigDeviceInfoHeader,
+        ) -> i32;
+    }
+
+    pub fn set_primary_display_by_bounds(bounds: NativeDisplayBounds) -> Result<bool, String> {
+        let (active_paths, active_modes) = query_display_config(QDC_ONLY_ACTIVE_PATHS)?;
+        let active_displays = build_active_displays(&active_paths, &active_modes);
+
+        let Some(target_display) = find_target_display(&active_displays, &bounds) else {
+            return Ok(false);
+        };
+
+        if target_display.x == 0 && target_display.y == 0 {
+            return Ok(true);
+        }
+
+        let offset_x = -target_display.x;
+        let offset_y = -target_display.y;
+
+        let desired_positions = active_displays
+            .iter()
+            .map(|display| {
+                let position = if display.source_name == target_display.source_name {
+                    PointL { x: 0, y: 0 }
+                } else {
+                    PointL {
+                        x: display.x + offset_x,
+                        y: display.y + offset_y,
+                    }
+                };
+
+                (display.source_name.clone(), position)
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut right_edge = active_displays
+            .iter()
+            .filter_map(|display| {
+                desired_positions
+                    .get(&display.source_name)
+                    .map(|position| position.x + display.width)
+            })
+            .max()
+            .unwrap_or(0);
+
+        let (paths, mut modes) = query_display_config(QDC_ALL_PATHS)?;
+
+        for path in paths.iter() {
+            if path.target_info.target_available == 0 {
+                continue;
+            }
+
+            let mode_index = path.source_info.mode_info_idx;
+            if mode_index == DISPLAYCONFIG_PATH_MODE_IDX_INVALID {
+                continue;
+            }
+
+            let Some(mode) = modes.get_mut(mode_index as usize) else {
+                continue;
+            };
+
+            let source_name = get_source_name(path.source_info.adapter_id, path.source_info.id);
+            let mut source_mode = unsafe { mode.data.source_mode };
+
+            if let Some(position) = desired_positions.get(&source_name) {
+                source_mode.position = *position;
+            } else if path.target_info.scan_line_ordering != 0 {
+                source_mode.position = PointL {
+                    x: right_edge,
+                    y: 0,
+                };
+                right_edge += source_mode.width as i32;
+            } else {
+                continue;
+            }
+
+            mode.data.source_mode = source_mode;
+        }
+
+        let result = unsafe {
+            SetDisplayConfig(
+                paths.len() as u32,
+                paths.as_ptr(),
+                modes.len() as u32,
+                modes.as_ptr(),
+                SDC_APPLY
+                    | SDC_USE_SUPPLIED_DISPLAY_CONFIG
+                    | SDC_ALLOW_CHANGES
+                    | SDC_SAVE_TO_DATABASE,
+            )
+        };
+
+        if result == ERROR_SUCCESS {
+            Ok(true)
+        } else {
+            Err(format!("SetDisplayConfig failed with Win32 error {result}"))
+        }
+    }
+
+    pub fn get_display_source_name_by_bounds(
+        bounds: NativeDisplayBounds,
+    ) -> Result<Option<String>, String> {
+        let (active_paths, active_modes) = query_display_config(QDC_ONLY_ACTIVE_PATHS)?;
+        let active_displays = build_active_displays(&active_paths, &active_modes);
+
+        Ok(find_target_display(&active_displays, &bounds)
+            .map(|display| display.source_name.clone()))
+    }
+
+    pub fn get_primary_display_source_name() -> Result<Option<String>, String> {
+        let (active_paths, active_modes) = query_display_config(QDC_ONLY_ACTIVE_PATHS)?;
+        let active_displays = build_active_displays(&active_paths, &active_modes);
+
+        Ok(active_displays
+            .iter()
+            .find(|display| display.x == 0 && display.y == 0)
+            .map(|display| display.source_name.clone()))
+    }
+
+    pub fn set_primary_display_by_source_name(source_name: &str) -> Result<bool, String> {
+        let (active_paths, active_modes) = query_display_config(QDC_ONLY_ACTIVE_PATHS)?;
+        let active_displays = build_active_displays(&active_paths, &active_modes);
+
+        let Some(target_display) = active_displays
+            .iter()
+            .find(|display| display.source_name.eq_ignore_ascii_case(source_name))
+        else {
+            return Ok(false);
+        };
+
+        set_primary_display_by_bounds(NativeDisplayBounds {
+            x: target_display.x,
+            y: target_display.y,
+            width: target_display.width,
+            height: target_display.height,
+        })
+    }
+
+    fn query_display_config(
+        flags: u32,
+    ) -> Result<(Vec<DisplayConfigPathInfo>, Vec<DisplayConfigModeInfo>), String> {
+        let mut path_count = 0;
+        let mut mode_count = 0;
+
+        let result =
+            unsafe { GetDisplayConfigBufferSizes(flags, &mut path_count, &mut mode_count) };
+        if result != ERROR_SUCCESS {
+            return Err(format!(
+                "GetDisplayConfigBufferSizes failed with Win32 error {result}"
+            ));
+        }
+
+        let mut paths = vec![DisplayConfigPathInfo::default(); path_count as usize];
+        let mut modes = vec![DisplayConfigModeInfo::default(); mode_count as usize];
+
+        let result = unsafe {
+            QueryDisplayConfig(
+                flags,
+                &mut path_count,
+                paths.as_mut_ptr(),
+                &mut mode_count,
+                modes.as_mut_ptr(),
+                std::ptr::null_mut(),
+            )
+        };
+        if result != ERROR_SUCCESS {
+            return Err(format!("QueryDisplayConfig failed with Win32 error {result}"));
+        }
+
+        paths.truncate(path_count as usize);
+        modes.truncate(mode_count as usize);
+
+        Ok((paths, modes))
+    }
+
+    fn build_active_displays(
+        paths: &[DisplayConfigPathInfo],
+        modes: &[DisplayConfigModeInfo],
+    ) -> Vec<ActiveDisplay> {
+        paths
+            .iter()
+            .filter_map(|path| {
+                if (path.flags & DISPLAYCONFIG_PATH_ACTIVE) == 0 {
+                    return None;
+                }
+
+                let mode_index = path.source_info.mode_info_idx;
+                if mode_index == DISPLAYCONFIG_PATH_MODE_IDX_INVALID {
+                    return None;
+                }
+
+                let mode = modes.get(mode_index as usize)?;
+                let source_mode = unsafe { mode.data.source_mode };
+
+                Some(ActiveDisplay {
+                    source_name: get_source_name(
+                        path.source_info.adapter_id,
+                        path.source_info.id,
+                    ),
+                    x: source_mode.position.x,
+                    y: source_mode.position.y,
+                    width: source_mode.width as i32,
+                    height: source_mode.height as i32,
+                })
+            })
+            .collect()
+    }
+
+    fn find_target_display<'a>(
+        displays: &'a [ActiveDisplay],
+        bounds: &NativeDisplayBounds,
+    ) -> Option<&'a ActiveDisplay> {
+        displays.iter().max_by_key(|display| score_display(display, bounds))
+    }
+
+    fn score_display(display: &ActiveDisplay, bounds: &NativeDisplayBounds) -> i64 {
+        let mut score = 0_i64;
+
+        if display.x == bounds.x && display.y == bounds.y {
+            score += 1_000_000;
+        }
+
+        if display.width == bounds.width && display.height == bounds.height {
+            score += 500_000;
+        }
+
+        let display_center_x = display.x as i64 + display.width as i64 / 2;
+        let display_center_y = display.y as i64 + display.height as i64 / 2;
+        let bounds_center_x = bounds.x as i64 + bounds.width as i64 / 2;
+        let bounds_center_y = bounds.y as i64 + bounds.height as i64 / 2;
+        let dx = display_center_x - bounds_center_x;
+        let dy = display_center_y - bounds_center_y;
+        let distance_squared = dx * dx + dy * dy;
+
+        score - distance_squared
+    }
+
+    fn get_source_name(adapter_id: Luid, id: u32) -> String {
+        let mut source_name = DisplayConfigSourceDeviceName {
+            header: DisplayConfigDeviceInfoHeader {
+                r#type: DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME,
+                size: size_of::<DisplayConfigSourceDeviceName>() as u32,
+                adapter_id,
+                id,
+            },
+            ..Default::default()
+        };
+
+        let result = unsafe { DisplayConfigGetDeviceInfo(&mut source_name.header) };
+        if result != ERROR_SUCCESS {
+            return format!("DISPLAY{id}");
+        }
+
+        let end = source_name
+            .view_gdi_device_name
+            .iter()
+            .position(|value| *value == 0)
+            .unwrap_or(source_name.view_gdi_device_name.len());
+
+        String::from_utf16_lossy(&source_name.view_gdi_device_name[..end])
+    }
 }
 
 fn detect_image_format(path: &Path) -> napi::Result<Option<ImageFormat>> {

--- a/src/big-picture/src/components/pages/library/use-library-launch-game.ts
+++ b/src/big-picture/src/components/pages/library/use-library-launch-game.ts
@@ -20,7 +20,9 @@ export function useLibraryLaunchGame(
         await globalThis.window.electron.openClassicsGame(
           game.shop,
           game.objectId,
-          game.selectedDiscPath ?? undefined
+          game.selectedDiscPath ?? undefined,
+          undefined,
+          "big-picture"
         );
         globalThis.window.dispatchEvent(new Event("library-update"));
         return;
@@ -36,7 +38,8 @@ export function useLibraryLaunchGame(
         game.shop,
         game.objectId,
         game.executablePath,
-        game.launchOptions
+        game.launchOptions,
+        "big-picture"
       );
     },
     [onMissingExecutable]

--- a/src/big-picture/src/hooks/use-game-details.hook.ts
+++ b/src/big-picture/src/hooks/use-game-details.hook.ts
@@ -123,7 +123,8 @@ export function useGameDetails(objectId: string, shop: GameShop) {
           game.shop,
           game.objectId,
           discPath,
-          force
+          force,
+          "big-picture"
         );
         return;
       }
@@ -135,7 +136,8 @@ export function useGameDetails(objectId: string, shop: GameShop) {
         game.shop,
         game.objectId,
         game.executablePath,
-        game.launchOptions
+        game.launchOptions,
+        "big-picture"
       );
     },
     [game]

--- a/src/big-picture/src/pages/settings/behavior-section.tsx
+++ b/src/big-picture/src/pages/settings/behavior-section.tsx
@@ -1,10 +1,16 @@
 import "./behavior-section.scss";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { Checkbox, VerticalFocusGroup } from "../../components";
+import {
+  Checkbox,
+  DropdownSelect,
+  type DropdownSelectOption,
+  VerticalFocusGroup,
+} from "../../components";
 import type { FocusOverrides } from "../../services";
 import { useUserPreferences } from "../../hooks";
+import type { HydraAudioDevice, HydraDisplay } from "@types";
 import {
   BEHAVIOR_ITEM_FOCUS_IDS,
   BEHAVIOR_SECTION_REGION_ID,
@@ -23,6 +29,8 @@ interface BehaviorForm {
   hideToTrayOnGameStart: boolean;
   launchToLibraryPage: boolean;
   launchInBigPicture: boolean;
+  bigPictureDisplayId: string;
+  bigPictureAudioDeviceId: string;
   enableAutoInstall: boolean;
 }
 
@@ -42,13 +50,20 @@ const DEFAULT_FORM: BehaviorForm = {
   hideToTrayOnGameStart: false,
   launchToLibraryPage: false,
   launchInBigPicture: false,
+  bigPictureDisplayId: "default",
+  bigPictureAudioDeviceId: "default",
   enableAutoInstall: false,
 };
+
+const DEFAULT_BIG_PICTURE_DISPLAY_ID = "default";
+const DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID = "default";
 
 export function BehaviorSection({ className }: Readonly<BehaviorSectionProps>) {
   const userPreferences = useUserPreferences();
   const [showRunAtStartup, setShowRunAtStartup] = useState(false);
   const [form, setForm] = useState<BehaviorForm>(DEFAULT_FORM);
+  const [displays, setDisplays] = useState<HydraDisplay[]>([]);
+  const [audioDevices, setAudioDevices] = useState<HydraAudioDevice[]>([]);
 
   useEffect(() => {
     let isMounted = true;
@@ -64,6 +79,32 @@ export function BehaviorSection({ className }: Readonly<BehaviorSectionProps>) {
         if (!isMounted) return;
 
         setShowRunAtStartup(true);
+      });
+
+    globalThis.window.electron
+      .getDisplays()
+      .then((nextDisplays) => {
+        if (!isMounted) return;
+
+        setDisplays(nextDisplays);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+
+        setDisplays([]);
+      });
+
+    globalThis.window.electron
+      .getAudioDevices()
+      .then((nextAudioDevices) => {
+        if (!isMounted) return;
+
+        setAudioDevices(nextAudioDevices);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+
+        setAudioDevices([]);
       });
 
     return () => {
@@ -82,24 +123,51 @@ export function BehaviorSection({ className }: Readonly<BehaviorSectionProps>) {
       hideToTrayOnGameStart: userPreferences.hideToTrayOnGameStart ?? false,
       launchToLibraryPage: userPreferences.launchToLibraryPage ?? false,
       launchInBigPicture: userPreferences.launchInBigPicture ?? false,
+      bigPictureDisplayId:
+        userPreferences.bigPictureDisplayId ?? DEFAULT_BIG_PICTURE_DISPLAY_ID,
+      bigPictureAudioDeviceId:
+        userPreferences.bigPictureAudioDeviceId ??
+        DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID,
       enableAutoInstall: userPreferences.enableAutoInstall ?? false,
     });
   }, [userPreferences]);
 
   const isLinux = globalThis.window.electron.platform === "linux";
 
-  const updateUserPreferences = async (
-    values: Partial<BehaviorForm>,
-    autoLaunchOptions?: { enabled: boolean; minimized: boolean }
-  ) => {
-    const nextForm = { ...form, ...values };
-    setForm(nextForm);
+  const updateUserPreferences = useCallback(
+    async (
+      values: Partial<BehaviorForm>,
+      autoLaunchOptions?: { enabled: boolean; minimized: boolean }
+    ) => {
+      setForm((prev) => ({ ...prev, ...values }));
 
-    await globalThis.window.electron.updateUserPreferences(values);
+      await globalThis.window.electron.updateUserPreferences(values);
 
-    if (autoLaunchOptions) {
-      globalThis.window.electron.autoLaunch(autoLaunchOptions);
-    }
+      if (autoLaunchOptions) {
+        globalThis.window.electron.autoLaunch(autoLaunchOptions);
+      }
+    },
+    []
+  );
+
+  const updateBigPictureDisplay = async (displayId: string) => {
+    setForm((prev) => ({ ...prev, bigPictureDisplayId: displayId }));
+
+    await globalThis.window.electron.updateUserPreferences({
+      bigPictureDisplayId:
+        displayId === DEFAULT_BIG_PICTURE_DISPLAY_ID ? null : displayId,
+    });
+  };
+
+  const updateBigPictureAudioDevice = async (audioDeviceId: string) => {
+    setForm((prev) => ({ ...prev, bigPictureAudioDeviceId: audioDeviceId }));
+
+    await globalThis.window.electron.updateUserPreferences({
+      bigPictureAudioDeviceId:
+        audioDeviceId === DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID
+          ? null
+          : audioDeviceId,
+    });
   };
 
   const items = useMemo<BehaviorItem[]>(() => {
@@ -190,7 +258,57 @@ export function BehaviorSection({ className }: Readonly<BehaviorSectionProps>) {
     ];
 
     return baseItems;
-  }, [form, isLinux, showRunAtStartup]);
+  }, [form, isLinux, showRunAtStartup, updateUserPreferences]);
+
+  const displayOptions = useMemo<Array<DropdownSelectOption<string>>>(() => {
+    const selectedDisplayMissing =
+      form.bigPictureDisplayId !== DEFAULT_BIG_PICTURE_DISPLAY_ID &&
+      displays.every((display) => display.id !== form.bigPictureDisplayId);
+
+    return [
+      {
+        value: DEFAULT_BIG_PICTURE_DISPLAY_ID,
+        label: "System default monitor",
+      },
+      ...displays.map((display) => ({
+        value: display.id,
+        label: display.isPrimary ? `${display.label} (Primary)` : display.label,
+      })),
+      ...(selectedDisplayMissing
+        ? [
+            {
+              value: form.bigPictureDisplayId,
+              label: `Missing display (${form.bigPictureDisplayId})`,
+            },
+          ]
+        : []),
+    ];
+  }, [displays, form.bigPictureDisplayId]);
+
+  const audioDeviceOptions = useMemo<Array<DropdownSelectOption<string>>>(() => {
+    const selectedAudioDeviceMissing =
+      form.bigPictureAudioDeviceId !== DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID &&
+      audioDevices.every((device) => device.id !== form.bigPictureAudioDeviceId);
+
+    return [
+      {
+        value: DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID,
+        label: "System default audio device",
+      },
+      ...audioDevices.map((device) => ({
+        value: device.id,
+        label: device.isDefault ? `${device.label} (Default)` : device.label,
+      })),
+      ...(selectedAudioDeviceMissing
+        ? [
+            {
+              value: form.bigPictureAudioDeviceId,
+              label: `Missing audio device (${form.bigPictureAudioDeviceId})`,
+            },
+          ]
+        : []),
+    ];
+  }, [audioDevices, form.bigPictureAudioDeviceId]);
 
   const navigationOverridesByFocusId = useMemo<
     Record<string, FocusOverrides>
@@ -220,13 +338,48 @@ export function BehaviorSection({ className }: Readonly<BehaviorSectionProps>) {
                   itemId: nextItem.focusId,
                 }
               : {
-                  type: "block",
+                  type: "item",
+                  itemId: BEHAVIOR_ITEM_FOCUS_IDS.bigPictureDisplay,
                 },
           } satisfies FocusOverrides,
         ];
       })
     );
   }, [items]);
+
+  const displayNavigationOverrides = useMemo<FocusOverrides>(() => {
+    const focusableItems = items.filter((item) => !item.disabled);
+    const previousItem = focusableItems[focusableItems.length - 1];
+
+    return {
+      up: previousItem
+        ? {
+            type: "item",
+            itemId: previousItem.focusId,
+          }
+        : {
+            type: "item",
+            itemId: LANGUAGE_SECTION_BUTTON_ID,
+          },
+      down: {
+        type: "item",
+        itemId: BEHAVIOR_ITEM_FOCUS_IDS.bigPictureAudioDevice,
+      },
+    };
+  }, [items]);
+
+  const audioDeviceNavigationOverrides = useMemo<FocusOverrides>(
+    () => ({
+      up: {
+        type: "item",
+        itemId: BEHAVIOR_ITEM_FOCUS_IDS.bigPictureDisplay,
+      },
+      down: {
+        type: "block",
+      },
+    }),
+    []
+  );
 
   return (
     <SettingsSection
@@ -249,6 +402,28 @@ export function BehaviorSection({ className }: Readonly<BehaviorSectionProps>) {
               onChange={item.onChange}
             />
           ))}
+
+          <DropdownSelect
+            label="Big Picture launching monitor"
+            value={form.bigPictureDisplayId}
+            options={displayOptions}
+            focusId={BEHAVIOR_ITEM_FOCUS_IDS.bigPictureDisplay}
+            focusNavigationOverrides={displayNavigationOverrides}
+            onValueChange={(displayId) => {
+              void updateBigPictureDisplay(displayId);
+            }}
+          />
+
+          <DropdownSelect
+            label="Big Picture output device"
+            value={form.bigPictureAudioDeviceId}
+            options={audioDeviceOptions}
+            focusId={BEHAVIOR_ITEM_FOCUS_IDS.bigPictureAudioDevice}
+            focusNavigationOverrides={audioDeviceNavigationOverrides}
+            onValueChange={(audioDeviceId) => {
+              void updateBigPictureAudioDevice(audioDeviceId);
+            }}
+          />
         </div>
       </VerticalFocusGroup>
     </SettingsSection>

--- a/src/big-picture/src/pages/settings/settings-navigation.ts
+++ b/src/big-picture/src/pages/settings/settings-navigation.ts
@@ -84,6 +84,8 @@ export const BEHAVIOR_ITEM_FOCUS_IDS = {
   startMinimized: "behavior-start-minimized",
   launchToLibraryPage: "behavior-launch-to-library-page",
   launchInBigPicture: "behavior-launch-in-big-picture",
+  bigPictureDisplay: "behavior-big-picture-display",
+  bigPictureAudioDevice: "behavior-big-picture-audio-device",
   enableAutoInstall: "behavior-enable-auto-install",
 } as const;
 

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "اكتمل التنزيل",

--- a/src/locales/be/translation.json
+++ b/src/locales/be/translation.json
@@ -760,7 +760,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Сцягванне скончана",

--- a/src/locales/bg/translation.json
+++ b/src/locales/bg/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Изтеглянето завърши",

--- a/src/locales/ca/translation.json
+++ b/src/locales/ca/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "La baixada ha finalitzat",

--- a/src/locales/cs/translation.json
+++ b/src/locales/cs/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Stahování dokončeno",

--- a/src/locales/da/translation.json
+++ b/src/locales/da/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download færdig",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download abgeschlossen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1051,7 +1051,6 @@
     "bios_note": "BIOS files are managed by {{name}}. Hydra cannot install BIOS for you. Set them up inside {{name}}.",
     "remove_rom_folder_title": "Remove ROM folder",
     "remove_rom_folder_description": "{{path}} will no longer be scanned. The folder and its files stay on your disk.",
-    "remove": "Remove",
     "cancel_remove": "Cancel",
     "stat_games": "GAMES",
     "stat_storage": "STORAGE",
@@ -1138,7 +1137,15 @@
     "setup_step_label_done": "Done",
     "remove_emulator": "Remove emulator",
     "remove_emulator_title": "Remove {{name}} from Hydra?",
-    "remove_emulator_description": "Hydra will forget the {{name}} path and all mapped ROM folders. The emulator itself and your ROM files stay on disk. You can re-run setup afterwards."
+    "remove_emulator_description": "Hydra will forget the {{name}} path and all mapped ROM folders. The emulator itself and your ROM files stay on disk. You can re-run setup afterwards.",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download complete",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1091,7 +1091,15 @@
     "setup_step_label_done": "Listo",
     "remove_emulator": "Quitar emulador",
     "remove_emulator_title": "¿Quitar {{name}} de Hydra?",
-    "remove_emulator_description": "Hydra olvidará la ruta de {{name}} y todas las carpetas de ROMs mapeadas. El emulador y tus archivos ROM permanecen en el disco. Puedes volver a ejecutar la configuración después."
+    "remove_emulator_description": "Hydra olvidará la ruta de {{name}} y todas las carpetas de ROMs mapeadas. El emulador y tus archivos ROM permanecen en el disco. Puedes volver a ejecutar la configuración después.",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Descarga completada",

--- a/src/locales/et/translation.json
+++ b/src/locales/et/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Allalaadimine lõpetatud",

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -760,7 +760,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "دانلود تمام شد",

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Lataus valmis",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1145,7 +1145,15 @@
     "setup_step_label_done": "Terminé",
     "remove_emulator": "Supprimer l'émulateur",
     "remove_emulator_title": "Supprimer {{name}} d'Hydra ?",
-    "remove_emulator_description": "Hydra oubliera le chemin de {{name}} et tous les dossiers ROM mappés. L'émulateur lui-même et vos fichiers ROM restent sur le disque. Vous pouvez relancer la configuration ensuite."
+    "remove_emulator_description": "Hydra oubliera le chemin de {{name}} et tous les dossiers ROM mappés. L'émulateur lui-même et vos fichiers ROM restent sur le disque. Vous pouvez relancer la configuration ensuite.",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "classics_onboarding": {
     "title": "Bienvenue dans Hydra Classics",

--- a/src/locales/hu/translation.json
+++ b/src/locales/hu/translation.json
@@ -786,7 +786,15 @@
     "downloads": "Letöltések",
     "create_shortcuts_on_download": "Asztali és Start menü parancsikonok létrehozása a letöltés befejezésekor",
     "default_proton_version": "Alapértelmezett Proton verzió",
-    "default_proton_version_description": "Válaszd ki azt a Proton verziót, amelyet az Auto mód használ, ha a játékhoz nincs egyedi felülírás"
+    "default_proton_version_description": "Válaszd ki azt a Proton verziót, amelyet az Auto mód használ, ha a játékhoz nincs egyedi felülírás",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Letöltés befejezve",

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -853,7 +853,15 @@
     "downloads": "Unduhan",
     "create_shortcuts_on_download": "Buat pintasan desktop dan Start Menu saat game selesai diunduh",
     "default_proton_version": "Versi Proton default",
-    "default_proton_version_description": "Pilih versi Proton yang digunakan oleh mode Otomatis saat game tidak memiliki pengaturan kustom"
+    "default_proton_version_description": "Pilih versi Proton yang digunakan oleh mode Otomatis saat game tidak memiliki pengaturan kustom",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Unduhan selesai",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download completato",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -788,7 +788,15 @@
     "cannot_change_downloader_while_downloading": "ダウンロード中はこの設定を変更できません",
     "create_shortcuts_on_download": "ゲームのダウンロード完了時にデスクトップとスタートメニューのショートカットを作成",
     "default_proton_version": "デフォルトProtonバージョン",
-    "default_proton_version_description": "カスタムオーバーライドがないゲームで自動モードが使用するProtonバージョンを選択"
+    "default_proton_version_description": "カスタムオーバーライドがないゲームで自動モードが使用するProtonバージョンを選択",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "ダウンロード完了",

--- a/src/locales/kk/translation.json
+++ b/src/locales/kk/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Жүктеу аяқталды",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -760,7 +760,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "다운로드 완료",

--- a/src/locales/lv/translation.json
+++ b/src/locales/lv/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Lejupielāde pabeigta",

--- a/src/locales/nb/translation.json
+++ b/src/locales/nb/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Nedlasting ferdig",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -760,7 +760,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download compleet",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -856,7 +856,15 @@
     "current_username": "Nazwa użytkownika:",
     "content_gameplay": "Treść i rozgrywka",
     "integrations": "Integracje",
-    "compatibility": "Kompatybilność"
+    "compatibility": "Kompatybilność",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "new_update_available": "Dostępna wersja {{version}}",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -1046,7 +1046,15 @@
     "setup_step_label_done": "Concluído",
     "remove_emulator": "Remover emulador",
     "remove_emulator_title": "Remover o {{name}} do Hydra?",
-    "remove_emulator_description": "O Hydra esquecerá o caminho do {{name}} e todas as pastas de ROM mapeadas. O emulador em si e seus arquivos de ROM permanecem no disco. Você pode executar a configuração novamente depois."
+    "remove_emulator_description": "O Hydra esquecerá o caminho do {{name}} e todas as pastas de ROM mapeadas. O emulador em si e seus arquivos de ROM permanecem no disco. Você pode executar a configuração novamente depois.",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download concluído",

--- a/src/locales/pt-PT/translation.json
+++ b/src/locales/pt-PT/translation.json
@@ -730,7 +730,15 @@
     "debrid": "Debrid",
     "debrid_description": "Serviços Debrid são transferidores premium sem restrições que permitem transferir rapidamente ficheiros alojados em vários serviços de alojamento de ficheiros, limitados apenas pela velocidade de internet.",
     "create_real_debrid_account": "Clica aqui se ainda não tens uma conta do Real-Debrid",
-    "create_torbox_account": "Clica aqui se ainda não tens uma conta do TorBox"
+    "create_torbox_account": "Clica aqui se ainda não tens uma conta do TorBox",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Transferência concluída",

--- a/src/locales/ro/translation.json
+++ b/src/locales/ro/translation.json
@@ -760,7 +760,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Descărcare completă",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1140,7 +1140,15 @@
     "setup_step_label_done": "Готово",
     "remove_emulator": "Удалить эмулятор",
     "remove_emulator_title": "Удалить {{name}} из Hydra?",
-    "remove_emulator_description": "Hydra забудет путь к {{name}} и все сопоставленные папки ROM. Сам эмулятор и ваши файлы ROM останутся на диске. Вы сможете повторно запустить настройку позже."
+    "remove_emulator_description": "Hydra забудет путь к {{name}} и все сопоставленные папки ROM. Сам эмулятор и ваши файлы ROM останутся на диске. Вы сможете повторно запустить настройку позже.",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Загрузка завершена",

--- a/src/locales/sl/translation.json
+++ b/src/locales/sl/translation.json
@@ -1001,7 +1001,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Download complete",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Nedladdning klar",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "İndirme tamamlandı",

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Завантаження завершено",

--- a/src/locales/uz/translation.json
+++ b/src/locales/uz/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "Yuklab olish yakunlandi",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -763,7 +763,15 @@
     "proton_version_auto": "Auto (global default or umu default)",
     "proton_source_umu_default": "umu default selection",
     "proton_source_steam": "Installed by Steam",
-    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d"
+    "proton_source_compatibility_tools": "Installed in Steam compatibilitytools.d",
+    "big_picture_launching_monitor": "Big Picture launching monitor",
+    "system_default_monitor": "System default monitor",
+    "primary_monitor": "Primary",
+    "missing_monitor": "Missing display",
+    "big_picture_output_device": "Big Picture output device",
+    "system_default_audio_device": "System default audio device",
+    "default_audio_device": "Default",
+    "missing_audio_device": "Missing audio device"
   },
   "notifications": {
     "download_complete": "下载完成",

--- a/src/main/events/hardware/get-audio-devices.ts
+++ b/src/main/events/hardware/get-audio-devices.ts
@@ -1,0 +1,6 @@
+import { AudioDeviceManager } from "@main/services";
+import { registerEvent } from "../register-event";
+
+const getAudioDevices = async () => AudioDeviceManager.getAudioDevices();
+
+registerEvent("getAudioDevices", getAudioDevices);

--- a/src/main/events/hardware/get-displays.ts
+++ b/src/main/events/hardware/get-displays.ts
@@ -1,0 +1,6 @@
+import { DisplayManager } from "@main/services";
+import { registerEvent } from "../register-event";
+
+const getDisplays = async () => DisplayManager.getDisplays();
+
+registerEvent("getDisplays", getDisplays);

--- a/src/main/events/hardware/index.ts
+++ b/src/main/events/hardware/index.ts
@@ -1,2 +1,4 @@
 import "./check-folder-write-permission";
 import "./get-disk-free-space";
+import "./get-audio-devices";
+import "./get-displays";

--- a/src/main/events/library/open-classics-game.ts
+++ b/src/main/events/library/open-classics-game.ts
@@ -2,7 +2,7 @@ import { registerEvent } from "../register-event";
 import { gamesSublevel, levelKeys } from "@main/level";
 import { launchClassicsGame, platformToSystem } from "@main/helpers";
 import { logger, NativeAddon } from "@main/services";
-import type { GameShop } from "@types";
+import type { GameShop, LaunchSource } from "@types";
 
 const isRpcs3RunningExternally = async (): Promise<number[]> => {
   const procs = await NativeAddon.listProcesses();
@@ -41,7 +41,8 @@ const openClassicsGame = async (
   shop: GameShop,
   objectId: string,
   discPath?: string,
-  force?: boolean
+  force?: boolean,
+  launchSource: LaunchSource = "default"
 ) => {
   if (shop !== "launchbox") {
     throw new Error("openClassicsGame called for non-launchbox shop");
@@ -106,6 +107,7 @@ const openClassicsGame = async (
       objectId,
       discPath: resolvedDiscPath,
       system,
+      launchSource,
     });
   } catch (error) {
     if (

--- a/src/main/events/library/open-game.ts
+++ b/src/main/events/library/open-game.ts
@@ -1,5 +1,5 @@
 import { registerEvent } from "../register-event";
-import { GameShop } from "@types";
+import { GameShop, type LaunchSource } from "@types";
 import { launchGame } from "@main/helpers";
 
 const openGame = async (
@@ -7,9 +7,16 @@ const openGame = async (
   shop: GameShop,
   objectId: string,
   executablePath: string,
-  launchOptions?: string | null
+  launchOptions?: string | null,
+  launchSource: LaunchSource = "default"
 ) => {
-  await launchGame({ shop, objectId, executablePath, launchOptions });
+  await launchGame({
+    shop,
+    objectId,
+    executablePath,
+    launchOptions,
+    launchSource,
+  });
 };
 
 registerEvent("openGame", openGame);

--- a/src/main/helpers/launch-classics-game.ts
+++ b/src/main/helpers/launch-classics-game.ts
@@ -2,11 +2,12 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { db, gamesSublevel, levelKeys } from "@main/level";
-import { emulators, logger } from "@main/services";
+import { DisplayManager, emulators, logger } from "@main/services";
 import type {
   EmulatorBinary,
   EmulatorSystem,
   GameShop,
+  LaunchSource,
   UserPreferences,
 } from "@types";
 import { isGamemodeAvailable } from "./is-gamemode-available";
@@ -27,6 +28,7 @@ export interface LaunchClassicsGameOptions {
   objectId: string;
   discPath: string;
   system: EmulatorSystem;
+  launchSource?: LaunchSource;
 }
 
 const buildEmulatorArgs = (
@@ -46,7 +48,7 @@ const buildEmulatorArgs = (
 export const launchClassicsGame = async (
   options: LaunchClassicsGameOptions
 ): Promise<void> => {
-  const { shop, objectId, discPath, system } = options;
+  const { shop, objectId, discPath, system, launchSource } = options;
 
   const config = await emulators.getEmulatorConfig(system);
   if (!config.executablePath || !existsSync(config.executablePath)) {
@@ -89,6 +91,10 @@ export const launchClassicsGame = async (
 
   if (!executableTarget || !existsSync(executableTarget)) {
     throw new EmulatorNotConfiguredError(system);
+  }
+
+  if (launchSource === "big-picture") {
+    await DisplayManager.prepareBigPictureDisplayForLaunch();
   }
 
   const resolvedLaunchCommand = resolveLaunchCommand({

--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -1,7 +1,7 @@
 import { shell } from "electron";
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { GameShop, type UserPreferences } from "@types";
+import { GameShop, type LaunchSource, type UserPreferences } from "@types";
 import { db, gamesSublevel, levelKeys } from "@main/level";
 import { updateGameExecutablePath } from "./update-executable-path";
 import {
@@ -11,6 +11,7 @@ import {
   PowerSaveBlockerManager,
   Wine,
   NativeAddon,
+  DisplayManager,
 } from "@main/services";
 import { CommonRedistManager } from "@main/services/common-redist-manager";
 import { parseExecutablePath } from "../events/helpers/parse-executable-path";
@@ -23,6 +24,7 @@ export interface LaunchGameOptions {
   objectId: string;
   executablePath: string;
   launchOptions?: string | null;
+  launchSource?: LaunchSource;
 }
 
 const isWindowsExecutable = (executablePath: string) =>
@@ -187,7 +189,8 @@ const cleanupStaleCompatibilityProcesses = async (
  * Shared between deep link handler and openGame event
  */
 export const launchGame = async (options: LaunchGameOptions): Promise<void> => {
-  const { shop, objectId, executablePath, launchOptions } = options;
+  const { shop, objectId, executablePath, launchOptions, launchSource } =
+    options;
 
   const parsedPath = parseExecutablePath(executablePath);
 
@@ -217,7 +220,12 @@ export const launchGame = async (options: LaunchGameOptions): Promise<void> => {
     });
   }
 
-  await WindowManager.createGameLauncherWindow(shop, objectId);
+  const launchDisplay =
+    launchSource === "big-picture"
+      ? await DisplayManager.getBigPictureDisplay()
+      : undefined;
+
+  await WindowManager.createGameLauncherWindow(shop, objectId, launchDisplay);
 
   // Run preflight check for common redistributables (Windows only)
   // Wrapped in try/catch to ensure game launch is never blocked
@@ -238,6 +246,10 @@ export const launchGame = async (options: LaunchGameOptions): Promise<void> => {
   }
 
   await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  if (launchSource === "big-picture") {
+    await DisplayManager.prepareBigPictureDisplayForLaunch();
+  }
 
   if (process.platform === "linux") {
     const isWindowsBinary = isWindowsExecutable(parsedPath);

--- a/src/main/services/audio-device-manager.ts
+++ b/src/main/services/audio-device-manager.ts
@@ -1,0 +1,230 @@
+import { execFile } from "node:child_process";
+import { Buffer } from "node:buffer";
+import type { HydraAudioDevice } from "@types";
+import { logger } from "./logger";
+
+const coreAudioScript = String.raw`
+Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+public enum EDataFlow { eRender = 0, eCapture = 1, eAll = 2 }
+public enum ERole { eConsole = 0, eMultimedia = 1, eCommunications = 2 }
+public enum DeviceState { Active = 1 }
+
+[StructLayout(LayoutKind.Sequential)]
+public struct PROPERTYKEY {
+  public Guid fmtid;
+  public uint pid;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct PROPVARIANT {
+  public ushort vt;
+  public ushort wReserved1;
+  public ushort wReserved2;
+  public ushort wReserved3;
+  public IntPtr p;
+  public int p2;
+}
+
+[ComImport]
+[Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+public class MMDeviceEnumerator {}
+
+[ComImport]
+[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDeviceEnumerator {
+  [PreserveSig]
+  int EnumAudioEndpoints(EDataFlow dataFlow, DeviceState stateMask, [MarshalAs(UnmanagedType.Interface)] out IMMDeviceCollection devices);
+  [PreserveSig]
+  int GetDefaultAudioEndpoint(EDataFlow dataFlow, ERole role, [MarshalAs(UnmanagedType.Interface)] out IMMDevice endpoint);
+}
+
+[ComImport]
+[Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDeviceCollection {
+  [PreserveSig]
+  int GetCount(out uint count);
+  [PreserveSig]
+  int Item(uint index, [MarshalAs(UnmanagedType.Interface)] out IMMDevice device);
+}
+
+[ComImport]
+[Guid("D666063F-1587-4E43-81F1-B948E807363F")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDevice {
+  [PreserveSig]
+  int Activate(ref Guid iid, uint clsCtx, IntPtr activationParams, out IntPtr interfacePointer);
+  [PreserveSig]
+  int OpenPropertyStore(uint access, [MarshalAs(UnmanagedType.Interface)] out IPropertyStore propertyStore);
+  [PreserveSig]
+  int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+  [PreserveSig]
+  int GetState(out uint state);
+}
+
+[ComImport]
+[Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IPropertyStore {
+  [PreserveSig]
+  int GetCount(out uint propertyCount);
+  [PreserveSig]
+  int GetAt(uint propertyIndex, out PROPERTYKEY key);
+  [PreserveSig]
+  int GetValue(ref PROPERTYKEY key, out PROPVARIANT value);
+  [PreserveSig]
+  int SetValue(ref PROPERTYKEY key, ref PROPVARIANT value);
+  [PreserveSig]
+  int Commit();
+}
+
+[ComImport]
+[Guid("870af99c-171d-4f9e-af0d-e63df40c2bc9")]
+public class PolicyConfigClient {}
+
+[ComImport]
+[Guid("f8679f50-850a-41cf-9c72-430f290290c8")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IPolicyConfig {
+  void GetMixFormat([MarshalAs(UnmanagedType.LPWStr)] string deviceName, out IntPtr waveFormat);
+  void GetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string deviceName, int defaultFormat, out IntPtr waveFormat);
+  void ResetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string deviceName);
+  void SetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string deviceName, IntPtr waveFormat, IntPtr mixFormat);
+  void GetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string deviceName, int defaultPeriod, out long defaultDevicePeriod, out long minimumDevicePeriod);
+  void SetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string deviceName, IntPtr period);
+  void GetShareMode([MarshalAs(UnmanagedType.LPWStr)] string deviceName, IntPtr mode);
+  void SetShareMode([MarshalAs(UnmanagedType.LPWStr)] string deviceName, IntPtr mode);
+  void GetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string deviceName, ref PROPERTYKEY key, out PROPVARIANT value);
+  void SetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string deviceName, ref PROPERTYKEY key, ref PROPVARIANT value);
+  void SetDefaultEndpoint([MarshalAs(UnmanagedType.LPWStr)] string deviceName, ERole role);
+  void SetEndpointVisibility([MarshalAs(UnmanagedType.LPWStr)] string deviceName, int visible);
+}
+
+public class AudioDeviceDto {
+  public string id { get; set; }
+  public string label { get; set; }
+  public bool isDefault { get; set; }
+}
+
+public static class HydraAudio {
+  private static PROPERTYKEY FriendlyNameKey = new PROPERTYKEY {
+    fmtid = new Guid("a45c254e-df1c-4efd-8020-67d146a850e0"),
+    pid = 14
+  };
+
+  public static List<AudioDeviceDto> ListRenderDevices() {
+    var enumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+    IMMDeviceCollection collection;
+    IMMDevice defaultDevice;
+    string defaultId;
+    uint count;
+    enumerator.EnumAudioEndpoints(EDataFlow.eRender, DeviceState.Active, out collection);
+    enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out defaultDevice);
+    defaultDevice.GetId(out defaultId);
+    collection.GetCount(out count);
+
+    var devices = new List<AudioDeviceDto>();
+    for (uint index = 0; index < count; index++) {
+      IMMDevice device;
+      string id;
+      IPropertyStore store;
+      PROPVARIANT value;
+      collection.Item(index, out device);
+      device.GetId(out id);
+      device.OpenPropertyStore(0, out store);
+      store.GetValue(ref FriendlyNameKey, out value);
+      var label = Marshal.PtrToStringUni(value.p);
+
+      devices.Add(new AudioDeviceDto {
+        id = id,
+        label = String.IsNullOrWhiteSpace(label) ? id : label,
+        isDefault = String.Equals(id, defaultId, StringComparison.OrdinalIgnoreCase)
+      });
+    }
+
+    return devices;
+  }
+
+  public static string GetDefaultRenderDeviceId() {
+    var enumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+    IMMDevice device;
+    string id;
+    enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out device);
+    device.GetId(out id);
+    return id;
+  }
+
+  public static void SetDefaultRenderDevice(string id) {
+    var policy = (IPolicyConfig)(new PolicyConfigClient());
+    policy.SetDefaultEndpoint(id, ERole.eConsole);
+    policy.SetDefaultEndpoint(id, ERole.eMultimedia);
+  }
+}
+"@
+`;
+
+const runAudioScript = async <T>(command: string): Promise<T | null> => {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  const encoded = Buffer.from(
+    `${coreAudioScript}\n${command}`,
+    "utf16le"
+  ).toString("base64");
+
+  return await new Promise<T | null>((resolve) => {
+    execFile(
+      "powershell.exe",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encoded],
+      { windowsHide: true, timeout: 10_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          logger.warn("CoreAudio PowerShell command failed", {
+            error,
+            stderr,
+          });
+          resolve(null);
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(stdout.trim()) as T);
+        } catch {
+          resolve((stdout.trim() as T) || null);
+        }
+      }
+    );
+  });
+};
+
+export class AudioDeviceManager {
+  public static async getAudioDevices(): Promise<HydraAudioDevice[]> {
+    return (
+      (await runAudioScript<HydraAudioDevice[]>(
+        "[HydraAudio]::ListRenderDevices() | ConvertTo-Json -Compress"
+      )) ?? []
+    );
+  }
+
+  public static async getDefaultAudioDeviceId(): Promise<string | null> {
+    return await runAudioScript<string>(
+      "[HydraAudio]::GetDefaultRenderDeviceId() | ConvertTo-Json -Compress"
+    );
+  }
+
+  public static async setDefaultAudioDevice(id: string | null | undefined) {
+    if (!id) return false;
+
+    const escaped = id.replaceAll("'", "''");
+    await runAudioScript<unknown>(
+      `[HydraAudio]::SetDefaultRenderDevice('${escaped}'); "true" | ConvertTo-Json -Compress`
+    );
+    return true;
+  }
+}

--- a/src/main/services/big-picture-session-manager.ts
+++ b/src/main/services/big-picture-session-manager.ts
@@ -1,0 +1,109 @@
+import { db, levelKeys } from "@main/level";
+import type { UserPreferences } from "@types";
+import { AudioDeviceManager } from "./audio-device-manager";
+import { DisplayManager } from "./display-manager";
+import { logger } from "./logger";
+import { NativeAddon } from "./native-addon";
+
+type BigPictureRestoreSnapshot = {
+  primaryDisplaySourceName: string | null;
+  defaultAudioDeviceId: string | null;
+};
+
+export class BigPictureSessionManager {
+  private static snapshot: BigPictureRestoreSnapshot | null = null;
+
+  private static async waitForPrimaryDisplaySourceName(
+    sourceName: string,
+    timeoutMs = 3_000
+  ) {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < timeoutMs) {
+      const currentSourceName = NativeAddon.getPrimaryDisplaySourceName();
+
+      if (currentSourceName?.toLowerCase() === sourceName.toLowerCase()) {
+        return true;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    return false;
+  }
+
+  private static async restorePrimaryDisplay(sourceName: string) {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const restored = NativeAddon.setPrimaryDisplayBySourceName(sourceName);
+      const settled = await this.waitForPrimaryDisplaySourceName(sourceName);
+
+      logger.info("Big Picture primary display restore attempt", {
+        sourceName,
+        attempt,
+        restored,
+        settled,
+        currentPrimary: NativeAddon.getPrimaryDisplaySourceName(),
+      });
+
+      if (restored && settled) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  public static async apply() {
+    if (this.snapshot) {
+      return;
+    }
+
+    const userPreferences = await db
+      .get<string, UserPreferences | null>(levelKeys.userPreferences, {
+        valueEncoding: "json",
+      })
+      .catch(() => null);
+
+    this.snapshot = {
+      primaryDisplaySourceName: NativeAddon.getPrimaryDisplaySourceName(),
+      defaultAudioDeviceId: await AudioDeviceManager.getDefaultAudioDeviceId(),
+    };
+
+    logger.info("Captured Big Picture restore snapshot", this.snapshot);
+
+    await DisplayManager.prepareBigPictureDisplayForLaunch();
+
+    if (userPreferences?.bigPictureAudioDeviceId) {
+      await AudioDeviceManager.setDefaultAudioDevice(
+        userPreferences.bigPictureAudioDeviceId
+      );
+    }
+  }
+
+  public static async restore() {
+    const snapshot = this.snapshot;
+    this.snapshot = null;
+
+    if (!snapshot) {
+      return;
+    }
+
+    if (snapshot.primaryDisplaySourceName) {
+      const restored = await this.restorePrimaryDisplay(
+        snapshot.primaryDisplaySourceName
+      );
+
+      if (!restored) {
+        logger.warn("Could not restore Big Picture primary display", {
+          sourceName: snapshot.primaryDisplaySourceName,
+        });
+      }
+    }
+
+    if (snapshot.defaultAudioDeviceId) {
+      await AudioDeviceManager.setDefaultAudioDevice(
+        snapshot.defaultAudioDeviceId
+      );
+    }
+  }
+}

--- a/src/main/services/display-manager-utils.test.ts
+++ b/src/main/services/display-manager-utils.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  DEFAULT_DISPLAY_ID,
+  resolveDisplayId,
+  toHydraDisplays,
+} from "./display-manager-utils.ts";
+
+const displays = [
+  {
+    id: 1,
+    label: "Main monitor",
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    internal: false,
+  },
+  {
+    id: 2,
+    label: "TV",
+    bounds: { x: 1920, y: 0, width: 3840, height: 2160 },
+    internal: false,
+  },
+];
+
+describe("display manager utilities", () => {
+  it("maps Electron displays to renderer-safe display payloads", () => {
+    assert.deepEqual(toHydraDisplays(displays, 1), [
+      {
+        id: "1",
+        label: "Main monitor",
+        bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+        isPrimary: true,
+        internal: false,
+      },
+      {
+        id: "2",
+        label: "TV",
+        bounds: { x: 1920, y: 0, width: 3840, height: 2160 },
+        isPrimary: false,
+        internal: false,
+      },
+    ]);
+  });
+
+  it("resolves the saved Big Picture display when it exists", () => {
+    assert.equal(resolveDisplayId("2", displays, 1), displays[1]);
+  });
+
+  it("falls back to the primary display for default or missing preferences", () => {
+    assert.equal(
+      resolveDisplayId(DEFAULT_DISPLAY_ID, displays, 1),
+      displays[0]
+    );
+    assert.equal(resolveDisplayId("missing", displays, 1), displays[0]);
+    assert.equal(resolveDisplayId(null, displays, 1), displays[0]);
+  });
+});

--- a/src/main/services/display-manager-utils.ts
+++ b/src/main/services/display-manager-utils.ts
@@ -1,0 +1,58 @@
+import type { HydraDisplay } from "@types";
+
+type ElectronDisplayLike = {
+  id: number;
+  label?: string;
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  internal: boolean;
+};
+
+export const DEFAULT_DISPLAY_ID = "default";
+
+export function toHydraDisplays(
+  displays: ElectronDisplayLike[],
+  primaryDisplayId: number
+): HydraDisplay[] {
+  return displays.map((display, index) => ({
+    id: String(display.id),
+    label: display.label?.trim() || `Display ${index + 1}`,
+    bounds: {
+      x: display.bounds.x,
+      y: display.bounds.y,
+      width: display.bounds.width,
+      height: display.bounds.height,
+    },
+    isPrimary: display.id === primaryDisplayId,
+    internal: display.internal,
+  }));
+}
+
+export function resolveDisplayId<TDisplay extends ElectronDisplayLike>(
+  displayId: string | null | undefined,
+  displays: TDisplay[],
+  primaryDisplayId: number
+): TDisplay {
+  if (displayId && displayId !== DEFAULT_DISPLAY_ID) {
+    const selectedDisplay = displays.find(
+      (display) => String(display.id) === displayId
+    );
+
+    if (selectedDisplay) {
+      return selectedDisplay;
+    }
+  }
+
+  const fallbackDisplay =
+    displays.find((display) => display.id === primaryDisplayId) ?? displays[0];
+
+  if (!fallbackDisplay) {
+    throw new Error("No active displays were found");
+  }
+
+  return fallbackDisplay;
+}

--- a/src/main/services/display-manager.ts
+++ b/src/main/services/display-manager.ts
@@ -1,0 +1,99 @@
+import { screen } from "electron";
+
+import { db, levelKeys } from "@main/level";
+import type { HydraDisplay, UserPreferences } from "@types";
+import { logger } from "./logger";
+import { NativeAddon } from "./native-addon";
+import { resolveDisplayId, toHydraDisplays } from "./display-manager-utils";
+
+export class DisplayManager {
+  private static async waitForPrimaryDisplay(
+    display: Electron.Display,
+    timeoutMs = 2_500
+  ) {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < timeoutMs) {
+      const primaryDisplay = screen.getPrimaryDisplay();
+      const primaryBounds = primaryDisplay.bounds;
+
+      if (
+        primaryDisplay.id === display.id ||
+        (primaryBounds.x === 0 &&
+          primaryBounds.y === 0 &&
+          Math.round(primaryBounds.width) === Math.round(display.bounds.width) &&
+          Math.round(primaryBounds.height) ===
+            Math.round(display.bounds.height))
+      ) {
+        return true;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    return false;
+  }
+
+  public static getDisplays(): HydraDisplay[] {
+    const primaryDisplay = screen.getPrimaryDisplay();
+    return toHydraDisplays(screen.getAllDisplays(), primaryDisplay.id);
+  }
+
+  private static async getBigPictureDisplayId() {
+    const userPreferences = await db
+      .get<string, UserPreferences | null>(levelKeys.userPreferences, {
+        valueEncoding: "json",
+      })
+      .catch(() => null);
+
+    return userPreferences?.bigPictureDisplayId;
+  }
+
+  public static async getBigPictureDisplay(): Promise<Electron.Display> {
+    const displays = screen.getAllDisplays();
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const selectedDisplayId = await this.getBigPictureDisplayId();
+
+    return resolveDisplayId(selectedDisplayId, displays, primaryDisplay.id);
+  }
+
+  public static async prepareBigPictureDisplayForLaunch() {
+    const display = await this.getBigPictureDisplay();
+
+    if (process.platform !== "win32") {
+      return display;
+    }
+
+    try {
+      const applied = NativeAddon.setPrimaryDisplayByBounds({
+        x: Math.round(display.bounds.x),
+        y: Math.round(display.bounds.y),
+        width: Math.round(display.size.width),
+        height: Math.round(display.size.height),
+      });
+
+      if (!applied) {
+        logger.warn("Could not apply Big Picture primary display", {
+          displayId: display.id,
+          bounds: display.bounds,
+        });
+      }
+
+      const primaryDisplaySettled = await this.waitForPrimaryDisplay(display);
+
+      if (!primaryDisplaySettled) {
+        logger.warn("Timed out waiting for Big Picture primary display", {
+          displayId: display.id,
+          bounds: display.bounds,
+          primaryDisplay: screen.getPrimaryDisplay().bounds,
+        });
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    } catch (error) {
+      logger.warn("Failed to apply Big Picture primary display", error);
+    }
+
+    return display;
+  }
+}

--- a/src/main/services/index.ts
+++ b/src/main/services/index.ts
@@ -26,4 +26,7 @@ export * from "./download-sources-checker";
 export * from "./notifications/local-notifications";
 export * from "./power-save-blocker";
 export * from "./native-addon";
+export * from "./display-manager";
+export * from "./audio-device-manager";
+export * from "./big-picture-session-manager";
 export * as emulators from "./emulators";

--- a/src/main/services/native-addon.ts
+++ b/src/main/services/native-addon.ts
@@ -8,6 +8,13 @@ import type { ProcessPayload } from "./download/types";
 
 import { logger } from "./logger";
 
+type NativeDisplayBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 type NativeProcessProfileImageResponse = {
   imagePath?: string;
   image_path?: string;
@@ -33,6 +40,12 @@ type HydraNativeModule = {
     preserveAnimation: boolean
   ) => Promise<NativeProcessFriendImageResponse>;
   listProcesses: () => ProcessPayload[];
+  setPrimaryDisplayByBounds?: (bounds: NativeDisplayBounds) => boolean;
+  getDisplaySourceNameByBounds?: (
+    bounds: NativeDisplayBounds
+  ) => string | null;
+  getPrimaryDisplaySourceName?: () => string | null;
+  setPrimaryDisplayBySourceName?: (sourceName: string) => boolean;
 };
 
 export type SystemProcessMap = {
@@ -302,5 +315,45 @@ export class NativeAddon {
         resolve({ processMap: {}, winePrefixMap: {}, linuxProcesses: [] });
       }
     });
+  }
+
+  public static setPrimaryDisplayByBounds(
+    bounds: NativeDisplayBounds
+  ): boolean {
+    try {
+      return this.load().setPrimaryDisplayByBounds?.(bounds) ?? false;
+    } catch (error) {
+      logger.error("Failed to set primary display via native addon", error);
+      return false;
+    }
+  }
+
+  public static getDisplaySourceNameByBounds(
+    bounds: NativeDisplayBounds
+  ): string | null {
+    try {
+      return this.load().getDisplaySourceNameByBounds?.(bounds) ?? null;
+    } catch (error) {
+      logger.error("Failed to get display source name via native addon", error);
+      return null;
+    }
+  }
+
+  public static getPrimaryDisplaySourceName(): string | null {
+    try {
+      return this.load().getPrimaryDisplaySourceName?.() ?? null;
+    } catch (error) {
+      logger.error("Failed to get primary display source name", error);
+      return null;
+    }
+  }
+
+  public static setPrimaryDisplayBySourceName(sourceName: string): boolean {
+    try {
+      return this.load().setPrimaryDisplayBySourceName?.(sourceName) ?? false;
+    } catch (error) {
+      logger.error("Failed to set primary display by source name", error);
+      return false;
+    }
   }
 }

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -25,6 +25,8 @@ import { t } from "i18next";
 import { orderBy, slice } from "lodash-es";
 import path from "node:path";
 import UserAgent from "user-agents";
+import { BigPictureSessionManager } from "./big-picture-session-manager";
+import { DisplayManager } from "./display-manager";
 import { HydraApi } from "./hydra-api";
 import { logger } from "./logger";
 
@@ -317,13 +319,9 @@ export class WindowManager {
       return;
     }
 
-    const targetDisplay = this.mainWindow?.isDestroyed()
-      ? null
-      : this.mainWindow
-        ? screen.getDisplayMatching(this.mainWindow.getBounds())
-        : screen.getPrimaryDisplay();
-    const targetBounds =
-      targetDisplay?.bounds ?? screen.getPrimaryDisplay().bounds;
+    await BigPictureSessionManager.apply();
+    const targetDisplay = await DisplayManager.getBigPictureDisplay();
+    const targetBounds = targetDisplay.bounds;
 
     this.bigPicture = new BrowserWindow({
       x: targetBounds.x,
@@ -360,8 +358,9 @@ export class WindowManager {
       this.bigPicture?.focus();
     });
 
-    this.bigPicture.on("closed", () => {
+    this.bigPicture.on("closed", async () => {
       this.bigPicture = null;
+      await BigPictureSessionManager.restore();
       const main = this.mainWindow;
       if (main && !main.isDestroyed()) {
         this.restoreMainWindowAfterBigPictureCloses();
@@ -761,18 +760,29 @@ export class WindowManager {
   private static readonly GAME_LAUNCHER_WINDOW_WIDTH = 550;
   private static readonly GAME_LAUNCHER_WINDOW_HEIGHT = 320;
 
-  public static async createGameLauncherWindow(shop: string, objectId: string) {
+  public static async createGameLauncherWindow(
+    shop: string,
+    objectId: string,
+    targetDisplay?: Electron.Display
+  ) {
     if (this.gameLauncherWindow) {
       this.gameLauncherWindow.close();
       this.gameLauncherWindow = null;
     }
 
-    const display = screen.getPrimaryDisplay();
-    const { width: displayWidth, height: displayHeight } = display.bounds;
+    const display = targetDisplay ?? screen.getPrimaryDisplay();
+    const {
+      x: displayX,
+      y: displayY,
+      width: displayWidth,
+      height: displayHeight,
+    } = display.bounds;
 
-    const x = Math.round((displayWidth - this.GAME_LAUNCHER_WINDOW_WIDTH) / 2);
+    const x = Math.round(
+      displayX + (displayWidth - this.GAME_LAUNCHER_WINDOW_WIDTH) / 2
+    );
     const y = Math.round(
-      (displayHeight - this.GAME_LAUNCHER_WINDOW_HEIGHT) / 2
+      displayY + (displayHeight - this.GAME_LAUNCHER_WINDOW_HEIGHT) / 2
     );
 
     this.gameLauncherWindow = new BrowserWindow({

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -32,6 +32,9 @@ import type {
   EmulationSavePlatform,
   MemcardRestoreResult,
   MemcardRestoreTarget,
+  HydraAudioDevice,
+  HydraDisplay,
+  LaunchSource,
 } from "@types";
 import type { AuthPage } from "@shared";
 import type { AxiosProgressEvent } from "axios";
@@ -593,21 +596,32 @@ contextBridge.exposeInMainWorld("electron", {
     shop: GameShop,
     objectId: string,
     executablePath: string,
-    launchOptions?: string | null
+    launchOptions?: string | null,
+    launchSource?: LaunchSource
   ) =>
     ipcRenderer.invoke(
       "openGame",
       shop,
       objectId,
       executablePath,
-      launchOptions
+      launchOptions,
+      launchSource
     ),
   openClassicsGame: (
     shop: GameShop,
     objectId: string,
     discPath?: string,
-    force?: boolean
-  ) => ipcRenderer.invoke("openClassicsGame", shop, objectId, discPath, force),
+    force?: boolean,
+    launchSource?: LaunchSource
+  ) =>
+    ipcRenderer.invoke(
+      "openClassicsGame",
+      shop,
+      objectId,
+      discPath,
+      force,
+      launchSource
+    ),
   updateClassicsDisc: (
     shop: GameShop,
     objectId: string,
@@ -733,6 +747,10 @@ contextBridge.exposeInMainWorld("electron", {
     ipcRenderer.invoke("getDiskFreeSpace", path),
   checkFolderWritePermission: (path: string) =>
     ipcRenderer.invoke("checkFolderWritePermission", path),
+  getDisplays: () =>
+    ipcRenderer.invoke("getDisplays") as Promise<HydraDisplay[]>,
+  getAudioDevices: () =>
+    ipcRenderer.invoke("getAudioDevices") as Promise<HydraAudioDevice[]>,
 
   /* Cloud save */
   uploadSaveGame: (

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -50,6 +50,9 @@ import type {
   EmulationSavePlatform,
   MemcardRestoreResult,
   MemcardRestoreTarget,
+  HydraAudioDevice,
+  HydraDisplay,
+  LaunchSource,
 } from "@types";
 import type { AxiosProgressEvent } from "axios";
 
@@ -271,13 +274,15 @@ declare global {
       shop: GameShop,
       objectId: string,
       executablePath: string,
-      launchOptions?: string | null
+      launchOptions?: string | null,
+      launchSource?: LaunchSource
     ) => Promise<void>;
     openClassicsGame: (
       shop: GameShop,
       objectId: string,
       discPath?: string,
-      force?: boolean
+      force?: boolean,
+      launchSource?: LaunchSource
     ) => Promise<void>;
     updateClassicsDisc: (
       shop: GameShop,
@@ -574,6 +579,8 @@ declare global {
     /* Hardware */
     getDiskFreeSpace: (path: string) => Promise<DiskUsage>;
     checkFolderWritePermission: (path: string) => Promise<boolean>;
+    getDisplays: () => Promise<HydraDisplay[]>;
+    getAudioDevices: () => Promise<HydraAudioDevice[]>;
 
     /* Cloud save */
     uploadSaveGame: (

--- a/src/renderer/src/pages/settings/settings-context-general.tsx
+++ b/src/renderer/src/pages/settings/settings-context-general.tsx
@@ -10,6 +10,7 @@ import {
   TextField,
 } from "@renderer/components";
 import type { DownloadDirectoryPreference } from "@types";
+import type { HydraAudioDevice, HydraDisplay } from "@types";
 import { settingsContext } from "@renderer/context";
 import { useAppSelector } from "@renderer/hooks";
 import languageResources from "@locales";
@@ -39,6 +40,9 @@ interface DownloadDirectoryReplacementState {
   selectedReplacementPath: string;
 }
 
+const DEFAULT_BIG_PICTURE_DISPLAY_ID = "default";
+const DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID = "default";
+
 export function SettingsContextGeneral({
   appearance,
 }: Readonly<SettingsContextGeneralProps>) {
@@ -50,6 +54,8 @@ export function SettingsContextGeneral({
   );
 
   const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>([]);
+  const [displays, setDisplays] = useState<HydraDisplay[]>([]);
+  const [audioDevices, setAudioDevices] = useState<HydraAudioDevice[]>([]);
   const [defaultDownloadsPath, setDefaultDownloadsPath] = useState("");
   const [showRunAtStartup, setShowRunAtStartup] = useState(false);
   const [downloadDirectoryReplacement, setDownloadDirectoryReplacement] =
@@ -64,6 +70,8 @@ export function SettingsContextGeneral({
     hideToTrayOnGameStart: false,
     launchToLibraryPage: false,
     launchInBigPicture: false,
+    bigPictureDisplayId: DEFAULT_BIG_PICTURE_DISPLAY_ID,
+    bigPictureAudioDeviceId: DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID,
     enableAutoInstall: false,
   });
 
@@ -75,6 +83,16 @@ export function SettingsContextGeneral({
     window.electron.isPortableVersion().then((isPortableVersion) => {
       setShowRunAtStartup(!isPortableVersion);
     });
+
+    window.electron
+      .getDisplays()
+      .then(setDisplays)
+      .catch(() => setDisplays([]));
+
+    window.electron
+      .getAudioDevices()
+      .then(setAudioDevices)
+      .catch(() => setAudioDevices([]));
 
     setLanguageOptions(
       orderBy(
@@ -110,6 +128,11 @@ export function SettingsContextGeneral({
       hideToTrayOnGameStart: userPreferences.hideToTrayOnGameStart ?? false,
       launchToLibraryPage: userPreferences.launchToLibraryPage ?? false,
       launchInBigPicture: userPreferences.launchInBigPicture ?? false,
+      bigPictureDisplayId:
+        userPreferences.bigPictureDisplayId ?? DEFAULT_BIG_PICTURE_DISPLAY_ID,
+      bigPictureAudioDeviceId:
+        userPreferences.bigPictureAudioDeviceId ??
+        DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID,
       enableAutoInstall: userPreferences.enableAutoInstall ?? false,
     });
   }, [userPreferences, defaultDownloadsPath]);
@@ -125,6 +148,80 @@ export function SettingsContextGeneral({
     const value = event.target.value;
     handleChange({ language: value });
     changeLanguage(value);
+  };
+
+  const displayOptions = [
+    {
+      key: DEFAULT_BIG_PICTURE_DISPLAY_ID,
+      value: DEFAULT_BIG_PICTURE_DISPLAY_ID,
+      label: t("system_default_monitor"),
+    },
+    ...displays.map((display) => ({
+      key: display.id,
+      value: display.id,
+      label: display.isPrimary
+        ? `${display.label} (${t("primary_monitor")})`
+        : display.label,
+    })),
+    ...(form.bigPictureDisplayId !== DEFAULT_BIG_PICTURE_DISPLAY_ID &&
+    displays.every((display) => display.id !== form.bigPictureDisplayId)
+      ? [
+          {
+            key: form.bigPictureDisplayId,
+            value: form.bigPictureDisplayId,
+            label: `${t("missing_monitor")} (${form.bigPictureDisplayId})`,
+          },
+        ]
+      : []),
+  ];
+
+  const handleBigPictureDisplayChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const value = event.target.value;
+
+    setForm((prev) => ({ ...prev, bigPictureDisplayId: value }));
+    updateUserPreferences({
+      bigPictureDisplayId:
+        value === DEFAULT_BIG_PICTURE_DISPLAY_ID ? null : value,
+    });
+  };
+
+  const audioDeviceOptions = [
+    {
+      key: DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID,
+      value: DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID,
+      label: t("system_default_audio_device"),
+    },
+    ...audioDevices.map((device) => ({
+      key: device.id,
+      value: device.id,
+      label: device.isDefault
+        ? `${device.label} (${t("default_audio_device")})`
+        : device.label,
+    })),
+    ...(form.bigPictureAudioDeviceId !== DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID &&
+    audioDevices.every((device) => device.id !== form.bigPictureAudioDeviceId)
+      ? [
+          {
+            key: form.bigPictureAudioDeviceId,
+            value: form.bigPictureAudioDeviceId,
+            label: `${t("missing_audio_device")} (${form.bigPictureAudioDeviceId})`,
+          },
+        ]
+      : []),
+  ];
+
+  const handleBigPictureAudioDeviceChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const value = event.target.value;
+
+    setForm((prev) => ({ ...prev, bigPictureAudioDeviceId: value }));
+    updateUserPreferences({
+      bigPictureAudioDeviceId:
+        value === DEFAULT_BIG_PICTURE_AUDIO_DEVICE_ID ? null : value,
+    });
   };
 
   const handleChooseDownloadsPath = async () => {
@@ -288,6 +385,20 @@ export function SettingsContextGeneral({
               launchInBigPicture: !form.launchInBigPicture,
             })
           }
+        />
+
+        <SelectField
+          label={t("big_picture_launching_monitor")}
+          value={form.bigPictureDisplayId}
+          onChange={handleBigPictureDisplayChange}
+          options={displayOptions}
+        />
+
+        <SelectField
+          label={t("big_picture_output_device")}
+          value={form.bigPictureAudioDeviceId}
+          onChange={handleBigPictureAudioDeviceChange}
+          options={audioDeviceOptions}
         />
       </div>
 

--- a/src/types/display.types.ts
+++ b/src/types/display.types.ts
@@ -1,0 +1,22 @@
+export interface HydraDisplayBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface HydraDisplay {
+  id: string;
+  label: string;
+  bounds: HydraDisplayBounds;
+  isPrimary: boolean;
+  internal: boolean;
+}
+
+export interface HydraAudioDevice {
+  id: string;
+  label: string;
+  isDefault: boolean;
+}
+
+export type LaunchSource = "default" | "big-picture";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -552,6 +552,7 @@ export type UserGameDetails = ShopAssets & {
 export * from "./game.types";
 export * from "./steam.types";
 export * from "./download.types";
+export * from "./display.types";
 export * from "./ludusavi.types";
 export * from "./how-long-to-beat.types";
 export * from "./level.types";

--- a/src/types/level.types.ts
+++ b/src/types/level.types.ts
@@ -144,6 +144,8 @@ export interface UserPreferences {
   startMinimized?: boolean;
   launchToLibraryPage?: boolean;
   launchInBigPicture?: boolean;
+  bigPictureDisplayId?: string | null;
+  bigPictureAudioDeviceId?: string | null;
   disableNsfwAlert?: boolean;
   enableAutoInstall?: boolean;
   seedAfterDownloadComplete?: boolean;


### PR DESCRIPTION
﻿## Summary

Adds Steam-like Big Picture monitor and audio output selection to Hydra.

Users can choose a **Big Picture launching monitor** and a **Big Picture output device** from Settings -> Behavior. When Big Picture opens, Hydra applies those session settings; when Big Picture closes, Hydra restores the previous Windows primary monitor and default audio output.

## What changed

- Added `bigPictureDisplayId` and `bigPictureAudioDeviceId` user preferences.
- Added display enumeration IPC and monitor dropdowns in normal Settings and Big Picture Settings.
- Added audio render device enumeration IPC and output device dropdowns in normal Settings and Big Picture Settings.
- Added a Big Picture session manager that captures the previous primary display/audio output, applies Big Picture settings, and restores them on close.
- Added Windows native DisplayConfig support for setting/restoring primary displays by bounds/source name.
- Added Windows CoreAudio support for enumerating active output devices and setting Console/Multimedia defaults.
- Tagged Big Picture game launches with `launchSource: "big-picture"` so display preparation only applies to Big Picture launches.

## Why

This makes Hydra's Big Picture behavior closer to Steam Big Picture for multi-monitor setups. Users can launch the couch/TV mode on a selected monitor, have games launched from Big Picture prefer that monitor, and route Big Picture audio to the selected output device without changing normal Hydra launches.

## Platform behavior

- Windows: moves Big Picture to the selected monitor, makes it primary for the Big Picture session, switches selected audio output, and restores previous monitor/audio settings when Big Picture closes.
- Linux/macOS: moves Big Picture to the selected Electron display; system primary-monitor and default-audio switching are skipped safely.

## Validation

- `corepack yarn build:native`
- `corepack yarn build`
- `corepack yarn typecheck`
- `corepack yarn test`
- `git diff --check`
- Manual Windows smoke test: audio device enumeration returns active render devices and the current default endpoint.

## Checklist

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
