### PR TITLE
fix: emulator library, classics launch, memcard backups and cloud save connector

### DIFF
--- a/src/big-picture/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/big-picture/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -13,13 +13,7 @@ import type {
   EmulatorConfig,
   MemcardRestoreTarget,
 } from "@types";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -45,6 +39,8 @@ import {
 } from "../settings-navigation";
 import { SETTINGS_TOAST_OPTIONS, basename } from "./shared";
 
+import { useCloudConnector } from "@renderer/hooks/use-cloud-connector";
+
 import ConsoleBackside from "@renderer/assets/emulation/console-backside.svg?react";
 import hydraSaveCard from "@renderer/assets/emulation/icons/hydra-save-card.png";
 
@@ -66,16 +62,6 @@ interface RenameModalProps {
   onClose: () => void;
   onRenamed: () => void;
 }
-
-interface Connector {
-  width: number;
-  height: number;
-  path: string;
-}
-
-const SLOT_X_RATIO = 59.5 / 411;
-const SLOT_Y_RATIO = 129 / 221;
-const BRANCH_GAP = 40;
 
 const RESTORE_MODAL_REGION_ID = "emulation-cloud-restore-modal-region";
 const RESTORE_MODAL_ACTIONS_REGION_ID = "emulation-cloud-restore-modal-actions";
