### PR TITLE
fix: restore collection creation in library and reposition scan cancel button

### DIFF
--- a/src/renderer/src/pages/library/library.scss
+++ b/src/renderer/src/pages/library/library.scss
@@ -198,6 +198,46 @@
     }
   }
 
+  &__collections-section {
+    display: flex;
+    flex-direction: column;
+    gap: calc(globals.$spacing-unit);
+    width: 100%;
+  }
+
+  &__collections-header {
+    display: flex;
+    align-items: center;
+    gap: calc(globals.$spacing-unit);
+  }
+
+  &__collections-title {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  &__add-collection-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.95);
+    }
+  }
+
   &__collections {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));

--- a/src/renderer/src/pages/library/library.tsx
+++ b/src/renderer/src/pages/library/library.tsx
@@ -13,6 +13,7 @@ import {
   useAppSelector,
   useGameCollections,
   useToast,
+  useUserDetails,
 } from "@renderer/hooks";
 import { setHeaderTitle } from "@renderer/features";
 import {
@@ -20,15 +21,19 @@ import {
   TelescopeIcon,
   FileDirectoryIcon,
   PencilIcon,
+  PlusIcon,
   TrashIcon,
   SyncIcon,
 } from "@primer/octicons-react";
 import { useTranslation } from "react-i18next";
+import { Tooltip } from "react-tooltip";
+import { AuthPage } from "@shared";
 import { GameCollection, LibraryGame } from "@types";
 import {
   Button,
   ConfirmationModal,
   ContextMenu,
+  CreateCollectionModal,
   GameContextMenu,
   Modal,
   TextField,
@@ -84,6 +89,7 @@ const getGameCollectionIds = (game: LibraryGame): string[] => {
 export default function Library() {
   const { library, updateLibrary } = useLibrary();
   const { showSuccessToast, showErrorToast } = useToast();
+  const { userDetails } = useUserDetails();
   const {
     collections,
     loadCollections,
@@ -122,6 +128,8 @@ export default function Library() {
   const [showDeleteCollectionModal, setShowDeleteCollectionModal] =
     useState(false);
   const [isDeletingCollection, setIsDeletingCollection] = useState(false);
+  const [showCreateCollectionModal, setShowCreateCollectionModal] =
+    useState(false);
 
   const [category, setCategory] = useState<LibraryCategory>(() => {
     const saved = localStorage.getItem("library-category");
@@ -273,6 +281,15 @@ export default function Library() {
   const handleCloseCollectionContextMenu = useCallback(() => {
     setCollectionContextMenu((prev) => ({ ...prev, visible: false }));
   }, []);
+
+  const handleCreateCollectionButtonClick = useCallback(() => {
+    if (!userDetails) {
+      window.electron.openAuthWindow(AuthPage.SignIn);
+      return;
+    }
+
+    setShowCreateCollectionModal(true);
+  }, [userDetails]);
 
   const resolveCollectionErrorMessage = useCallback(
     (
@@ -677,46 +694,67 @@ export default function Library() {
             </div>
           </div>
 
-          <div
-            className="library__collections"
-            role="group"
-            aria-label={t("collections")}
-          >
-            {libraryCollections.map((collection) => {
-              const isFavoritesCollection =
-                collection.id === FAVORITES_COLLECTION_ID;
+          <div className="library__collections-section">
+            <div className="library__collections-header">
+              <small className="library__collections-title">
+                {t("collections")}
+              </small>
+              <button
+                type="button"
+                className="library__add-collection-button"
+                onClick={handleCreateCollectionButtonClick}
+                aria-label={t("create_collection", { ns: "sidebar" })}
+                data-tooltip-id="library-create-collection-tooltip"
+                data-tooltip-content={t("create_collection_tooltip", {
+                  ns: "sidebar",
+                })}
+                data-tooltip-place="top"
+              >
+                <PlusIcon size={16} />
+              </button>
+            </div>
 
-              return (
-                <button
-                  key={collection.id}
-                  type="button"
-                  className={`library__collection-item ${selectedCollectionId === collection.id ? "library__collection-item--active" : ""}`}
-                  onClick={() =>
-                    handleCollectionSelect(
-                      selectedCollectionId === collection.id
-                        ? null
-                        : collection.id
-                    )
-                  }
-                  onContextMenu={
-                    isFavoritesCollection
-                      ? undefined
-                      : (event) =>
-                          handleOpenCollectionContextMenu(event, collection)
-                  }
-                >
-                  {isFavoritesCollection ? (
-                    <HeartIcon size={16} />
-                  ) : (
-                    <FileDirectoryIcon size={16} />
-                  )}
-                  <span>{collection.name}</span>
-                  <span className="library__collection-count">
-                    {collection.gamesCount}
-                  </span>
-                </button>
-              );
-            })}
+            <div
+              className="library__collections"
+              role="group"
+              aria-label={t("collections")}
+            >
+              {libraryCollections.map((collection) => {
+                const isFavoritesCollection =
+                  collection.id === FAVORITES_COLLECTION_ID;
+
+                return (
+                  <button
+                    key={collection.id}
+                    type="button"
+                    className={`library__collection-item ${selectedCollectionId === collection.id ? "library__collection-item--active" : ""}`}
+                    onClick={() =>
+                      handleCollectionSelect(
+                        selectedCollectionId === collection.id
+                          ? null
+                          : collection.id
+                      )
+                    }
+                    onContextMenu={
+                      isFavoritesCollection
+                        ? undefined
+                        : (event) =>
+                            handleOpenCollectionContextMenu(event, collection)
+                    }
+                  >
+                    {isFavoritesCollection ? (
+                      <HeartIcon size={16} />
+                    ) : (
+                      <FileDirectoryIcon size={16} />
+                    )}
+                    <span>{collection.name}</span>
+                    <span className="library__collection-count">
+                      {collection.gamesCount}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
       )}
@@ -890,10 +928,17 @@ export default function Library() {
         buttonsIsDisabled={isDeletingCollection}
       />
 
+      <CreateCollectionModal
+        visible={showCreateCollectionModal}
+        onClose={() => setShowCreateCollectionModal(false)}
+      />
+
       <ClassicsOnboardingModal
         visible={showClassicsOnboarding}
         onClose={() => setShowClassicsOnboarding(false)}
       />
+
+      <Tooltip id="library-create-collection-tooltip" />
     </section>
   );
 }

--- a/src/renderer/src/pages/settings/emulation/setup/setup-footer.tsx
+++ b/src/renderer/src/pages/settings/emulation/setup/setup-footer.tsx
@@ -57,6 +57,14 @@ export function SetupFooter({
           >
             {t("setup_cancel")}
           </button>
+        ) : endAction ? (
+          <button
+            type="button"
+            className="setup-modal__ghost-button"
+            onClick={endAction.onClick}
+          >
+            {endAction.label}
+          </button>
         ) : null}
       </div>
 
@@ -72,15 +80,6 @@ export function SetupFooter({
       </div>
 
       <div className="setup-modal__footer-side setup-modal__footer-side--end">
-        {endAction && (
-          <button
-            type="button"
-            className="setup-modal__ghost-button"
-            onClick={endAction.onClick}
-          >
-            {endAction.label}
-          </button>
-        )}
         {showSkip && (
           <button
             type="button"


### PR DESCRIPTION
## What

Two small fixes bundled together.

### Restore collection creation on the library page
The sidebar performance rewrite (#2366) removed the only entry point that opened the create collection modal outside the game context menu, so there was no longer any way to create a collection from the library. The modal and the underlying `createCollection` flow were both untouched, just orphaned.

This adds a `+` button with a tooltip to the collections header on the library page that opens the existing `CreateCollectionModal`. Same auth gate as before: signed-out users get the sign-in window, signed-in users get the modal. On success the new collection is dispatched to the store and shows up in the chips immediately.

### Reposition the scan cancel button
In the emulator setup flow, while a ROM folder is being scanned, the cancel scan button sat on the right side of the footer right before Continue. Moved it to the left side so it no longer crowds the primary action.

## Testing
- `yarn typecheck:web` passes
- `yarn format` clean