### PR TITLE
fix: detect emulator BIOS by content instead of file extension

### DIFF
--- a/src/main/services/emulators/bios-detection.ts
+++ b/src/main/services/emulators/bios-detection.ts
@@ -103,7 +103,7 @@ export const resolvePs2BiosDirs = async (
   return Array.from(new Set(dirs)).filter((dir) => existsSync(dir));
 };
 
-const PS1_BIOS_SIGNATURE = Buffer.from("Sony Computer Entertainment Inc.");
+const PS1_BIOS_SIGNATURE = Buffer.from("Sony Computer Entertainment");
 const PS2_ROMDIR_RESET = Buffer.from("RESET\0");
 const PS2_ROMDIR_ROMVER = Buffer.from("ROMVER");
 const PS2_ROMDIR_ENTRY_BYTES = 16;

--- a/src/main/services/emulators/bios-detection.ts
+++ b/src/main/services/emulators/bios-detection.ts
@@ -105,32 +105,10 @@ export const resolvePs2BiosDirs = async (
 };
 
 const PS1_BIOS_SIGNATURE = Buffer.from("Sony Computer Entertainment");
-const PS2_ROMDIR_RESET = Buffer.from("RESET\0");
-const PS2_ROMDIR_ROMVER = Buffer.from("ROMVER");
-const PS2_ROMDIR_ENTRY_BYTES = 16;
-const PS2_ROMDIR_NAME_BYTES = 10;
+const PS2_RESET = Buffer.from("RESET");
+const PS2_ROMVER = Buffer.from("ROMVER");
 const PS2_HEADER_BYTES = 0x80000;
 const PS1_HEADER_BYTES = 0x10000;
