### PR TITLE
fix: add window controls to auth window on linux

### DIFF
--- a/src/main/events/auth/auth-window-controls.ts
+++ b/src/main/events/auth/auth-window-controls.ts
@@ -1,0 +1,10 @@
+import { WindowManager } from "@main/services";
+import { ipcMain } from "electron";
+
+ipcMain.handle("minimizeAuthWindow", () => {
+  WindowManager.minimizeAuthWindow();
+});
+
+ipcMain.handle("closeAuthWindow", () => {
+  WindowManager.closeAuthWindow();
+});

--- a/src/main/events/auth/index.ts
+++ b/src/main/events/auth/index.ts
@@ -1,3 +1,4 @@
+import "./auth-window-controls";
 import "./get-session-hash";
 import "./open-auth-window";
 import "./sign-out";

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -517,6 +517,7 @@ export class WindowManager {
   private static readonly AUTH_WINDOW_WIDTH = 600;
   private static readonly AUTH_WINDOW_HEIGHT = 640;
   private static readonly AUTH_WINDOW_TITLE_BAR_HEIGHT = 34;
+  private static readonly AUTH_WINDOW_BORDER = 1;
 
   private static bindAuthNavigation(
     contents: Electron.WebContents,
@@ -593,8 +594,11 @@ export class WindowManager {
     authUrl: string
   ) {
     const authWindow = new BrowserWindow({
-      width: this.AUTH_WINDOW_WIDTH,
-      height: this.AUTH_WINDOW_HEIGHT + this.AUTH_WINDOW_TITLE_BAR_HEIGHT,
+      width: this.AUTH_WINDOW_WIDTH + this.AUTH_WINDOW_BORDER * 2,
+      height:
+        this.AUTH_WINDOW_HEIGHT +
+        this.AUTH_WINDOW_TITLE_BAR_HEIGHT +
+        this.AUTH_WINDOW_BORDER * 2,
       backgroundColor: "#1c1c1c",
       parent: parentWindow,
       modal: true,
@@ -622,8 +626,8 @@ export class WindowManager {
 
     authWindow.contentView.addChildView(authView);
     authView.setBounds({
-      x: 0,
-      y: this.AUTH_WINDOW_TITLE_BAR_HEIGHT,
+      x: this.AUTH_WINDOW_BORDER,
+      y: this.AUTH_WINDOW_BORDER + this.AUTH_WINDOW_TITLE_BAR_HEIGHT,
       width: this.AUTH_WINDOW_WIDTH,
       height: this.AUTH_WINDOW_HEIGHT,
     });

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -16,6 +16,7 @@ import {
   MenuItem,
   MenuItemConstructorOptions,
   Tray,
+  WebContentsView,
   app,
   nativeImage,
   screen,
@@ -39,6 +40,7 @@ export class WindowManager {
   public static gameLauncherWindow: Electron.BrowserWindow | null = null;
   private static bigPicture: Electron.BrowserWindow | null = null;
   private static friendsWindow: Electron.BrowserWindow | null = null;
+  private static authWindow: Electron.BrowserWindow | null = null;
   private static deferredMainMaximize = false;
 
   private static readonly editorWindows: Map<string, BrowserWindow> = new Map();
@@ -512,62 +514,157 @@ export class WindowManager {
     this.mainWindow?.webContents.send("on-open-add-friend-modal");
   }
 
+  private static readonly AUTH_WINDOW_WIDTH = 600;
+  private static readonly AUTH_WINDOW_HEIGHT = 640;
+  private static readonly AUTH_WINDOW_TITLE_BAR_HEIGHT = 34;
+
+  private static bindAuthNavigation(
+    contents: Electron.WebContents,
+    closeWindow: () => void
+  ) {
+    contents.on("will-navigate", (_event, url) => {
+      if (url.startsWith("hydralauncher://auth")) {
+        closeWindow();
+
+        HydraApi.handleExternalAuth(url);
+        return;
+      }
+
+      if (url.startsWith("hydralauncher://update-account")) {
+        closeWindow();
+
+        WindowManager.sendToAppWindows("on-account-updated");
+      }
+    });
+  }
+
   public static openAuthWindow(page: AuthPage, searchParams: URLSearchParams) {
     const parentWindow =
       this.bigPicture && !this.bigPicture.isDestroyed()
         ? this.bigPicture
         : this.mainWindow;
 
-    if (parentWindow && !parentWindow.isDestroyed()) {
-      const authWindow = new BrowserWindow({
-        width: 600,
-        height: 640,
-        backgroundColor: "#1c1c1c",
-        parent: parentWindow,
-        modal: true,
-        show: false,
-        maximizable: false,
-        resizable: false,
-        minimizable: false,
-        webPreferences: {
-          sandbox: false,
-          nodeIntegrationInSubFrames: true,
-        },
-      });
+    if (!parentWindow || parentWindow.isDestroyed()) return;
 
-      authWindow.removeMenu();
+    const authUrl = `${import.meta.env.MAIN_VITE_AUTH_URL}${page}?${searchParams.toString()}`;
 
-      if (!app.isPackaged) authWindow.webContents.openDevTools();
-
-      authWindow.loadURL(
-        `${import.meta.env.MAIN_VITE_AUTH_URL}${page}?${searchParams.toString()}`
-      );
-
-      authWindow.once("ready-to-show", () => {
-        authWindow.show();
-      });
-
-      authWindow.once("closed", () => {
-        if (!parentWindow.isDestroyed()) {
-          parentWindow.focus();
-        }
-      });
-
-      authWindow.webContents.on("will-navigate", (_event, url) => {
-        if (url.startsWith("hydralauncher://auth")) {
-          authWindow.close();
-
-          HydraApi.handleExternalAuth(url);
-          return;
-        }
-
-        if (url.startsWith("hydralauncher://update-account")) {
-          authWindow.close();
-
-          WindowManager.sendToAppWindows("on-account-updated");
-        }
-      });
+    if (process.platform === "linux") {
+      this.openLinuxAuthWindow(parentWindow, authUrl);
+      return;
     }
+
+    const authWindow = new BrowserWindow({
+      width: this.AUTH_WINDOW_WIDTH,
+      height: this.AUTH_WINDOW_HEIGHT,
+      backgroundColor: "#1c1c1c",
+      parent: parentWindow,
+      modal: true,
+      show: false,
+      maximizable: false,
+      resizable: false,
+      minimizable: false,
+      webPreferences: {
+        sandbox: false,
+        nodeIntegrationInSubFrames: true,
+      },
+    });
+
+    authWindow.removeMenu();
+
+    if (!app.isPackaged) authWindow.webContents.openDevTools();
+
+    authWindow.loadURL(authUrl);
+
+    authWindow.once("ready-to-show", () => {
+      authWindow.show();
+    });
+
+    authWindow.once("closed", () => {
+      if (!parentWindow.isDestroyed()) {
+        parentWindow.focus();
+      }
+    });
+
+    this.bindAuthNavigation(authWindow.webContents, () => authWindow.close());
+  }
+
+  private static openLinuxAuthWindow(
+    parentWindow: Electron.BrowserWindow,
+    authUrl: string
+  ) {
+    // Tiling compositors (Niri, Hyprland, Sway, i3) draw no native titlebar, so
+    // a native-frame auth window would have no minimize or close controls. Mirror
+    // the main window and render our own titlebar; the auth page itself is remote
+    // content, so it lives in a WebContentsView below the strip instead of in the
+    // window's own webContents.
+    const authWindow = new BrowserWindow({
+      width: this.AUTH_WINDOW_WIDTH,
+      height: this.AUTH_WINDOW_HEIGHT + this.AUTH_WINDOW_TITLE_BAR_HEIGHT,
+      backgroundColor: "#1c1c1c",
+      parent: parentWindow,
+      modal: true,
+      show: false,
+      maximizable: false,
+      resizable: false,
+      frame: false,
+      icon,
+      webPreferences: {
+        preload: path.join(__dirname, "../preload/index.mjs"),
+        sandbox: false,
+      },
+    });
+
+    this.authWindow = authWindow;
+
+    authWindow.removeMenu();
+
+    const authView = new WebContentsView({
+      webPreferences: {
+        sandbox: false,
+        nodeIntegrationInSubFrames: true,
+      },
+    });
+
+    authWindow.contentView.addChildView(authView);
+    authView.setBounds({
+      x: 0,
+      y: this.AUTH_WINDOW_TITLE_BAR_HEIGHT,
+      width: this.AUTH_WINDOW_WIDTH,
+      height: this.AUTH_WINDOW_HEIGHT,
+    });
+
+    this.loadWindowURL(authWindow, "auth-window");
+    authView.webContents.loadURL(authUrl);
+
+    if (!app.isPackaged) authView.webContents.openDevTools();
+
+    authWindow.once("ready-to-show", () => {
+      authWindow.show();
+    });
+
+    authWindow.once("closed", () => {
+      this.authWindow = null;
+      if (!parentWindow.isDestroyed()) {
+        parentWindow.focus();
+      }
+    });
+
+    this.bindAuthNavigation(authView.webContents, () => {
+      if (!authWindow.isDestroyed()) authWindow.close();
+    });
+  }
+
+  public static minimizeAuthWindow() {
+    if (this.authWindow && !this.authWindow.isDestroyed()) {
+      this.authWindow.minimize();
+    }
+  }
+
+  public static closeAuthWindow() {
+    if (this.authWindow && !this.authWindow.isDestroyed()) {
+      this.authWindow.close();
+    }
+    this.authWindow = null;
   }
 
   private static readonly NOTIFICATION_WINDOW_WIDTH = 360;

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -518,7 +518,6 @@ export class WindowManager {
   private static readonly AUTH_WINDOW_HEIGHT = 640;
   private static readonly AUTH_WINDOW_TITLE_BAR_HEIGHT = 34;
   private static readonly AUTH_WINDOW_BORDER = 1;
-  private static readonly AUTH_WINDOW_BORDER_RADIUS = 8;
 
   private static bindAuthNavigation(
     contents: Electron.WebContents,
@@ -607,9 +606,7 @@ export class WindowManager {
       resizable: false,
       frame: false,
       icon,
-      ...(isLinuxWayland
-        ? { transparent: true, backgroundColor: "#00000000" }
-        : { backgroundColor: "#1c1c1c" }),
+      backgroundColor: "#1c1c1c",
       webPreferences: {
         preload: path.join(__dirname, "../preload/index.mjs"),
         sandbox: false,
@@ -634,7 +631,6 @@ export class WindowManager {
       width: this.AUTH_WINDOW_WIDTH,
       height: this.AUTH_WINDOW_HEIGHT,
     });
-    authView.setBorderRadius(this.AUTH_WINDOW_BORDER_RADIUS);
 
     this.loadWindowURL(authWindow, "auth-window");
     authView.webContents.loadURL(authUrl);

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -592,11 +592,6 @@ export class WindowManager {
     parentWindow: Electron.BrowserWindow,
     authUrl: string
   ) {
-    // Tiling compositors (Niri, Hyprland, Sway, i3) draw no native titlebar, so
-    // a native-frame auth window would have no minimize or close controls. Mirror
-    // the main window and render our own titlebar; the auth page itself is remote
-    // content, so it lives in a WebContentsView below the strip instead of in the
-    // window's own webContents.
     const authWindow = new BrowserWindow({
       width: this.AUTH_WINDOW_WIDTH,
       height: this.AUTH_WINDOW_HEIGHT + this.AUTH_WINDOW_TITLE_BAR_HEIGHT,
@@ -664,7 +659,6 @@ export class WindowManager {
     if (this.authWindow && !this.authWindow.isDestroyed()) {
       this.authWindow.close();
     }
-    this.authWindow = null;
   }
 
   private static readonly NOTIFICATION_WINDOW_WIDTH = 360;

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -518,6 +518,7 @@ export class WindowManager {
   private static readonly AUTH_WINDOW_HEIGHT = 640;
   private static readonly AUTH_WINDOW_TITLE_BAR_HEIGHT = 34;
   private static readonly AUTH_WINDOW_BORDER = 1;
+  private static readonly AUTH_WINDOW_BORDER_RADIUS = 8;
 
   private static bindAuthNavigation(
     contents: Electron.WebContents,
@@ -633,6 +634,7 @@ export class WindowManager {
       width: this.AUTH_WINDOW_WIDTH,
       height: this.AUTH_WINDOW_HEIGHT,
     });
+    authView.setBorderRadius(this.AUTH_WINDOW_BORDER_RADIUS);
 
     this.loadWindowURL(authWindow, "auth-window");
     authView.webContents.loadURL(authUrl);

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -599,7 +599,6 @@ export class WindowManager {
         this.AUTH_WINDOW_HEIGHT +
         this.AUTH_WINDOW_TITLE_BAR_HEIGHT +
         this.AUTH_WINDOW_BORDER * 2,
-      backgroundColor: "#1c1c1c",
       parent: parentWindow,
       modal: true,
       show: false,
@@ -607,6 +606,9 @@ export class WindowManager {
       resizable: false,
       frame: false,
       icon,
+      ...(isLinuxWayland
+        ? { transparent: true, backgroundColor: "#00000000" }
+        : { backgroundColor: "#1c1c1c" }),
       webPreferences: {
         preload: path.join(__dirname, "../preload/index.mjs"),
         sandbox: false,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1065,6 +1065,8 @@ contextBridge.exposeInMainWorld("electron", {
   signOut: () => ipcRenderer.invoke("signOut"),
   openAuthWindow: (page: AuthPage) =>
     ipcRenderer.invoke("openAuthWindow", page),
+  minimizeAuthWindow: () => ipcRenderer.invoke("minimizeAuthWindow"),
+  closeAuthWindow: () => ipcRenderer.invoke("closeAuthWindow"),
   getSessionHash: () => ipcRenderer.invoke("getSessionHash"),
   onSignIn: (cb: () => void) => {
     const listener = (_event: Electron.IpcRendererEvent) => cb();

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -751,6 +751,8 @@ declare global {
     getAuth: () => Promise<Auth | null>;
     signOut: () => Promise<void>;
     openAuthWindow: (page: AuthPage) => Promise<void>;
+    minimizeAuthWindow: () => Promise<void>;
+    closeAuthWindow: () => Promise<void>;
     getSessionHash: () => Promise<string | null>;
     onSignIn: (cb: () => void) => () => Electron.IpcRenderer;
     onAccountUpdated: (cb: () => void) => () => Electron.IpcRenderer;

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -37,6 +37,7 @@ import { AchievementNotification } from "./pages/achievements/notification/achie
 import { AchievementNotificationOverlay } from "./components/achievements/notification/achievement-notification-overlay";
 import GameLauncher from "./pages/game-launcher/game-launcher";
 import FriendsWindow from "./pages/friends-window/friends-window";
+import AuthWindow from "./pages/auth-window/auth-window";
 import BigPictureApp from "../../big-picture/src/app";
 import BigPictureCatalogue from "../../big-picture/src/pages/catalogue/catalogue";
 import BigPictureComponentLab from "../../big-picture/src/pages/component-lab/component-lab";
@@ -133,6 +134,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           />
           <Route path="/game-launcher" element={<GameLauncher />} />
           <Route path="/friends-window" element={<FriendsWindow />} />
+          <Route path="/auth-window" element={<AuthWindow />} />
 
           <Route path="/big-picture" element={<BigPictureApp />}>
             <Route index element={<BigPictureHome />} />

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -6,7 +6,7 @@ $auth-title-bar-height: 34px;
   height: 100vh;
   box-sizing: border-box;
   border: 1px solid globals.$border-color;
-  border-radius: 8px;
+  border-radius: 0 0 8px 8px;
   background-color: globals.$dark-background-color;
   overflow: hidden;
 

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -6,6 +6,8 @@ $auth-title-bar-height: 34px;
   height: 100vh;
   box-sizing: border-box;
   border: 1px solid globals.$border-color;
+  border-radius: 8px;
+  background-color: globals.$dark-background-color;
   overflow: hidden;
 
   &__title-bar {

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -6,7 +6,6 @@ $auth-title-bar-height: 34px;
   height: 100vh;
   box-sizing: border-box;
   border: 1px solid globals.$border-color;
-  border-radius: 0 0 8px 8px;
   background-color: globals.$dark-background-color;
   overflow: hidden;
 

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -1,16 +1,15 @@
 @use "../../scss/globals.scss";
 
+$auth-title-bar-height: 34px;
+
 .auth-window {
-  // The auth page itself is rendered in a WebContentsView below this strip, so
-  // this route only ever draws the 34px title bar that sits above it. The height
-  // must match WindowManager.AUTH_WINDOW_TITLE_BAR_HEIGHT.
   &__title-bar {
     position: relative;
     display: flex;
     align-items: center;
     width: 100%;
-    height: 34px;
-    min-height: 34px;
+    height: $auth-title-bar-height;
+    min-height: $auth-title-bar-height;
     padding: 0 0 0 calc(globals.$spacing-unit * 2);
     background-color: globals.$dark-background-color;
     border-bottom: 1px solid globals.$border-color;

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -3,6 +3,11 @@
 $auth-title-bar-height: 34px;
 
 .auth-window {
+  height: 100vh;
+  box-sizing: border-box;
+  border: 1px solid globals.$border-color;
+  overflow: hidden;
+
   &__title-bar {
     position: relative;
     display: flex;

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -1,0 +1,61 @@
+@use "../../scss/globals.scss";
+
+.auth-window {
+  // The auth page itself is rendered in a WebContentsView below this strip, so
+  // this route only ever draws the 34px title bar that sits above it. The height
+  // must match WindowManager.AUTH_WINDOW_TITLE_BAR_HEIGHT.
+  &__title-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 34px;
+    min-height: 34px;
+    padding: 0 0 0 calc(globals.$spacing-unit * 2);
+    background-color: globals.$dark-background-color;
+    border-bottom: 1px solid globals.$border-color;
+    -webkit-app-region: drag;
+    z-index: globals.$title-bar-z-index;
+
+    h4 {
+      margin: 0;
+      font-size: globals.$small-font-size;
+      font-weight: 500;
+      color: globals.$muted-color;
+    }
+  }
+
+  &__window-controls {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    margin-left: auto;
+    -webkit-app-region: no-drag;
+  }
+
+  &__window-control {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 100%;
+    padding: 0;
+    background: none;
+    border: none;
+    color: globals.$muted-color;
+    cursor: pointer;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.08);
+      color: #dadbe1;
+    }
+
+    &--close:hover {
+      background-color: globals.$error-color;
+      color: #ffffff;
+    }
+  }
+}

--- a/src/renderer/src/pages/auth-window/auth-window.scss
+++ b/src/renderer/src/pages/auth-window/auth-window.scss
@@ -55,7 +55,7 @@ $auth-title-bar-height: 34px;
       color 0.2s ease;
 
     &:hover {
-      background-color: rgba(255, 255, 255, 0.08);
+      background-color: #606060;
       color: #dadbe1;
     }
 

--- a/src/renderer/src/pages/auth-window/auth-window.tsx
+++ b/src/renderer/src/pages/auth-window/auth-window.tsx
@@ -9,28 +9,30 @@ export default function AuthWindow() {
   const { t } = useTranslation("header");
 
   return (
-    <header className="auth-window__title-bar">
-      <h4>Hydra</h4>
-      <div className="auth-window__window-controls">
-        <button
-          type="button"
-          className="auth-window__window-control"
-          onClick={() => electron.minimizeAuthWindow()}
-          title={t("minimize")}
-          aria-label={t("minimize")}
-        >
-          <DashIcon size={16} />
-        </button>
-        <button
-          type="button"
-          className="auth-window__window-control auth-window__window-control--close"
-          onClick={() => electron.closeAuthWindow()}
-          title={t("close")}
-          aria-label={t("close")}
-        >
-          <XIcon size={16} />
-        </button>
-      </div>
-    </header>
+    <div className="auth-window">
+      <header className="auth-window__title-bar">
+        <h4>Hydra</h4>
+        <div className="auth-window__window-controls">
+          <button
+            type="button"
+            className="auth-window__window-control"
+            onClick={() => electron.minimizeAuthWindow()}
+            title={t("minimize")}
+            aria-label={t("minimize")}
+          >
+            <DashIcon size={16} />
+          </button>
+          <button
+            type="button"
+            className="auth-window__window-control auth-window__window-control--close"
+            onClick={() => electron.closeAuthWindow()}
+            title={t("close")}
+            aria-label={t("close")}
+          >
+            <XIcon size={16} />
+          </button>
+        </div>
+      </header>
+    </div>
   );
 }

--- a/src/renderer/src/pages/auth-window/auth-window.tsx
+++ b/src/renderer/src/pages/auth-window/auth-window.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "react-i18next";
+import { DashIcon, XIcon } from "@primer/octicons-react";
+
+import "./auth-window.scss";
+
+const electron = globalThis.electron as Electron;
+
+export default function AuthWindow() {
+  const { t } = useTranslation("header");
+
+  return (
+    <header className="auth-window__title-bar">
+      <h4>Hydra</h4>
+      <div className="auth-window__window-controls">
+        <button
+          type="button"
+          className="auth-window__window-control"
+          onClick={() => electron.minimizeAuthWindow()}
+          title={t("minimize")}
+          aria-label={t("minimize")}
+        >
+          <DashIcon size={16} />
+        </button>
+        <button
+          type="button"
+          className="auth-window__window-control auth-window__window-control--close"
+          onClick={() => electron.closeAuthWindow()}
+          title={t("close")}
+          aria-label={t("close")}
+        >
+          <XIcon size={16} />
+        </button>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
Closes LBX-812.

On Linux the login window relied on native window decorations for minimize and close. On tiling compositors that draw no titlebar (Niri, Hyprland, Sway, i3) the modal had no usable controls, so users got stuck on it with no way to dismiss. This is the same gap the main window had before the custom-titlebar fix, the auth window just got missed.

The auth page is remote content we can't draw our own chrome into, so on Linux the window is now frameless with our own titlebar strip rendered on top, and the auth page is hosted in a WebContentsView below it. The redirect interception (`hydralauncher://auth`) moves to whichever webContents holds the page. Windows and macOS are untouched and keep the native frame.

Reuses the existing `header:minimize` / `header:close` translation keys, so no new strings.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.