@@ -385,14 +371,7 @@ export function CloudSavesSection({
     position: { x: number; y: number };
   } | null>(null);
 
-  const stageRef = useRef<HTMLDivElement>(null);
-  const consoleRef = useRef<HTMLDivElement>(null);
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [connector, setConnector] = useState<Connector>({
-    width: 0,
-    height: 0,
-    path: "",
-  });
+  const { stageRef, consoleRef, gridRef, connector } = useCloudConnector(saves);
 
   const loadSaves = useCallback(async () => {
     if (!hasActiveSubscription) {
@@ -421,100 +400,6 @@ export function CloudSavesSection({
     showSuccessToast("Cloud save removed", SETTINGS_TOAST_OPTIONS);
     await loadSaves();
   }, [deleteTarget, loadSaves, showSuccessToast]);
-
-  const drawConnector = useCallback(() => {
-    const stage = stageRef.current;
-    const consoleElement = consoleRef.current;
-    const grid = gridRef.current;
-
-    if (!stage || !consoleElement || !grid) return;
-
-    const stageRect = stage.getBoundingClientRect();
-    const consoleRect = consoleElement.getBoundingClientRect();
-    const cards = Array.from(
-      grid.querySelectorAll<HTMLElement>(".emulator-detail__cloud-card")
-    );
-
-    if (cards.length === 0) {
-      setConnector({
-        width: stageRect.width,
-        height: stageRect.height,
-        path: "",
-      });
-      return;
-    }
-
-    const slotX =
-      consoleRect.left - stageRect.left + SLOT_X_RATIO * consoleRect.width;
-    const slotY =
-      consoleRect.top - stageRect.top + SLOT_Y_RATIO * consoleRect.height;
-
-    const cardGeoms = cards.map((card) => {
-      const rect = card.getBoundingClientRect();
-      return {
-        x: rect.left - stageRect.left + rect.width / 2,
-        top: rect.top - stageRect.top,
-        bottom: rect.bottom - stageRect.top,
-      };
-    });
-
-    type CardGeom = (typeof cardGeoms)[number];
-
-    const rowsByTop = new Map<number, CardGeom[]>();
-    for (const geom of cardGeoms) {
-      const key = Math.round(geom.top);
-      const row = rowsByTop.get(key);
-      if (row) row.push(geom);
-      else rowsByTop.set(key, [geom]);
-    }
-    const firstRow = Array.from(rowsByTop.entries()).sort(
-      (a, b) => a[0] - b[0]
-    )[0][1];
-
-    const segments: string[] = [];
-
-    const rowTop = Math.min(...firstRow.map((c) => c.top));
-    const busY = rowTop - BRANCH_GAP;
-    const xs = firstRow.map((c) => c.x).sort((a, b) => a - b);
-    const left = Math.min(slotX, xs[0]);
-    const right = Math.max(slotX, xs[xs.length - 1]);
-    segments.push(`M ${slotX} ${slotY} L ${slotX} ${busY}`);
-    segments.push(`M ${left} ${busY} L ${right} ${busY}`);
-    for (const geom of firstRow) {
-      segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
-    }
-
-    const columns = new Map<number, CardGeom[]>();
-    for (const geom of cardGeoms) {
-      const key = Math.round(geom.x);
-      const column = columns.get(key);
-      if (column) column.push(geom);
-      else columns.set(key, [geom]);
-    }
-    for (const column of columns.values()) {
-      column.sort((a, b) => a.top - b.top);
-      for (let i = 1; i < column.length; i += 1) {
-        const upper = column[i - 1];
-        const lower = column[i];
-        segments.push(`M ${lower.x} ${upper.bottom} L ${lower.x} ${lower.top}`);
-      }
-    }
-
-    setConnector({
-      width: stageRect.width,
-      height: stageRect.height,
-      path: segments.join(" "),
-    });
-  }, []);
-
-  useLayoutEffect(() => {
-    drawConnector();
-
-    const observer = new ResizeObserver(drawConnector);
-    if (stageRef.current) observer.observe(stageRef.current);
-
-    return () => observer.disconnect();
-  }, [drawConnector, saves]);
 
   if (!hasActiveSubscription || saves.length === 0) {
     return null;

--- a/src/big-picture/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/big-picture/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -76,7 +76,7 @@ interface Connector {
 const SLOT_X_RATIO = 59.5 / 411;
 const SLOT_Y_RATIO = 129 / 221;
 const BRANCH_GAP = 40;
-const CORNER_RADIUS = 8;
+const MIN_BRANCH_GAP = 8;
 
 const RESTORE_MODAL_REGION_ID = "emulation-cloud-restore-modal-region";
 const RESTORE_MODAL_ACTIONS_REGION_ID = "emulation-cloud-restore-modal-actions";
@@ -450,47 +450,56 @@ export function CloudSavesSection({
     const slotY =
       consoleRect.top - stageRect.top + SLOT_Y_RATIO * consoleRect.height;
 
-    const centers = cards.map((card) => {
+    const cardGeoms = cards.map((card) => {
       const rect = card.getBoundingClientRect();
       return {
         x: rect.left - stageRect.left + rect.width / 2,
         top: rect.top - stageRect.top,
+        bottom: rect.bottom - stageRect.top,
       };
     });
-    const cardTop = Math.min(...centers.map((center) => center.top));
-    const busY = cardTop - BRANCH_GAP;
-    const xs = centers.map((center) => center.x);
-    const first = xs[0];
-    const last = xs[xs.length - 1];
-    const segments = [`M ${slotX} ${slotY} L ${slotX} ${busY}`];
 
-    if (first === last) {
-      segments.push(`M ${first} ${busY} L ${first} ${cardTop}`);
-      segments.push(
-        `M ${Math.min(slotX, first)} ${busY} L ${Math.max(slotX, first)} ${busY}`
-      );
-    } else {
-      const radius = Math.min(CORNER_RADIUS, (last - first) / 2);
-      segments.push(
-        `M ${first} ${cardTop} L ${first} ${busY + radius} Q ${first} ${busY} ${
-          first + radius
-        } ${busY} L ${last - radius} ${busY} Q ${last} ${busY} ${last} ${
-          busY + radius
-        } L ${last} ${cardTop}`
-      );
-
-      for (let index = 1; index < xs.length - 1; index += 1) {
-        segments.push(`M ${xs[index]} ${busY} L ${xs[index]} ${cardTop}`);
-      }
-
-      if (slotX < first) {
-        segments.push(`M ${slotX} ${busY} L ${first} ${busY}`);
-      }
-
-      if (slotX > last) {
-        segments.push(`M ${last} ${busY} L ${slotX} ${busY}`);
-      }
+    type CardGeom = (typeof cardGeoms)[number];
+    const rowsByTop = new Map<number, CardGeom[]>();
+    for (const geom of cardGeoms) {
+      const key = Math.round(geom.top);
+      const row = rowsByTop.get(key);
+      if (row) row.push(geom);
+      else rowsByTop.set(key, [geom]);
     }
+    const rows = Array.from(rowsByTop.values()).sort(
+      (a, b) => a[0].top - b[0].top
+    );
+
+    const segments: string[] = [];
+    const busYs: number[] = [];
+    let prevRowBottom: number | null = null;
+
+    rows.forEach((row, index) => {
+      const rowTop = Math.min(...row.map((c) => c.top));
+      const gapAbove =
+        prevRowBottom === null ? BRANCH_GAP : rowTop - prevRowBottom;
+      const branch =
+        index === 0
+          ? BRANCH_GAP
+          : Math.max(MIN_BRANCH_GAP, Math.min(BRANCH_GAP, gapAbove / 2));
+      const busY = rowTop - branch;
+      busYs.push(busY);
+
+      const xs = row.map((c) => c.x).sort((a, b) => a - b);
+      const left = Math.min(slotX, xs[0]);
+      const right = Math.max(slotX, xs[xs.length - 1]);
+      segments.push(`M ${left} ${busY} L ${right} ${busY}`);
+      for (const geom of row) {
+        segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+      }
+
+      prevRowBottom = Math.max(...row.map((c) => c.bottom));
+    });
+
+    segments.unshift(
+      `M ${slotX} ${slotY} L ${slotX} ${busYs[busYs.length - 1]}`
+    );
 
     setConnector({
       width: stageRect.width,

--- a/src/big-picture/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/big-picture/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -76,7 +76,6 @@ interface Connector {
 const SLOT_X_RATIO = 59.5 / 411;
 const SLOT_Y_RATIO = 129 / 221;
 const BRANCH_GAP = 40;
-const MIN_BRANCH_GAP = 8;
 
 const RESTORE_MODAL_REGION_ID = "emulation-cloud-restore-modal-region";
 const RESTORE_MODAL_ACTIONS_REGION_ID = "emulation-cloud-restore-modal-actions";
@@ -460,6 +459,7 @@ export function CloudSavesSection({
     });
 
     type CardGeom = (typeof cardGeoms)[number];
+
     const rowsByTop = new Map<number, CardGeom[]>();
     for (const geom of cardGeoms) {
       const key = Math.round(geom.top);
@@ -467,39 +467,38 @@ export function CloudSavesSection({
       if (row) row.push(geom);
       else rowsByTop.set(key, [geom]);
     }
-    const rows = Array.from(rowsByTop.values()).sort(
-      (a, b) => a[0].top - b[0].top
-    );
+    const firstRow = Array.from(rowsByTop.entries()).sort(
+      (a, b) => a[0] - b[0]
+    )[0][1];
 
     const segments: string[] = [];
-    const busYs: number[] = [];
-    let prevRowBottom: number | null = null;
 
-    rows.forEach((row, index) => {
-      const rowTop = Math.min(...row.map((c) => c.top));
-      const gapAbove =
-        prevRowBottom === null ? BRANCH_GAP : rowTop - prevRowBottom;
-      const branch =
-        index === 0
-          ? BRANCH_GAP
-          : Math.max(MIN_BRANCH_GAP, Math.min(BRANCH_GAP, gapAbove / 2));
-      const busY = rowTop - branch;
-      busYs.push(busY);
+    const rowTop = Math.min(...firstRow.map((c) => c.top));
+    const busY = rowTop - BRANCH_GAP;
+    const xs = firstRow.map((c) => c.x).sort((a, b) => a - b);
+    const left = Math.min(slotX, xs[0]);
+    const right = Math.max(slotX, xs[xs.length - 1]);
+    segments.push(`M ${slotX} ${slotY} L ${slotX} ${busY}`);
+    segments.push(`M ${left} ${busY} L ${right} ${busY}`);
+    for (const geom of firstRow) {
+      segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+    }
 
-      const xs = row.map((c) => c.x).sort((a, b) => a - b);
-      const left = Math.min(slotX, xs[0]);
-      const right = Math.max(slotX, xs[xs.length - 1]);
-      segments.push(`M ${left} ${busY} L ${right} ${busY}`);
-      for (const geom of row) {
-        segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+    const columns = new Map<number, CardGeom[]>();
+    for (const geom of cardGeoms) {
+      const key = Math.round(geom.x);
+      const column = columns.get(key);
+      if (column) column.push(geom);
+      else columns.set(key, [geom]);
+    }
+    for (const column of columns.values()) {
+      column.sort((a, b) => a.top - b.top);
+      for (let i = 1; i < column.length; i += 1) {
+        const upper = column[i - 1];
+        const lower = column[i];
+        segments.push(`M ${lower.x} ${upper.bottom} L ${lower.x} ${lower.top}`);
       }
-
-      prevRowBottom = Math.max(...row.map((c) => c.bottom));
-    });
-
-    segments.unshift(
-      `M ${slotX} ${slotY} L ${slotX} ${busYs[busYs.length - 1]}`
-    );
+    }
 
     setConnector({
       width: stageRect.width,

--- a/src/big-picture/src/pages/settings/emulation/memory-cards-section.tsx
+++ b/src/big-picture/src/pages/settings/emulation/memory-cards-section.tsx
@@ -375,11 +375,8 @@ export function MemoryCardsSection({
   const [scanInput, setScanInput] = useState<MemcardScanInput | null>(null);
   const [exportingKey, setExportingKey] = useState<string | null>(null);
   const [backingUpKey, setBackingUpKey] = useState<string | null>(null);
-  const {
-    backupProgressByCard,
-    markCardBackupStarted,
-    markCardBackupFinished,
-  } = useEmulationBackupProgress(platform);
+  const { backupProgressByCard, backupCard } =
+    useEmulationBackupProgress(platform);
   const [forgetCardTarget, setForgetCardTarget] = useState<{
     cardFilePath: string;
     cardLabel: string;
@@ -498,32 +495,18 @@ export function MemoryCardsSection({
 
   const handleBackupAll = useCallback(
     async (cardFilePath: string, recordCount: number) => {
-      markCardBackupStarted(cardFilePath, recordCount);
-      try {
-        const result =
-          await globalThis.window.electron.uploadEmulationSavesForCard(
-            platform,
-            cardFilePath
-          );
+      const result = await backupCard(cardFilePath, recordCount);
+      if (result) {
         showSuccessToast("Cloud backup complete", {
           ...SETTINGS_TOAST_OPTIONS,
           message: `${result.uploaded}/${result.total} saves uploaded.`,
         });
         onUploaded?.();
-      } catch {
+      } else {
         showErrorToast("Cloud backup failed", SETTINGS_TOAST_OPTIONS);
-      } finally {
-        markCardBackupFinished(cardFilePath);
       }
     },
-    [
-      onUploaded,
-      platform,
-      showErrorToast,
-      showSuccessToast,
-      markCardBackupStarted,
-      markCardBackupFinished,
-    ]
+    [onUploaded, backupCard, showErrorToast, showSuccessToast]
   );
 
   const handleForgetCard = useCallback(async () => {

--- a/src/big-picture/src/pages/settings/emulation/memory-cards-section.tsx
+++ b/src/big-picture/src/pages/settings/emulation/memory-cards-section.tsx
@@ -733,7 +733,9 @@ export function MemoryCardsSection({
                           type="button"
                           className="emulator-detail__memcard-backup-all"
                           onClick={() => {
-                            void handleBackupAll(cardFilePath, records.length);
+                            handleBackupAll(cardFilePath, records.length).catch(
+                              () => {}
+                            );
                           }}
                           disabled={isBackingUp}
                         >

--- a/src/big-picture/src/pages/settings/emulation/memory-cards-section.tsx
+++ b/src/big-picture/src/pages/settings/emulation/memory-cards-section.tsx
@@ -375,8 +375,11 @@ export function MemoryCardsSection({
   const [scanInput, setScanInput] = useState<MemcardScanInput | null>(null);
   const [exportingKey, setExportingKey] = useState<string | null>(null);
   const [backingUpKey, setBackingUpKey] = useState<string | null>(null);
-  const { backingUpCard, backupProgress, setBackingUpCard, setBackupProgress } =
-    useEmulationBackupProgress(platform);
+  const {
+    backupProgressByCard,
+    markCardBackupStarted,
+    markCardBackupFinished,
+  } = useEmulationBackupProgress(platform);
   const [forgetCardTarget, setForgetCardTarget] = useState<{
     cardFilePath: string;
     cardLabel: string;
@@ -494,9 +497,8 @@ export function MemoryCardsSection({
   );
 
   const handleBackupAll = useCallback(
-    async (cardFilePath: string) => {
-      setBackingUpCard(cardFilePath);
-      setBackupProgress(null);
+    async (cardFilePath: string, recordCount: number) => {
+      markCardBackupStarted(cardFilePath, recordCount);
       try {
         const result =
           await globalThis.window.electron.uploadEmulationSavesForCard(
@@ -511,8 +513,7 @@ export function MemoryCardsSection({
       } catch {
         showErrorToast("Cloud backup failed", SETTINGS_TOAST_OPTIONS);
       } finally {
-        setBackingUpCard(null);
-        setBackupProgress(null);
+        markCardBackupFinished(cardFilePath);
       }
     },
     [
@@ -520,8 +521,8 @@ export function MemoryCardsSection({
       platform,
       showErrorToast,
       showSuccessToast,
-      setBackingUpCard,
-      setBackupProgress,
+      markCardBackupStarted,
+      markCardBackupFinished,
     ]
   );
 
@@ -612,8 +613,7 @@ export function MemoryCardsSection({
                 label: progressLabel,
                 percent: progressPercent,
               } = resolveCardBackupProgress(
-                backingUpCard,
-                backupProgress,
+                backupProgressByCard,
                 cardFilePath,
                 records.length
               );
@@ -750,7 +750,7 @@ export function MemoryCardsSection({
                           type="button"
                           className="emulator-detail__memcard-backup-all"
                           onClick={() => {
-                            void handleBackupAll(cardFilePath);
+                            void handleBackupAll(cardFilePath, records.length);
                           }}
                           disabled={isBackingUp}
                         >

--- a/src/big-picture/src/pages/settings/emulation/styles.scss
+++ b/src/big-picture/src/pages/settings/emulation/styles.scss
@@ -975,8 +975,11 @@
 
   &__cloud-grid {
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     align-items: stretch;
-    gap: 16px;
+    column-gap: 16px;
+    row-gap: 44px;
     width: 100%;
   }
 

--- a/src/big-picture/src/pages/settings/emulation/styles.scss
+++ b/src/big-picture/src/pages/settings/emulation/styles.scss
@@ -974,18 +974,19 @@
   }
 
   &__cloud-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(max(200px, calc((100% - 3 * 16px) / 4)), 1fr)
+    );
     align-items: stretch;
     column-gap: 16px;
-    row-gap: 44px;
+    row-gap: 40px;
     width: 100%;
   }
 
   &__cloud-card {
     box-sizing: border-box;
-    flex: 1 1 0;
     min-width: 0;
     height: 153px;
     background: #0d0d0d;
@@ -1246,10 +1247,6 @@
   .emulator-detail__stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .emulator-detail__cloud-grid {
-    flex-wrap: wrap;
-  }
 }
 
 @media (max-width: 820px) {
@@ -1275,7 +1272,7 @@
   }
 
   .emulator-detail__cloud-grid {
-    flex-direction: column;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .emulator-detail__memcard-grid {

--- a/src/main/events/emulators/import-launchbox-roms.ts
+++ b/src/main/events/emulators/import-launchbox-roms.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { chunk } from "lodash-es";
 
@@ -7,7 +8,7 @@ import {
   setActiveClassicsImport,
   updateActiveClassicsImport,
 } from "./classics-import-state";
-import { isWithin, normalizePath } from "./rom-path-utils";
+import { isWithin } from "./rom-path-utils";
 import { HydraApi, WindowManager, emulators, logger } from "@main/services";
 import { platformToSystem } from "@main/helpers";
 import {
@@ -733,20 +734,10 @@ const persistFolderRollups = async (
   }
 };
 
-// After a scan, any previously-imported game for this system whose disc files
-// no longer exist within the scanned folders is stale (file removed from disk).
-// Mark it deleted so it stops showing up in the library tab. Scoped to the
-// folders actually scanned this run, and keyed on disk presence rather than
-// match success so a transient SKU-sniff miss never wipes a valid game.
 const reconcileDeletedGames = async (
   system: EmulatorSystem,
-  folders: FolderInput[],
-  collected: ScannedGameInfo[]
+  folders: FolderInput[]
 ) => {
-  const scannedPaths = new Set(
-    collected.map((game) => normalizePath(game.primaryPath))
-  );
-
   const entries = await gamesSublevel.iterator().all();
   for (const [key, game] of entries) {
     if (game.isDeleted) continue;
@@ -759,9 +750,7 @@ const reconcileDeletedGames = async (
     );
     if (!inScannedFolders) continue;
 
-    const stillOnDisk = discs.some((disc) =>
-      scannedPaths.has(normalizePath(disc.path))
-    );
+    const stillOnDisk = discs.some((disc) => existsSync(disc.path));
     if (stillOnDisk) continue;
 
     game.isDeleted = true;
@@ -892,7 +881,7 @@ export async function runLaunchboxImport(
     signal
   );
   await persistFolderRollups(system, folderRollup, folderInputBy);
-  await reconcileDeletedGames(system, folders, collected);
+  await reconcileDeletedGames(system, folders);
   await syncProfileBatch(Array.from(matchedEntries.keys()));
 
   if (system === "ps3" && !signal.cancelled && ps3ExtractedForYml.size > 0) {

--- a/src/main/events/emulators/import-launchbox-roms.ts
+++ b/src/main/events/emulators/import-launchbox-roms.ts
@@ -7,7 +7,9 @@ import {
   setActiveClassicsImport,
   updateActiveClassicsImport,
 } from "./classics-import-state";
+import { isWithin, normalizePath } from "./rom-path-utils";
 import { HydraApi, WindowManager, emulators, logger } from "@main/services";
+import { platformToSystem } from "@main/helpers";
 import {
   fetchShopDetailsForSkus,
   normalizeSku,
@@ -731,6 +733,44 @@ const persistFolderRollups = async (
   }
 };
 
+// After a scan, any previously-imported game for this system whose disc files
+// no longer exist within the scanned folders is stale (file removed from disk).
+// Mark it deleted so it stops showing up in the library tab. Scoped to the
+// folders actually scanned this run, and keyed on disk presence rather than
+// match success so a transient SKU-sniff miss never wipes a valid game.
+const reconcileDeletedGames = async (
+  system: EmulatorSystem,
+  folders: FolderInput[],
+  collected: ScannedGameInfo[]
+) => {
+  const scannedPaths = new Set(
+    collected.map((game) => normalizePath(game.primaryPath))
+  );
+
+  const entries = await gamesSublevel.iterator().all();
+  for (const [key, game] of entries) {
+    if (game.isDeleted) continue;
+    if (game.shop !== "launchbox") continue;
+    if (platformToSystem(game.platform) !== system) continue;
+
+    const discs = game.discs ?? [];
+    const inScannedFolders = discs.some((disc) =>
+      folders.some((folder) => isWithin(disc.path, folder.path))
+    );
+    if (!inScannedFolders) continue;
+
+    const stillOnDisk = discs.some((disc) =>
+      scannedPaths.has(normalizePath(disc.path))
+    );
+    if (stillOnDisk) continue;
+
+    game.isDeleted = true;
+    await gamesSublevel.put(key, game).catch((err) => {
+      logger.error("Could not mark stale launchbox game as deleted", err);
+    });
+  }
+};
+
 export async function runLaunchboxImport(
   system: EmulatorSystem,
   folders: FolderInput[],
@@ -852,6 +892,7 @@ export async function runLaunchboxImport(
     signal
   );
   await persistFolderRollups(system, folderRollup, folderInputBy);
+  await reconcileDeletedGames(system, folders, collected);
   await syncProfileBatch(Array.from(matchedEntries.keys()));
 
   if (system === "ps3" && !signal.cancelled && ps3ExtractedForYml.size > 0) {

--- a/src/main/events/emulators/list-emulator-roms.ts
+++ b/src/main/events/emulators/list-emulator-roms.ts
@@ -1,5 +1,3 @@
-import path from "node:path";
-
 import type { DetectedRom, EmulatorSystem } from "@types";
 
 import { registerEvent } from "../register-event";
@@ -7,18 +5,7 @@ import { gamesSublevel, gamesShopAssetsSublevel } from "@main/level";
 import { platformToSystem } from "@main/helpers";
 import { emulators } from "@main/services";
 
-const normalizePath = (p: string): string => {
-  const normalized = path.normalize(p);
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
-};
-
-const isWithin = (child: string, parent: string): boolean => {
-  const c = normalizePath(child);
-  const p = normalizePath(parent);
-  if (c === p) return true;
-  const rel = path.relative(p, c);
-  return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
-};
+import { isWithin } from "./rom-path-utils";
 
 const listEmulatorRoms = async (
   _event: Electron.IpcMainInvokeEvent,

--- a/src/main/events/emulators/rom-path-utils.ts
+++ b/src/main/events/emulators/rom-path-utils.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+
+export const normalizePath = (p: string): string => {
+  const normalized = path.normalize(p);
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+};
+
+export const isWithin = (child: string, parent: string): boolean => {
+  const c = normalizePath(child);
+  const p = normalizePath(parent);
+  if (c === p) return true;
+  const rel = path.relative(p, c);
+  return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
+};

--- a/src/main/events/library/open-classics-game.ts
+++ b/src/main/events/library/open-classics-game.ts
@@ -1,8 +1,19 @@
+import { existsSync } from "node:fs";
+
 import { registerEvent } from "../register-event";
 import { gamesSublevel, levelKeys } from "@main/level";
 import { launchClassicsGame, platformToSystem } from "@main/helpers";
 import { logger, NativeAddon } from "@main/services";
 import type { GameShop } from "@types";
+
+const codedLaunchError = (
+  code: string,
+  message: string,
+  context: Record<string, unknown>
+): Error & { code: string } => {
+  logger.error("Failed to launch classics game", { code, ...context });
+  return Object.assign(new Error(message), { code });
+};
 
 const isRpcs3RunningExternally = async (): Promise<number[]> => {
   const procs = await NativeAddon.listProcesses();
@@ -56,33 +67,33 @@ const openClassicsGame = async (
 
   const system = platformToSystem(game.platform);
   if (!system) {
-    const error: Error & { code?: string } = new Error(
-      `PLATFORM_UNKNOWN: Unknown platform for game ${objectId}`
+    throw codedLaunchError(
+      "PLATFORM_UNKNOWN",
+      `PLATFORM_UNKNOWN: Unknown platform for game ${objectId}`,
+      { objectId, platform: game.platform }
     );
-    error.code = "PLATFORM_UNKNOWN";
-    throw error;
   }
 
   const resolvedDiscPath =
     discPath ?? game.selectedDiscPath ?? game.discs?.[0]?.path ?? null;
 
-  if (!resolvedDiscPath) {
-    const error: Error & { code?: string } = new Error(
-      `NO_DISC: No disc available for game ${objectId}`
+  if (!resolvedDiscPath || !existsSync(resolvedDiscPath)) {
+    throw codedLaunchError(
+      "NO_DISC",
+      `NO_DISC: No disc available for game ${objectId}`,
+      { objectId, system, resolvedDiscPath }
     );
-    error.code = "NO_DISC";
-    throw error;
   }
 
   if (system === "ps3") {
     const running = await isRpcs3RunningExternally();
     if (running.length > 0) {
       if (!force) {
-        const error: Error & { code?: string } = new Error(
-          `EMULATOR_ALREADY_RUNNING: rpcs3 is already running`
+        throw codedLaunchError(
+          "EMULATOR_ALREADY_RUNNING",
+          `EMULATOR_ALREADY_RUNNING: rpcs3 is already running`,
+          { objectId, system, pids: running }
         );
-        error.code = "EMULATOR_ALREADY_RUNNING";
-        throw error;
       }
       killPids(running);
       let exited = await waitForRpcs3Exit(running);
@@ -91,11 +102,11 @@ const openClassicsGame = async (
         exited = await waitForRpcs3Exit(running);
       }
       if (!exited) {
-        const error: Error & { code?: string } = new Error(
-          `EMULATOR_ALREADY_RUNNING: rpcs3 did not exit before relaunch`
+        throw codedLaunchError(
+          "EMULATOR_ALREADY_RUNNING",
+          `EMULATOR_ALREADY_RUNNING: rpcs3 did not exit before relaunch`,
+          { objectId, system, pids: running }
         );
-        error.code = "EMULATOR_ALREADY_RUNNING";
-        throw error;
       }
     }
   }
@@ -114,12 +125,14 @@ const openClassicsGame = async (
       "code" in error &&
       error.code === "EMULATOR_NOT_CONFIGURED"
     ) {
-      const wrapped: Error & { code?: string; system?: string } = new Error(
-        `EMULATOR_NOT_CONFIGURED: Emulator not configured for ${system}`
+      throw Object.assign(
+        codedLaunchError(
+          "EMULATOR_NOT_CONFIGURED",
+          `EMULATOR_NOT_CONFIGURED: Emulator not configured for ${system}`,
+          { objectId, system }
+        ),
+        { system }
       );
-      wrapped.code = "EMULATOR_NOT_CONFIGURED";
-      wrapped.system = system;
-      throw wrapped;
     }
 
     if (
@@ -128,12 +141,14 @@ const openClassicsGame = async (
       "code" in error &&
       error.code === "BIOS_NOT_CONFIGURED"
     ) {
-      const wrapped: Error & { code?: string; system?: string } = new Error(
-        `BIOS_NOT_CONFIGURED: BIOS not configured for ${system}`
+      throw Object.assign(
+        codedLaunchError(
+          "BIOS_NOT_CONFIGURED",
+          `BIOS_NOT_CONFIGURED: BIOS not configured for ${system}`,
+          { objectId, system }
+        ),
+        { system }
       );
-      wrapped.code = "BIOS_NOT_CONFIGURED";
-      wrapped.system = system;
-      throw wrapped;
     }
     logger.error("Failed to launch classics game", error);
     throw error;

--- a/src/renderer/src/hooks/use-cloud-connector.ts
+++ b/src/renderer/src/hooks/use-cloud-connector.ts
@@ -71,14 +71,14 @@ export function useCloudConnector(dependency: unknown) {
 
     const rowTop = Math.min(...firstRow.map((c) => c.top));
     const busY = rowTop - BRANCH_GAP;
-    const xs = firstRow.map((c) => c.x).sort((a, b) => a - b);
-    const left = Math.min(slotX, xs[0]);
-    const right = Math.max(slotX, xs[xs.length - 1]);
-    segments.push(`M ${slotX} ${slotY} L ${slotX} ${busY}`);
-    segments.push(`M ${left} ${busY} L ${right} ${busY}`);
-    for (const geom of firstRow) {
-      segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
-    }
+    const xs = firstRow.map((c) => c.x);
+    const left = Math.min(slotX, ...xs);
+    const right = Math.max(slotX, ...xs);
+    segments.push(
+      `M ${slotX} ${slotY} L ${slotX} ${busY}`,
+      `M ${left} ${busY} L ${right} ${busY}`,
+      ...firstRow.map((geom) => `M ${geom.x} ${busY} L ${geom.x} ${geom.top}`)
+    );
 
     const columns = new Map<number, CardGeom[]>();
     for (const geom of cardGeoms) {

--- a/src/renderer/src/hooks/use-cloud-connector.ts
+++ b/src/renderer/src/hooks/use-cloud-connector.ts
@@ -1,0 +1,114 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+const SLOT_X_RATIO = 59.5 / 411;
+const SLOT_Y_RATIO = 129 / 221;
+const BRANCH_GAP = 40;
+
+export interface CloudConnector {
+  width: number;
+  height: number;
+  path: string;
+}
+
+export function useCloudConnector(dependency: unknown) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const consoleRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [connector, setConnector] = useState<CloudConnector>({
+    width: 0,
+    height: 0,
+    path: "",
+  });
+
+  const drawConnector = useCallback(() => {
+    const stage = stageRef.current;
+    const consoleEl = consoleRef.current;
+    const grid = gridRef.current;
+    if (!stage || !consoleEl || !grid) return;
+
+    const stageRect = stage.getBoundingClientRect();
+    const consoleRect = consoleEl.getBoundingClientRect();
+    const cards = Array.from(
+      grid.querySelectorAll<HTMLElement>(".emulator-detail__cloud-card")
+    );
+    if (cards.length === 0) {
+      setConnector({
+        width: stageRect.width,
+        height: stageRect.height,
+        path: "",
+      });
+      return;
+    }
+
+    const slotX =
+      consoleRect.left - stageRect.left + SLOT_X_RATIO * consoleRect.width;
+    const slotY =
+      consoleRect.top - stageRect.top + SLOT_Y_RATIO * consoleRect.height;
+
+    const cardGeoms = cards.map((card) => {
+      const rect = card.getBoundingClientRect();
+      return {
+        x: rect.left - stageRect.left + rect.width / 2,
+        top: rect.top - stageRect.top,
+        bottom: rect.bottom - stageRect.top,
+      };
+    });
+
+    type CardGeom = (typeof cardGeoms)[number];
+
+    const rowsByTop = new Map<number, CardGeom[]>();
+    for (const geom of cardGeoms) {
+      const key = Math.round(geom.top);
+      const row = rowsByTop.get(key);
+      if (row) row.push(geom);
+      else rowsByTop.set(key, [geom]);
+    }
+    const firstRow = Array.from(rowsByTop.entries()).sort(
+      (a, b) => a[0] - b[0]
+    )[0][1];
+
+    const segments: string[] = [];
+
+    const rowTop = Math.min(...firstRow.map((c) => c.top));
+    const busY = rowTop - BRANCH_GAP;
+    const xs = firstRow.map((c) => c.x).sort((a, b) => a - b);
+    const left = Math.min(slotX, xs[0]);
+    const right = Math.max(slotX, xs[xs.length - 1]);
+    segments.push(`M ${slotX} ${slotY} L ${slotX} ${busY}`);
+    segments.push(`M ${left} ${busY} L ${right} ${busY}`);
+    for (const geom of firstRow) {
+      segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+    }
+
+    const columns = new Map<number, CardGeom[]>();
+    for (const geom of cardGeoms) {
+      const key = Math.round(geom.x);
+      const column = columns.get(key);
+      if (column) column.push(geom);
+      else columns.set(key, [geom]);
+    }
+    for (const column of columns.values()) {
+      column.sort((a, b) => a.top - b.top);
+      for (let i = 1; i < column.length; i += 1) {
+        const upper = column[i - 1];
+        const lower = column[i];
+        segments.push(`M ${lower.x} ${upper.bottom} L ${lower.x} ${lower.top}`);
+      }
+    }
+
+    setConnector({
+      width: stageRect.width,
+      height: stageRect.height,
+      path: segments.join(" "),
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    drawConnector();
+    const observer = new ResizeObserver(drawConnector);
+    if (stageRef.current) observer.observe(stageRef.current);
+    return () => observer.disconnect();
+  }, [drawConnector, dependency]);
+
+  return { stageRef, consoleRef, gridRef, connector };
+}

--- a/src/renderer/src/hooks/use-cloud-connector.ts
+++ b/src/renderer/src/hooks/use-cloud-connector.ts
@@ -3,6 +3,8 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react";
 const SLOT_X_RATIO = 59.5 / 411;
 const SLOT_Y_RATIO = 129 / 221;
 const BRANCH_GAP = 40;
+const ROW_TOLERANCE = 8;
+const COLUMN_TOLERANCE = 8;
 
 export interface CloudConnector {
   width: number;
@@ -56,16 +58,22 @@ export function useCloudConnector(dependency: unknown) {
 
     type CardGeom = (typeof cardGeoms)[number];
 
-    const rowsByTop = new Map<number, CardGeom[]>();
-    for (const geom of cardGeoms) {
-      const key = Math.round(geom.top);
-      const row = rowsByTop.get(key);
-      if (row) row.push(geom);
-      else rowsByTop.set(key, [geom]);
-    }
-    const firstRow = Array.from(rowsByTop.entries()).sort(
-      (a, b) => a[0] - b[0]
-    )[0][1];
+    const clusterBy = (
+      pick: (card: CardGeom) => number,
+      tolerance: number
+    ): CardGeom[][] => {
+      const sorted = [...cardGeoms].sort((a, b) => pick(a) - pick(b));
+      const groups: CardGeom[][] = [];
+      for (const card of sorted) {
+        const last = groups.at(-1);
+        if (last && pick(card) - pick(last[0]) <= tolerance) last.push(card);
+        else groups.push([card]);
+      }
+      return groups;
+    };
+
+    const rows = clusterBy((card) => card.top, ROW_TOLERANCE);
+    const firstRow = rows[0];
 
     const segments: string[] = [];
 
@@ -80,18 +88,12 @@ export function useCloudConnector(dependency: unknown) {
       ...firstRow.map((geom) => `M ${geom.x} ${busY} L ${geom.x} ${geom.top}`)
     );
 
-    const columns = new Map<number, CardGeom[]>();
-    for (const geom of cardGeoms) {
-      const key = Math.round(geom.x);
-      const column = columns.get(key);
-      if (column) column.push(geom);
-      else columns.set(key, [geom]);
-    }
-    for (const column of columns.values()) {
-      column.sort((a, b) => a.top - b.top);
-      for (let i = 1; i < column.length; i += 1) {
-        const upper = column[i - 1];
-        const lower = column[i];
+    const columns = clusterBy((card) => card.x, COLUMN_TOLERANCE);
+    for (const column of columns) {
+      const ordered = [...column].sort((a, b) => a.top - b.top);
+      for (let i = 1; i < ordered.length; i += 1) {
+        const upper = ordered[i - 1];
+        const lower = ordered[i];
         segments.push(`M ${lower.x} ${upper.bottom} L ${lower.x} ${lower.top}`);
       }
     }

--- a/src/renderer/src/hooks/use-emulation-backup-progress.ts
+++ b/src/renderer/src/hooks/use-emulation-backup-progress.ts
@@ -85,10 +85,26 @@ export function useEmulationBackupProgress(platform: EmulationSavePlatform) {
     });
   }, []);
 
+  const backupCard = useCallback(
+    async (cardFilePath: string, recordCount: number) => {
+      markCardBackupStarted(cardFilePath, recordCount);
+      try {
+        return await window.electron.uploadEmulationSavesForCard(
+          platform,
+          cardFilePath
+        );
+      } catch {
+        return null;
+      } finally {
+        markCardBackupFinished(cardFilePath);
+      }
+    },
+    [platform, markCardBackupStarted, markCardBackupFinished]
+  );
+
   return {
     backupProgressByCard,
-    markCardBackupStarted,
-    markCardBackupFinished,
+    backupCard,
   };
 }
 

--- a/src/renderer/src/hooks/use-emulation-backup-progress.ts
+++ b/src/renderer/src/hooks/use-emulation-backup-progress.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { EmulationBackupProgress, EmulationSavePlatform } from "@types";
 
@@ -13,9 +13,9 @@ export interface CardBackupProgress {
 }
 
 export function useEmulationBackupProgress(platform: EmulationSavePlatform) {
-  const [backingUpCard, setBackingUpCard] = useState<string | null>(null);
-  const [backupProgress, setBackupProgress] =
-    useState<EmulationBackupProgress | null>(null);
+  const [backupProgressByCard, setBackupProgressByCard] = useState<
+    Record<string, EmulationBackupProgress>
+  >({});
 
   useEffect(() => {
     let active = true;
@@ -23,26 +23,33 @@ export function useEmulationBackupProgress(platform: EmulationSavePlatform) {
 
     void window.electron.getActiveEmulationBackups().then((list) => {
       if (!active) return;
-      const match = list.find((b) => b.platform === platform);
-      if (!match || seenDone.has(match.cardFilePath)) return;
-      setBackingUpCard(match.cardFilePath);
-      setBackupProgress(match);
+      const matches = list.filter(
+        (b) => b.platform === platform && !seenDone.has(b.cardFilePath)
+      );
+      if (matches.length === 0) return;
+      setBackupProgressByCard((prev) => {
+        const next = { ...prev };
+        for (const match of matches) next[match.cardFilePath] = match;
+        return next;
+      });
     });
 
     const unsubscribe = window.electron.onEmulationBackupProgress((payload) => {
       if (payload.platform !== platform) return;
       if (payload.processed >= payload.total) {
         seenDone.add(payload.cardFilePath);
-        setBackingUpCard((prev) =>
-          prev === payload.cardFilePath ? null : prev
-        );
-        setBackupProgress((prev) =>
-          prev?.cardFilePath === payload.cardFilePath ? null : prev
-        );
+        setBackupProgressByCard((prev) => {
+          if (!(payload.cardFilePath in prev)) return prev;
+          const next = { ...prev };
+          delete next[payload.cardFilePath];
+          return next;
+        });
         return;
       }
-      setBackingUpCard(payload.cardFilePath);
-      setBackupProgress(payload);
+      setBackupProgressByCard((prev) => ({
+        ...prev,
+        [payload.cardFilePath]: payload,
+      }));
     });
 
     return () => {
@@ -51,20 +58,47 @@ export function useEmulationBackupProgress(platform: EmulationSavePlatform) {
     };
   }, [platform]);
 
-  return { backingUpCard, backupProgress, setBackingUpCard, setBackupProgress };
+  const markCardBackupStarted = useCallback(
+    (cardFilePath: string, total: number) => {
+      setBackupProgressByCard((prev) => ({
+        ...prev,
+        [cardFilePath]: {
+          platform,
+          cardFilePath,
+          processed: 0,
+          uploaded: 0,
+          failed: 0,
+          total,
+          currentLabel: null,
+        },
+      }));
+    },
+    [platform]
+  );
+
+  const markCardBackupFinished = useCallback((cardFilePath: string) => {
+    setBackupProgressByCard((prev) => {
+      if (!(cardFilePath in prev)) return prev;
+      const next = { ...prev };
+      delete next[cardFilePath];
+      return next;
+    });
+  }, []);
+
+  return {
+    backupProgressByCard,
+    markCardBackupStarted,
+    markCardBackupFinished,
+  };
 }
 
 export function resolveCardBackupProgress(
-  backingUpCard: string | null,
-  backupProgress: EmulationBackupProgress | null,
+  backupProgressByCard: Record<string, EmulationBackupProgress>,
   cardFilePath: string,
   recordCount: number
 ): CardBackupProgress {
-  const isBackingUp = backingUpCard === cardFilePath;
-  const progress =
-    isBackingUp && backupProgress?.cardFilePath === cardFilePath
-      ? backupProgress
-      : null;
+  const progress = backupProgressByCard[cardFilePath] ?? null;
+  const isBackingUp = progress !== null;
   const total = progress?.total ?? recordCount;
   const done = progress?.processed ?? 0;
   const percent =

--- a/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -41,7 +41,6 @@ interface Props {
 const SLOT_X_RATIO = 59.5 / 411;
 const SLOT_Y_RATIO = 129 / 221;
 const BRANCH_GAP = 40;
-const MIN_BRANCH_GAP = 8;
 
 interface Connector {
   width: number;
@@ -132,6 +131,7 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
     });
 
     type CardGeom = (typeof cardGeoms)[number];
+
     const rowsByTop = new Map<number, CardGeom[]>();
     for (const geom of cardGeoms) {
       const key = Math.round(geom.top);
@@ -139,39 +139,38 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
       if (row) row.push(geom);
       else rowsByTop.set(key, [geom]);
     }
-    const rows = Array.from(rowsByTop.values()).sort(
-      (a, b) => a[0].top - b[0].top
-    );
+    const firstRow = Array.from(rowsByTop.entries()).sort(
+      (a, b) => a[0] - b[0]
+    )[0][1];
 
     const segments: string[] = [];
-    const busYs: number[] = [];
-    let prevRowBottom: number | null = null;
 
-    rows.forEach((row, index) => {
-      const rowTop = Math.min(...row.map((c) => c.top));
-      const gapAbove =
-        prevRowBottom === null ? BRANCH_GAP : rowTop - prevRowBottom;
-      const branch =
-        index === 0
-          ? BRANCH_GAP
-          : Math.max(MIN_BRANCH_GAP, Math.min(BRANCH_GAP, gapAbove / 2));
-      const busY = rowTop - branch;
-      busYs.push(busY);
+    const rowTop = Math.min(...firstRow.map((c) => c.top));
+    const busY = rowTop - BRANCH_GAP;
+    const xs = firstRow.map((c) => c.x).sort((a, b) => a - b);
+    const left = Math.min(slotX, xs[0]);
+    const right = Math.max(slotX, xs[xs.length - 1]);
+    segments.push(`M ${slotX} ${slotY} L ${slotX} ${busY}`);
+    segments.push(`M ${left} ${busY} L ${right} ${busY}`);
+    for (const geom of firstRow) {
+      segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+    }
 
-      const xs = row.map((c) => c.x).sort((a, b) => a - b);
-      const left = Math.min(slotX, xs[0]);
-      const right = Math.max(slotX, xs[xs.length - 1]);
-      segments.push(`M ${left} ${busY} L ${right} ${busY}`);
-      for (const geom of row) {
-        segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+    const columns = new Map<number, CardGeom[]>();
+    for (const geom of cardGeoms) {
+      const key = Math.round(geom.x);
+      const column = columns.get(key);
+      if (column) column.push(geom);
+      else columns.set(key, [geom]);
+    }
+    for (const column of columns.values()) {
+      column.sort((a, b) => a.top - b.top);
+      for (let i = 1; i < column.length; i += 1) {
+        const upper = column[i - 1];
+        const lower = column[i];
+        segments.push(`M ${lower.x} ${upper.bottom} L ${lower.x} ${lower.top}`);
       }
-
-      prevRowBottom = Math.max(...row.map((c) => c.bottom));
-    });
-
-    segments.unshift(
-      `M ${slotX} ${slotY} L ${slotX} ${busYs[busYs.length - 1]}`
-    );
+    }
 
     setConnector({
       width: stageRect.width,

--- a/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -41,7 +41,7 @@ interface Props {
 const SLOT_X_RATIO = 59.5 / 411;
 const SLOT_Y_RATIO = 129 / 221;
 const BRANCH_GAP = 40;
-const CORNER_RADIUS = 8;
+const MIN_BRANCH_GAP = 8;
 
 interface Connector {
   width: number;
@@ -122,37 +122,56 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
     const slotY =
       consoleRect.top - stageRect.top + SLOT_Y_RATIO * consoleRect.height;
 
-    const centers = cards.map((card) => {
+    const cardGeoms = cards.map((card) => {
       const rect = card.getBoundingClientRect();
       return {
         x: rect.left - stageRect.left + rect.width / 2,
         top: rect.top - stageRect.top,
+        bottom: rect.bottom - stageRect.top,
       };
     });
-    const cardTop = Math.min(...centers.map((c) => c.top));
-    const busY = cardTop - BRANCH_GAP;
-    const xs = centers.map((c) => c.x);
-    const first = xs[0];
-    const last = xs[xs.length - 1];
 
-    const segments = [`M ${slotX} ${slotY} L ${slotX} ${busY}`];
-
-    if (first === last) {
-      segments.push(`M ${first} ${busY} L ${first} ${cardTop}`);
-      segments.push(
-        `M ${Math.min(slotX, first)} ${busY} L ${Math.max(slotX, first)} ${busY}`
-      );
-    } else {
-      const r = Math.min(CORNER_RADIUS, (last - first) / 2);
-      segments.push(
-        `M ${first} ${cardTop} L ${first} ${busY + r} Q ${first} ${busY} ${first + r} ${busY} L ${last - r} ${busY} Q ${last} ${busY} ${last} ${busY + r} L ${last} ${cardTop}`
-      );
-      for (let i = 1; i < xs.length - 1; i += 1) {
-        segments.push(`M ${xs[i]} ${busY} L ${xs[i]} ${cardTop}`);
-      }
-      if (slotX < first) segments.push(`M ${slotX} ${busY} L ${first} ${busY}`);
-      if (slotX > last) segments.push(`M ${last} ${busY} L ${slotX} ${busY}`);
+    type CardGeom = (typeof cardGeoms)[number];
+    const rowsByTop = new Map<number, CardGeom[]>();
+    for (const geom of cardGeoms) {
+      const key = Math.round(geom.top);
+      const row = rowsByTop.get(key);
+      if (row) row.push(geom);
+      else rowsByTop.set(key, [geom]);
     }
+    const rows = Array.from(rowsByTop.values()).sort(
+      (a, b) => a[0].top - b[0].top
+    );
+
+    const segments: string[] = [];
+    const busYs: number[] = [];
+    let prevRowBottom: number | null = null;
+
+    rows.forEach((row, index) => {
+      const rowTop = Math.min(...row.map((c) => c.top));
+      const gapAbove =
+        prevRowBottom === null ? BRANCH_GAP : rowTop - prevRowBottom;
+      const branch =
+        index === 0
+          ? BRANCH_GAP
+          : Math.max(MIN_BRANCH_GAP, Math.min(BRANCH_GAP, gapAbove / 2));
+      const busY = rowTop - branch;
+      busYs.push(busY);
+
+      const xs = row.map((c) => c.x).sort((a, b) => a - b);
+      const left = Math.min(slotX, xs[0]);
+      const right = Math.max(slotX, xs[xs.length - 1]);
+      segments.push(`M ${left} ${busY} L ${right} ${busY}`);
+      for (const geom of row) {
+        segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
+      }
+
+      prevRowBottom = Math.max(...row.map((c) => c.bottom));
+    });
+
+    segments.unshift(
+      `M ${slotX} ${slotY} L ${slotX} ${busYs[busYs.length - 1]}`
+    );
 
     setConnector({
       width: stageRect.width,

--- a/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ClockIcon,
@@ -20,6 +14,7 @@ import {
 import { Button, ConfirmationModal } from "@renderer/components";
 import { DropdownMenu } from "@renderer/components/dropdown-menu/dropdown-menu";
 import { useToast, useUserDetails } from "@renderer/hooks";
+import { useCloudConnector } from "@renderer/hooks/use-cloud-connector";
 import { useSubscription } from "@renderer/hooks/use-subscription";
 import type {
   EmulationCloudSave,
@@ -38,16 +33,6 @@ interface Props {
   refreshKey: number;
 }
 
-const SLOT_X_RATIO = 59.5 / 411;
-const SLOT_Y_RATIO = 129 / 221;
-const BRANCH_GAP = 40;
-
-interface Connector {
-  width: number;
-  height: number;
-  path: string;
-}
-
 export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
   const { t } = useTranslation("settings");
   const { t: tHydraCloud } = useTranslation("hydra_cloud");
@@ -62,14 +47,7 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
   const [renameFor, setRenameFor] = useState<EmulationCloudSave | null>(null);
   const [deleteFor, setDeleteFor] = useState<EmulationCloudSave | null>(null);
 
-  const stageRef = useRef<HTMLDivElement>(null);
-  const consoleRef = useRef<HTMLDivElement>(null);
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [connector, setConnector] = useState<Connector>({
-    width: 0,
-    height: 0,
-    path: "",
-  });
+  const { stageRef, consoleRef, gridRef, connector } = useCloudConnector(saves);
 
   const load = useCallback(async () => {
     if (!hasActiveSubscription) {
@@ -95,96 +73,6 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
     showSuccessToast(t("cloud_delete_success"));
     load();
   }, [deleteFor, showSuccessToast, t, load]);
-
-  const drawConnector = useCallback(() => {
-    const stage = stageRef.current;
-    const consoleEl = consoleRef.current;
-    const grid = gridRef.current;
-    if (!stage || !consoleEl || !grid) return;
-
-    const stageRect = stage.getBoundingClientRect();
-    const consoleRect = consoleEl.getBoundingClientRect();
-    const cards = Array.from(
-      grid.querySelectorAll<HTMLElement>(".emulator-detail__cloud-card")
-    );
-    if (cards.length === 0) {
-      setConnector({
-        width: stageRect.width,
-        height: stageRect.height,
-        path: "",
-      });
-      return;
-    }
-
-    const slotX =
-      consoleRect.left - stageRect.left + SLOT_X_RATIO * consoleRect.width;
-    const slotY =
-      consoleRect.top - stageRect.top + SLOT_Y_RATIO * consoleRect.height;
-
-    const cardGeoms = cards.map((card) => {
-      const rect = card.getBoundingClientRect();
-      return {
-        x: rect.left - stageRect.left + rect.width / 2,
-        top: rect.top - stageRect.top,
-        bottom: rect.bottom - stageRect.top,
-      };
-    });
-
-    type CardGeom = (typeof cardGeoms)[number];
-
-    const rowsByTop = new Map<number, CardGeom[]>();
-    for (const geom of cardGeoms) {
-      const key = Math.round(geom.top);
-      const row = rowsByTop.get(key);
-      if (row) row.push(geom);
-      else rowsByTop.set(key, [geom]);
-    }
-    const firstRow = Array.from(rowsByTop.entries()).sort(
-      (a, b) => a[0] - b[0]
-    )[0][1];
-
-    const segments: string[] = [];
-
-    const rowTop = Math.min(...firstRow.map((c) => c.top));
-    const busY = rowTop - BRANCH_GAP;
-    const xs = firstRow.map((c) => c.x).sort((a, b) => a - b);
-    const left = Math.min(slotX, xs[0]);
-    const right = Math.max(slotX, xs[xs.length - 1]);
-    segments.push(`M ${slotX} ${slotY} L ${slotX} ${busY}`);
-    segments.push(`M ${left} ${busY} L ${right} ${busY}`);
-    for (const geom of firstRow) {
-      segments.push(`M ${geom.x} ${busY} L ${geom.x} ${geom.top}`);
-    }
-
-    const columns = new Map<number, CardGeom[]>();
-    for (const geom of cardGeoms) {
-      const key = Math.round(geom.x);
-      const column = columns.get(key);
-      if (column) column.push(geom);
-      else columns.set(key, [geom]);
-    }
-    for (const column of columns.values()) {
-      column.sort((a, b) => a.top - b.top);
-      for (let i = 1; i < column.length; i += 1) {
-        const upper = column[i - 1];
-        const lower = column[i];
-        segments.push(`M ${lower.x} ${upper.bottom} L ${lower.x} ${lower.top}`);
-      }
-    }
-
-    setConnector({
-      width: stageRect.width,
-      height: stageRect.height,
-      path: segments.join(" "),
-    });
-  }, []);
-
-  useLayoutEffect(() => {
-    drawConnector();
-    const observer = new ResizeObserver(drawConnector);
-    if (stageRef.current) observer.observe(stageRef.current);
-    return () => observer.disconnect();
-  }, [drawConnector, saves]);
 
   if (!hasActiveSubscription) {
     return (

--- a/src/renderer/src/pages/settings/emulation/emulator-detail.scss
+++ b/src/renderer/src/pages/settings/emulation/emulator-detail.scss
@@ -741,20 +741,20 @@
   }
 
   &__cloud-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(max(200px, calc((100% - 3 * 16px) / 4)), 1fr)
+    );
     align-items: stretch;
     column-gap: 16px;
-    row-gap: 44px;
+    row-gap: 40px;
     width: 100%;
   }
 
   &__cloud-card {
     box-sizing: border-box;
-    flex: 0 1 calc((100% - 3 * 16px) / 4);
-    max-width: calc((100% - 3 * 16px) / 4);
-    min-width: 200px;
+    min-width: 0;
     height: 153px;
     background: #0d0d0d;
     border: 1px solid rgba(255, 255, 255, 0.08);

--- a/src/renderer/src/pages/settings/emulation/emulator-detail.scss
+++ b/src/renderer/src/pages/settings/emulation/emulator-detail.scss
@@ -741,19 +741,20 @@
   }
 
   &__cloud-grid {
-    display: grid;
-    grid-template-columns: repeat(
-      auto-fill,
-      minmax(max(200px, calc((100% - 3 * 16px) / 4)), 1fr)
-    );
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     align-items: stretch;
-    gap: 16px;
+    column-gap: 16px;
+    row-gap: 44px;
     width: 100%;
   }
 
   &__cloud-card {
     box-sizing: border-box;
-    min-width: 0;
+    flex: 0 1 calc((100% - 3 * 16px) / 4);
+    max-width: calc((100% - 3 * 16px) / 4);
+    min-width: 200px;
     height: 153px;
     background: #0d0d0d;
     border: 1px solid rgba(255, 255, 255, 0.08);

--- a/src/renderer/src/pages/settings/emulation/memory-cards-section.tsx
+++ b/src/renderer/src/pages/settings/emulation/memory-cards-section.tsx
@@ -114,8 +114,11 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
   const [scanInput, setScanInput] = useState<MemcardScanInput | null>(null);
   const [exportingKey, setExportingKey] = useState<string | null>(null);
   const [backingUpKey, setBackingUpKey] = useState<string | null>(null);
-  const { backingUpCard, backupProgress, setBackingUpCard, setBackupProgress } =
-    useEmulationBackupProgress(platform);
+  const {
+    backupProgressByCard,
+    markCardBackupStarted,
+    markCardBackupFinished,
+  } = useEmulationBackupProgress(platform);
   const [forgetCardTarget, setForgetCardTarget] = useState<{
     cardFilePath: string;
     cardLabel: string;
@@ -271,9 +274,8 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
   );
 
   const handleBackupAll = useCallback(
-    async (cardFilePath: string) => {
-      setBackingUpCard(cardFilePath);
-      setBackupProgress(null);
+    async (cardFilePath: string, recordCount: number) => {
+      markCardBackupStarted(cardFilePath, recordCount);
       try {
         const res = await window.electron.uploadEmulationSavesForCard(
           platform,
@@ -289,8 +291,7 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
       } catch {
         showErrorToast(t("cloud_backup_failed"));
       } finally {
-        setBackingUpCard(null);
-        setBackupProgress(null);
+        markCardBackupFinished(cardFilePath);
       }
     },
     [
@@ -299,8 +300,8 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
       showErrorToast,
       t,
       onUploaded,
-      setBackingUpCard,
-      setBackupProgress,
+      markCardBackupStarted,
+      markCardBackupFinished,
     ]
   );
 
@@ -383,8 +384,7 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
                     label: progressLabel,
                     percent: progressPercent,
                   } = resolveCardBackupProgress(
-                    backingUpCard,
-                    backupProgress,
+                    backupProgressByCard,
                     cardFilePath,
                     records.length
                   );
@@ -429,7 +429,9 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
                           <button
                             type="button"
                             className="emulator-detail__memcard-backup-all"
-                            onClick={() => handleBackupAll(cardFilePath)}
+                            onClick={() =>
+                              handleBackupAll(cardFilePath, records.length)
+                            }
                             disabled={isBackingUp}
                           >
                             <UploadIcon size={13} />

--- a/src/renderer/src/pages/settings/emulation/memory-cards-section.tsx
+++ b/src/renderer/src/pages/settings/emulation/memory-cards-section.tsx
@@ -114,11 +114,8 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
   const [scanInput, setScanInput] = useState<MemcardScanInput | null>(null);
   const [exportingKey, setExportingKey] = useState<string | null>(null);
   const [backingUpKey, setBackingUpKey] = useState<string | null>(null);
-  const {
-    backupProgressByCard,
-    markCardBackupStarted,
-    markCardBackupFinished,
-  } = useEmulationBackupProgress(platform);
+  const { backupProgressByCard, backupCard } =
+    useEmulationBackupProgress(platform);
   const [forgetCardTarget, setForgetCardTarget] = useState<{
     cardFilePath: string;
     cardLabel: string;
@@ -275,12 +272,8 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
 
   const handleBackupAll = useCallback(
     async (cardFilePath: string, recordCount: number) => {
-      markCardBackupStarted(cardFilePath, recordCount);
-      try {
-        const res = await window.electron.uploadEmulationSavesForCard(
-          platform,
-          cardFilePath
-        );
+      const res = await backupCard(cardFilePath, recordCount);
+      if (res) {
         showSuccessToast(
           t("cloud_backup_all_done", {
             uploaded: res.uploaded,
@@ -288,21 +281,11 @@ export function MemoryCardsSection({ config, onUploaded }: Readonly<Props>) {
           })
         );
         onUploaded?.();
-      } catch {
+      } else {
         showErrorToast(t("cloud_backup_failed"));
-      } finally {
-        markCardBackupFinished(cardFilePath);
       }
     },
-    [
-      platform,
-      showSuccessToast,
-      showErrorToast,
-      t,
-      onUploaded,
-      markCardBackupStarted,
-      markCardBackupFinished,
-    ]
+    [backupCard, showSuccessToast, showErrorToast, t, onUploaded]
   );
 
   const handleForgetCard = useCallback(async () => {

--- a/src/renderer/src/pages/settings/emulation/setup/setup-shell.scss
+++ b/src/renderer/src/pages/settings/emulation/setup/setup-shell.scss
@@ -160,6 +160,7 @@
   &__download-grid {
     display: grid;
     grid-template-columns: 1fr;
+    align-content: start;
     gap: 12px;
     flex: 1;
   }


### PR DESCRIPTION
Bundle of fixes around the emulator settings page reported by users.

## Stale games in the emulator library tab
Re-scanning a ROM folder only ever upserted the games it found, so a game whose files were moved or deleted kept its stale disc paths and stayed in the library tab no matter how many rescans. Now a scan reconciles afterwards and soft-deletes games whose disc files are no longer present in the scanned folders. It keys on disk presence rather than match success, so a transient SKU sniff miss cannot wipe a still-valid game.

## Classics launch with a moved or removed disc
Launch resolved a disc path but never checked the file still existed, so a moved or deleted ROM spawned the emulator into a broken state with no feedback. It now verifies the disc exists and surfaces NO_DISC otherwise. The coded launch errors were also thrown without any logging, which made user reports impossible to diagnose, so each one now logs its code and context.

## Concurrent memory card backups
Backup progress was a single active card plus a single progress value, so starting a second card's backup overwrote the first and the bar flickered between the two as their events interleaved. Progress is now keyed by card file path, so concurrent backups each render their own bar.

## Download sources modal spacing
With a single source above the divider the grid stretched its rows to fill the modal body, leaving a large gap before the install guide. Rows now pack to the top so spacing is consistent regardless of source count.

## Cloud save connector lines
The connector assumed a single row of cards, so once they wrapped to a second row the lower rows lost their lines. It now draws one bus per row with a central trunk linking them to the console, centers the cards under the console, and widens the row gap so each bus has room.

## Testing
- typecheck and lint pass