-
-const ps2RomdirHasRomver = (head: Buffer): boolean => {
-  for (
-    let start = head.indexOf(PS2_ROMDIR_RESET);
-    start >= 0;
-    start = head.indexOf(PS2_ROMDIR_RESET, start + 1)
-  ) {
-    for (
-      let off = start;
-      off + PS2_ROMDIR_ENTRY_BYTES <= head.length;
-      off += PS2_ROMDIR_ENTRY_BYTES
-    ) {
-      const name = head.subarray(off, off + PS2_ROMDIR_NAME_BYTES);
-      const end = name.indexOf(0);
-      if (end <= 0) break;
-      if (name.subarray(0, end).equals(PS2_ROMDIR_ROMVER)) return true;
-    }
-  }
-  return false;
-};
 
 const fileLooksLikeBios = async (
   filePath: string,
@@ -145,7 +123,7 @@ const fileLooksLikeBios = async (
     const head = buffer.subarray(0, bytesRead);
 
     if (system === "ps1") return head.includes(PS1_BIOS_SIGNATURE);
-    return ps2RomdirHasRomver(head);
+    return head.includes(PS2_RESET) && head.includes(PS2_ROMVER);
   } catch {
     return false;
   } finally {

--- a/src/main/services/emulators/bios-detection.ts
+++ b/src/main/services/emulators/bios-detection.ts
@@ -18,7 +18,6 @@ import {
  * or downloads BIOS files; it only detects whether the user has provided one.
  */
 
-const BIOS_EXTENSIONS = new Set([".bin", ".rom"]);
 const SECTION_RE = /^\s*\[([^\]]+)\]\s*$/;
 const DUCKSTATION_DIR_RE = /^\s*SearchDirectory\s*=(.+)$/i;
 const PCSX2_DIR_RE = /^\s*Bios\s*=(.+)$/i;
@@ -104,10 +103,54 @@ export const resolvePs2BiosDirs = async (
   return Array.from(new Set(dirs)).filter((dir) => existsSync(dir));
 };
 
+const PS1_BIOS_SIGNATURE = Buffer.from("Sony Computer Entertainment Inc.");
+const PS2_ROMDIR_RESET = Buffer.from("RESET\0");
+const PS2_ROMDIR_NEXT = Buffer.from("ROMDIR");
+const PS2_ROMDIR_ENTRY_BYTES = 16;
+const PS2_HEADER_BYTES = 0x40000;
+const PS1_HEADER_BYTES = 0x10000;
+
+const fileLooksLikeBios = async (
+  filePath: string,
+  system: "ps1" | "ps2"
+): Promise<boolean> => {
+  let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
+  try {
+    handle = await fs.open(filePath, "r");
+    const length = system === "ps2" ? PS2_HEADER_BYTES : PS1_HEADER_BYTES;
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, 0);
+    const head = buffer.subarray(0, bytesRead);
+
+    if (system === "ps1") return head.includes(PS1_BIOS_SIGNATURE);
+
+    for (
+      let i = head.indexOf(PS2_ROMDIR_RESET);
+      i >= 0;
+      i = head.indexOf(PS2_ROMDIR_RESET, i + 1)
+    ) {
+      const next = i + PS2_ROMDIR_ENTRY_BYTES;
+      if (
+        head
+          .subarray(next, next + PS2_ROMDIR_NEXT.length)
+          .equals(PS2_ROMDIR_NEXT)
+      )
+        return true;
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    await handle?.close();
+  }
+};
+
 const hasPlausibleBios = async (
   dir: string,
-  limits: { min: number; max: number }
+  system: "ps1" | "ps2"
 ): Promise<boolean> => {
+  const limits = SIZE_LIMITS[system];
+
   let entries: import("node:fs").Dirent[];
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
@@ -116,14 +159,20 @@ const hasPlausibleBios = async (
   }
 
   for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    if (!BIOS_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) continue;
+    if (entry.isDirectory()) continue;
+    const filePath = path.join(dir, entry.name);
+
+    let size: number;
     try {
-      const stat = await fs.stat(path.join(dir, entry.name));
-      if (stat.size >= limits.min && stat.size <= limits.max) return true;
+      const stat = await fs.stat(filePath);
+      if (!stat.isFile()) continue;
+      size = stat.size;
     } catch {
-      // unreadable, keep looking
+      continue;
     }
+
+    if (size < limits.min || size > limits.max) continue;
+    if (await fileLooksLikeBios(filePath, system)) return true;
   }
   return false;
 };
@@ -133,7 +182,7 @@ export const isPs1BiosInstalled = async (
 ): Promise<boolean> => {
   const dirs = await resolvePs1BiosDirs(executablePath);
   for (const dir of dirs) {
-    if (await hasPlausibleBios(dir, SIZE_LIMITS.ps1)) return true;
+    if (await hasPlausibleBios(dir, "ps1")) return true;
   }
   return false;
 };
@@ -143,7 +192,7 @@ export const isPs2BiosInstalled = async (
 ): Promise<boolean> => {
   const dirs = await resolvePs2BiosDirs(executablePath);
   for (const dir of dirs) {
-    if (await hasPlausibleBios(dir, SIZE_LIMITS.ps2)) return true;
+    if (await hasPlausibleBios(dir, "ps2")) return true;
   }
   return false;
 };

--- a/src/main/services/emulators/bios-detection.ts
+++ b/src/main/services/emulators/bios-detection.ts
@@ -23,12 +23,13 @@ const DUCKSTATION_DIR_RE = /^\s*SearchDirectory\s*=(.+)$/i;
 const PCSX2_DIR_RE = /^\s*Bios\s*=(.+)$/i;
 
 const PS1_BIOS_MIN_BYTES = 256 * 1024;
-const PS2_BIOS_MIN_BYTES = 3 * 1024 * 1024;
-const BIOS_MAX_BYTES = 16 * 1024 * 1024;
+const PS1_BIOS_MAX_BYTES = 16 * 1024 * 1024;
+const PS2_BIOS_MIN_BYTES = 4 * 1024 * 1024;
+const PS2_BIOS_MAX_BYTES = 8 * 1024 * 1024;
 
 const SIZE_LIMITS: Record<"ps1" | "ps2", { min: number; max: number }> = {
-  ps1: { min: PS1_BIOS_MIN_BYTES, max: BIOS_MAX_BYTES },
-  ps2: { min: PS2_BIOS_MIN_BYTES, max: BIOS_MAX_BYTES },
+  ps1: { min: PS1_BIOS_MIN_BYTES, max: PS1_BIOS_MAX_BYTES },
+  ps2: { min: PS2_BIOS_MIN_BYTES, max: PS2_BIOS_MAX_BYTES },
 };
 
 const readIniBiosDir = async (

--- a/src/main/services/emulators/bios-detection.ts
+++ b/src/main/services/emulators/bios-detection.ts
@@ -105,10 +105,31 @@ export const resolvePs2BiosDirs = async (
 
 const PS1_BIOS_SIGNATURE = Buffer.from("Sony Computer Entertainment Inc.");
 const PS2_ROMDIR_RESET = Buffer.from("RESET\0");
-const PS2_ROMDIR_NEXT = Buffer.from("ROMDIR");
+const PS2_ROMDIR_ROMVER = Buffer.from("ROMVER");
 const PS2_ROMDIR_ENTRY_BYTES = 16;
-const PS2_HEADER_BYTES = 0x40000;
+const PS2_ROMDIR_NAME_BYTES = 10;
+const PS2_HEADER_BYTES = 0x80000;
 const PS1_HEADER_BYTES = 0x10000;
+
+const ps2RomdirHasRomver = (head: Buffer): boolean => {
+  for (
+    let start = head.indexOf(PS2_ROMDIR_RESET);
+    start >= 0;
+    start = head.indexOf(PS2_ROMDIR_RESET, start + 1)
+  ) {
+    for (
+      let off = start;
+      off + PS2_ROMDIR_ENTRY_BYTES <= head.length;
+      off += PS2_ROMDIR_ENTRY_BYTES
+    ) {
+      const name = head.subarray(off, off + PS2_ROMDIR_NAME_BYTES);
+      const end = name.indexOf(0);
+      if (end <= 0) break;
+      if (name.subarray(0, end).equals(PS2_ROMDIR_ROMVER)) return true;
+    }
+  }
+  return false;
+};
 
 const fileLooksLikeBios = async (
   filePath: string,
@@ -123,21 +144,7 @@ const fileLooksLikeBios = async (
     const head = buffer.subarray(0, bytesRead);
 
     if (system === "ps1") return head.includes(PS1_BIOS_SIGNATURE);
-
-    for (
-      let i = head.indexOf(PS2_ROMDIR_RESET);
-      i >= 0;
-      i = head.indexOf(PS2_ROMDIR_RESET, i + 1)
-    ) {
-      const next = i + PS2_ROMDIR_ENTRY_BYTES;
-      if (
-        head
-          .subarray(next, next + PS2_ROMDIR_NEXT.length)
-          .equals(PS2_ROMDIR_NEXT)
-      )
-        return true;
-    }
-    return false;
+    return ps2RomdirHasRomver(head);
   } catch {
     return false;
   } finally {


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## What

BIOS detection in the emulator setup now validates files by their contents instead of their extension.

## Why

A user reported that his PS2 BIOS worked fine in PCSX2 but Hydra kept saying the BIOS was missing and refused to launch any game (`BIOS_NOT_CONFIGURED`). His BIOS folder contained a valid dump named `SCPH-90001_BIOS_V18_USA_230.ROM0`, with no `.bin`/`.rom` file at all.

The scan only accepted files ending in `.bin` or `.rom`. PCSX2 and DuckStation ignore the extension entirely and read the actual file contents, so anything dumped as `.ROM0` (or any other naming) gets picked up by the emulator but was rejected by us.

## How

- Removed the `.bin`/`.rom` allowlist.
- Validate by content the way the emulators do: the PS2 romdir signature (`RESET`/`ROMDIR` records) and the PS1 copyright string, gated behind the existing size range as a cheap prefilter.
- Skip only directories and `stat` each entry rather than trusting the `readdir` dirent type, so symlinked BIOS files are no longer dropped before the check runs.

## Testing

Verified against the reported BIOS set:
- the `.ROM0`-only folder is now detected
- a folder containing only a random 4MB file is correctly rejected (content check, not just size)
- the auxiliary `.MEC`/`.NVM`/`.DIFF`/`.INF` files are skipped
- existing `.bin` dumps and PS1 BIOS still detected
