### PR TITLE
fix: move big picture button to right side of title bar

### DIFF
--- a/src/renderer/src/app.scss
+++ b/src/renderer/src/app.scss
@@ -142,6 +142,15 @@ progress[value] {
   z-index: 4;
   border-bottom: 1px solid globals.$border-color;
 
+  &--windows {
+    padding-right: calc(
+      100vw - env(titlebar-area-width, calc(100vw - 140px)) - env(
+          titlebar-area-x,
+          0px
+        )
+    );
+  }
+
   &__cloud-text {
     background: linear-gradient(270deg, #16b195 50%, #3e62c0 100%);
     background-clip: text;

--- a/src/renderer/src/app.scss
+++ b/src/renderer/src/app.scss
@@ -157,6 +157,7 @@ progress[value] {
     cursor: pointer;
     padding: 4px 8px;
     border-radius: 4px;
+    margin-left: auto;
     margin-right: globals.$spacing-unit;
     font-size: 12px;
     -webkit-app-region: no-drag;
@@ -173,7 +174,6 @@ progress[value] {
   &__window-controls {
     display: flex;
     align-self: stretch;
-    margin-left: auto;
     margin-right: calc(globals.$spacing-unit * -2);
     -webkit-app-region: no-drag;
   }

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -519,6 +519,13 @@ export function App() {
       {(window.electron.platform === "win32" ||
         window.electron.platform === "linux") && (
         <div className="title-bar">
+          <h4>
+            Hydra
+            {hasActiveSubscription && (
+              <span className="title-bar__cloud-text"> Cloud</span>
+            )}
+          </h4>
+
           <button
             type="button"
             className="title-bar__big-picture"
@@ -527,12 +534,6 @@ export function App() {
             <VideoIcon size={14} />
             {t("big_picture", { ns: "sidebar" })}
           </button>
-          <h4>
-            Hydra
-            {hasActiveSubscription && (
-              <span className="title-bar__cloud-text"> Cloud</span>
-            )}
-          </h4>
 
           {window.electron.platform === "linux" && (
             <div className="title-bar__window-controls">

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -518,7 +518,11 @@ export function App() {
     <>
       {(window.electron.platform === "win32" ||
         window.electron.platform === "linux") && (
-        <div className="title-bar">
+        <div
+          className={`title-bar${
+            window.electron.platform === "win32" ? " title-bar--windows" : ""
+          }`}
+        >
           <h4>
             Hydra
             {hasActiveSubscription && (


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Moves the Big Picture button in the title bar from the far left (before the "Hydra Cloud" text) over to the right side, where it now sits just before the minimize/maximize/close window controls.

Layout left to right is now: `Hydra Cloud` ... `Big Picture` `[min] [max] [close]`.

Done by giving `.title-bar__big-picture` a `margin-left: auto` and dropping it from `.title-bar__window-controls`, plus reordering the elements in the JSX. On Windows (no custom window controls) the button sits flush at the right edge.