### PR TITLE
style: restore modal selection color and region flags on save cards

### DIFF
--- a/src/renderer/src/helpers.ts
+++ b/src/renderer/src/helpers.ts
@@ -263,6 +263,17 @@ export const getSkuRegion = (sku: string): SkuRegion | null => {
   return SKU_REGION_MAP[prefix] ?? null;
 };
 
+export const getSkuRegionFromSaveIdentity = (
+  saveIdentity: string | null | undefined
+): SkuRegion | null => {
+  if (!saveIdentity) return null;
+  const cleaned = saveIdentity
+    .trim()
+    .toUpperCase()
+    .replace(/^B[A-Z](?=[A-Z]{4}[-_ .]?\d{5})/, "");
+  return getSkuRegion(cleaned);
+};
+
 export const getSkuRegionFlag = (region: SkuRegion): string =>
   SKU_REGION_FLAGS[region];
 

--- a/src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.scss
+++ b/src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.scss
@@ -136,6 +136,16 @@
     filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.35));
   }
 
+  &__card-flag {
+    width: 20px;
+    height: auto;
+    border-radius: 2px;
+    flex-shrink: 0;
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+  }
+
   &__card-title {
     font-size: 15px;
     font-weight: 600;

--- a/src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.tsx
+++ b/src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.tsx
@@ -15,6 +15,11 @@ import {
 } from "@primer/octicons-react";
 
 import { Button, ConfirmationModal } from "@renderer/components";
+import {
+  getSkuRegion,
+  getSkuRegionFlag,
+  getSkuRegionFromSaveIdentity,
+} from "@renderer/helpers";
 import { useToast, useUserDetails } from "@renderer/hooks";
 import type {
   EmulationCloudSave,
@@ -192,6 +197,7 @@ export function GameEmulationSaves({
                 {localSaves.map((record) => {
                   const key = recordKey(record);
                   const uploading = uploadingKey === key;
+                  const region = record.sku ? getSkuRegion(record.sku) : null;
                   return (
                     <li key={key} className="game-emulation-saves__card">
                       <div className="game-emulation-saves__card-head">
@@ -200,6 +206,14 @@ export function GameEmulationSaves({
                           src={hydraSaveCard}
                           alt=""
                         />
+                        {region && (
+                          <img
+                            className="game-emulation-saves__card-flag"
+                            src={getSkuRegionFlag(region)}
+                            alt={region}
+                            title={region}
+                          />
+                        )}
                         <span
                           className="game-emulation-saves__card-title"
                           title={record.title ?? record.folderName}
@@ -262,69 +276,82 @@ export function GameEmulationSaves({
                 {t("game_cloud_group_title")}
               </h3>
               <ul className="game-emulation-saves__list">
-                {cloudSaves.map((save) => (
-                  <li key={save.id} className="game-emulation-saves__card">
-                    <div className="game-emulation-saves__card-head">
-                      <img
-                        className="game-emulation-saves__card-icon"
-                        src={hydraSaveCard}
-                        alt=""
-                      />
-                      <span
-                        className="game-emulation-saves__card-title"
-                        title={save.label ?? save.fileName}
-                      >
-                        {save.label ?? save.fileName}
-                      </span>
-                      <button
-                        type="button"
-                        className="game-emulation-saves__icon-button"
-                        onClick={() => setRenameFor(save)}
-                        aria-label={t("cloud_rename_title")}
-                      >
-                        <PencilIcon size={14} />
-                      </button>
-                      <small className="game-emulation-saves__card-size">
-                        {formatBytes(save.artifactLengthInBytes)}
-                      </small>
-                    </div>
-
-                    <div className="game-emulation-saves__card-body">
-                      <div className="game-emulation-saves__card-meta">
-                        <span title={save.fileName}>
-                          <CodeIcon size={14} />
-                          {save.fileName}
-                        </span>
-                        <span>
-                          <DeviceDesktopIcon size={14} />
-                          {save.hostname ?? "—"}
-                        </span>
-                        <span>
-                          <ClockIcon size={14} />
-                          {formatDate(save.localLastModifiedAt)}
-                        </span>
-                      </div>
-
-                      <div className="game-emulation-saves__card-actions">
-                        <Button
-                          theme="outline"
-                          onClick={() => setRestoreFor(save)}
+                {cloudSaves.map((save) => {
+                  const region = getSkuRegionFromSaveIdentity(
+                    save.saveIdentity
+                  );
+                  return (
+                    <li key={save.id} className="game-emulation-saves__card">
+                      <div className="game-emulation-saves__card-head">
+                        <img
+                          className="game-emulation-saves__card-icon"
+                          src={hydraSaveCard}
+                          alt=""
+                        />
+                        {region && (
+                          <img
+                            className="game-emulation-saves__card-flag"
+                            src={getSkuRegionFlag(region)}
+                            alt={region}
+                            title={region}
+                          />
+                        )}
+                        <span
+                          className="game-emulation-saves__card-title"
+                          title={save.label ?? save.fileName}
                         >
-                          <HistoryIcon size={14} />
-                          <span>{t("cloud_restore")}</span>
-                        </Button>
+                          {save.label ?? save.fileName}
+                        </span>
                         <button
                           type="button"
-                          className="game-emulation-saves__delete"
-                          onClick={() => setDeleteFor(save)}
-                          aria-label={t("cloud_delete")}
+                          className="game-emulation-saves__icon-button"
+                          onClick={() => setRenameFor(save)}
+                          aria-label={t("cloud_rename_title")}
                         >
-                          <TrashIcon size={16} />
+                          <PencilIcon size={14} />
                         </button>
+                        <small className="game-emulation-saves__card-size">
+                          {formatBytes(save.artifactLengthInBytes)}
+                        </small>
                       </div>
-                    </div>
-                  </li>
-                ))}
+
+                      <div className="game-emulation-saves__card-body">
+                        <div className="game-emulation-saves__card-meta">
+                          <span title={save.fileName}>
+                            <CodeIcon size={14} />
+                            {save.fileName}
+                          </span>
+                          <span>
+                            <DeviceDesktopIcon size={14} />
+                            {save.hostname ?? "—"}
+                          </span>
+                          <span>
+                            <ClockIcon size={14} />
+                            {formatDate(save.localLastModifiedAt)}
+                          </span>
+                        </div>
+
+                        <div className="game-emulation-saves__card-actions">
+                          <Button
+                            theme="outline"
+                            onClick={() => setRestoreFor(save)}
+                          >
+                            <HistoryIcon size={14} />
+                            <span>{t("cloud_restore")}</span>
+                          </Button>
+                          <button
+                            type="button"
+                            className="game-emulation-saves__delete"
+                            onClick={() => setDeleteFor(save)}
+                            aria-label={t("cloud_delete")}
+                          >
+                            <TrashIcon size={16} />
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
               </ul>
             </section>
           )}

--- a/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
+++ b/src/renderer/src/pages/settings/emulation/cloud-saves-section.tsx
@@ -13,6 +13,10 @@ import {
 
 import { Button, ConfirmationModal } from "@renderer/components";
 import { DropdownMenu } from "@renderer/components/dropdown-menu/dropdown-menu";
+import {
+  getSkuRegionFlag,
+  getSkuRegionFromSaveIdentity,
+} from "@renderer/helpers";
 import { useToast, useUserDetails } from "@renderer/hooks";
 import { useCloudConnector } from "@renderer/hooks/use-cloud-connector";
 import { useSubscription } from "@renderer/hooks/use-subscription";
@@ -184,6 +188,7 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
           <div className="emulator-detail__cloud-grid" ref={gridRef}>
             {saves.map((save) => {
               const name = save.label ?? save.fileName;
+              const region = getSkuRegionFromSaveIdentity(save.saveIdentity);
               return (
                 <div key={save.id} className="emulator-detail__cloud-card">
                   <div className="emulator-detail__cloud-card-top">
@@ -225,12 +230,22 @@ export function CloudSavesSection({ config, refreshKey }: Readonly<Props>) {
                     </DropdownMenu>
                   </div>
 
-                  <span
-                    className="emulator-detail__cloud-card-title"
-                    title={name}
-                  >
-                    {name}
-                  </span>
+                  <div className="emulator-detail__cloud-card-title-row">
+                    {region && (
+                      <img
+                        className="emulator-detail__cloud-card-flag"
+                        src={getSkuRegionFlag(region)}
+                        alt={region}
+                        title={region}
+                      />
+                    )}
+                    <span
+                      className="emulator-detail__cloud-card-title"
+                      title={name}
+                    >
+                      {name}
+                    </span>
+                  </div>
 
                   <div className="emulator-detail__cloud-card-info">
                     <span title={save.hostname ?? undefined}>

--- a/src/renderer/src/pages/settings/emulation/emulation-save-modals.scss
+++ b/src/renderer/src/pages/settings/emulation/emulation-save-modals.scss
@@ -30,7 +30,7 @@
     cursor: pointer;
 
     &--selected {
-      border-color: #f6746b;
+      border-color: #fafafa;
     }
   }
 

--- a/src/renderer/src/pages/settings/emulation/emulator-detail.scss
+++ b/src/renderer/src/pages/settings/emulation/emulator-detail.scss
@@ -804,8 +804,27 @@
     transform: rotate(90deg);
   }
 
-  &__cloud-card-title {
+  &__cloud-card-title-row {
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  &__cloud-card-flag {
+    width: 20px;
+    height: auto;
+    border-radius: 2px;
+    flex-shrink: 0;
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+  }
+
+  &__cloud-card-title {
+    flex: 0 1 auto;
+    min-width: 0;
     font-size: 18px;
     font-weight: 700;
     letter-spacing: 0.18px;


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

A couple of small tweaks around emulation cloud saves.

The classics cloud-save restore modal used a red border to mark the selected memory card, which read like an error state. Switched it to white so it just looks like a normal selection.

Also started showing the region flag on emulation save cards in the two places that were missing it, matching what we already do in the memory cards tab and on the game page. The flag comes from the SKU: cloud saves derive it from the `saveIdentity` returned by `/profile/emulation-saves` (a new `getSkuRegionFromSaveIdentity` helper strips the leading `B<region>` marker and any trailing game suffix, reusing the existing region mapping), and local memory-card saves use their already-normalized `sku`.

Covered cards:
- Emulator settings > memory card backups > cloud saves
- Game options modal > Hydra Cloud tab (both the cloud saves and the "your memory cards" local saves)
