### PR TITLE
fix: restore .exe selection in Linux executable pickers

### DIFF
--- a/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
@@ -3,6 +3,10 @@ import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { platformToSystem } from "@renderer/helpers";
+import {
+  LINUX_GAME_EXECUTABLE_EXTENSIONS,
+  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
+} from "@shared";
 import { useBigPictureToast } from "../../../../hooks";
 import {
   applyClassicsDiscUpdate,
@@ -401,18 +405,7 @@ export function useGameSettingsModalState({
         ? [
             {
               name: "Game executable",
-              extensions: [
-                "exe",
-                "lnk",
-                "bat",
-                "cmd",
-                "AppImage",
-                "sh",
-                "x86_64",
-                "x86",
-                "run",
-                "bin",
-              ],
+              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
             },
             { name: "All files", extensions: ["*"] },
           ]
@@ -421,7 +414,7 @@ export function useGameSettingsModalState({
           : [
               {
                 name: "Game executable",
-                extensions: ["exe", "lnk", "bat", "cmd"],
+                extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
               },
             ];
 

--- a/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
@@ -395,15 +395,40 @@ export function useGameSettingsModalState({
 
   const selectGameExecutable = useCallback(async () => {
     const downloadsPath = await getDownloadsPath();
+
+    const filters =
+      globalThis.window.electron.platform === "linux"
+        ? [
+            {
+              name: "Game executable",
+              extensions: [
+                "exe",
+                "lnk",
+                "bat",
+                "cmd",
+                "AppImage",
+                "sh",
+                "x86_64",
+                "x86",
+                "run",
+                "bin",
+              ],
+            },
+            { name: "All files", extensions: ["*"] },
+          ]
+        : globalThis.window.electron.platform === "darwin"
+          ? [{ name: "Game executable", extensions: ["app"] }]
+          : [
+              {
+                name: "Game executable",
+                extensions: ["exe", "lnk", "bat", "cmd"],
+              },
+            ];
+
     const { filePaths } = await globalThis.window.electron.showOpenDialog({
       properties: ["openFile"],
       defaultPath: downloadsPath,
-      filters: [
-        {
-          name: "Game executable",
-          extensions: ["exe", "lnk"],
-        },
-      ],
+      filters,
     });
 
     if (filePaths && filePaths.length > 0) {

--- a/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
@@ -3,10 +3,7 @@ import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { platformToSystem } from "@renderer/helpers";
-import {
-  LINUX_GAME_EXECUTABLE_EXTENSIONS,
-  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
-} from "@shared";
+import { getGameExecutableFilters } from "@shared";
 import { useBigPictureToast } from "../../../../hooks";
 import {
   applyClassicsDiscUpdate,
@@ -400,23 +397,13 @@ export function useGameSettingsModalState({
   const selectGameExecutable = useCallback(async () => {
     const downloadsPath = await getDownloadsPath();
 
-    const filters =
-      globalThis.window.electron.platform === "linux"
-        ? [
-            {
-              name: t("game_executable"),
-              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
-            },
-            { name: t("all_files"), extensions: ["*"] },
-          ]
-        : globalThis.window.electron.platform === "darwin"
-          ? [{ name: t("game_executable"), extensions: ["app"] }]
-          : [
-              {
-                name: t("game_executable"),
-                extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
-              },
-            ];
+    const filters = getGameExecutableFilters(
+      globalThis.window.electron.platform,
+      {
+        executable: t("game_executable"),
+        allFiles: t("all_files"),
+      }
+    );
 
     const { filePaths } = await globalThis.window.electron.showOpenDialog({
       properties: ["openFile"],

--- a/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
@@ -404,16 +404,16 @@ export function useGameSettingsModalState({
       globalThis.window.electron.platform === "linux"
         ? [
             {
-              name: "Game executable",
+              name: t("game_executable"),
               extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
             },
-            { name: "All files", extensions: ["*"] },
+            { name: t("all_files"), extensions: ["*"] },
           ]
         : globalThis.window.electron.platform === "darwin"
-          ? [{ name: "Game executable", extensions: ["app"] }]
+          ? [{ name: t("game_executable"), extensions: ["app"] }]
           : [
               {
-                name: "Game executable",
+                name: t("game_executable"),
                 extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
               },
             ];
@@ -429,7 +429,7 @@ export function useGameSettingsModalState({
     }
 
     return null;
-  }, [getDownloadsPath]);
+  }, [getDownloadsPath, t]);
 
   const handleChangeExecutableLocation = useCallback(async () => {
     if (!game) return;

--- a/src/renderer/src/components/sidebar/sidebar-adding-custom-game-modal.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-adding-custom-game-modal.tsx
@@ -9,6 +9,7 @@ import {
   buildGameDetailsPath,
   generateRandomGradient,
 } from "@renderer/helpers";
+import { LINUX_GAME_EXECUTABLE_EXTENSIONS } from "@shared";
 
 import "./sidebar-adding-custom-game-modal.scss";
 
@@ -36,20 +37,7 @@ export function SidebarAddingCustomGameModal({
         ? [
             {
               name: t("custom_game_modal_executable"),
-              extensions: [
-                "exe",
-                "msi",
-                "bat",
-                "cmd",
-                "AppImage",
-                "sh",
-                "x86_64",
-                "x86",
-                "run",
-                "bin",
-                "deb",
-                "rpm",
-              ],
+              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
             },
             { name: t("all_files", { ns: "game_details" }), extensions: ["*"] },
           ]

--- a/src/renderer/src/components/sidebar/sidebar-adding-custom-game-modal.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-adding-custom-game-modal.tsx
@@ -36,7 +36,20 @@ export function SidebarAddingCustomGameModal({
         ? [
             {
               name: t("custom_game_modal_executable"),
-              extensions: ["AppImage", "sh", "x86_64", "x86", "run", "bin"],
+              extensions: [
+                "exe",
+                "msi",
+                "bat",
+                "cmd",
+                "AppImage",
+                "sh",
+                "x86_64",
+                "x86",
+                "run",
+                "bin",
+                "deb",
+                "rpm",
+              ],
             },
             { name: t("all_files", { ns: "game_details" }), extensions: ["*"] },
           ]

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -27,11 +27,7 @@ import {
   GameDetailsContext,
   GameOptionsCategoryId,
 } from "./game-details.context.types";
-import {
-  LINUX_GAME_EXECUTABLE_EXTENSIONS,
-  SteamContentDescriptor,
-  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
-} from "@shared";
+import { getGameExecutableFilters, SteamContentDescriptor } from "@shared";
 
 export const gameDetailsContext = createContext<GameDetailsContext>({
   game: null,
@@ -424,23 +420,10 @@ export function GameDetailsContextProvider({
   const selectGameExecutable = async () => {
     const downloadsPath = await getDownloadsPath();
 
-    const filters =
-      window.electron.platform === "linux"
-        ? [
-            {
-              name: t("game_executable"),
-              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
-            },
-            { name: t("all_files"), extensions: ["*"] },
-          ]
-        : window.electron.platform === "darwin"
-          ? [{ name: t("game_executable"), extensions: ["app"] }]
-          : [
-              {
-                name: t("game_executable"),
-                extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
-              },
-            ];
+    const filters = getGameExecutableFilters(window.electron.platform, {
+      executable: t("game_executable"),
+      allFiles: t("all_files"),
+    });
 
     return window.electron
       .showOpenDialog({

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -420,10 +420,13 @@ export function GameDetailsContextProvider({
   const selectGameExecutable = async () => {
     const downloadsPath = await getDownloadsPath();
 
-    const filters = getGameExecutableFilters(window.electron.platform, {
-      executable: t("game_executable"),
-      allFiles: t("all_files"),
-    });
+    const filters = getGameExecutableFilters(
+      globalThis.window.electron.platform,
+      {
+        executable: t("game_executable"),
+        allFiles: t("all_files"),
+      }
+    );
 
     return window.electron
       .showOpenDialog({

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -425,7 +425,18 @@ export function GameDetailsContextProvider({
         ? [
             {
               name: t("game_executable"),
-              extensions: ["AppImage", "sh", "x86_64", "x86", "run", "bin"],
+              extensions: [
+                "exe",
+                "lnk",
+                "bat",
+                "cmd",
+                "AppImage",
+                "sh",
+                "x86_64",
+                "x86",
+                "run",
+                "bin",
+              ],
             },
             { name: t("all_files"), extensions: ["*"] },
           ]

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -27,7 +27,11 @@ import {
   GameDetailsContext,
   GameOptionsCategoryId,
 } from "./game-details.context.types";
-import { SteamContentDescriptor } from "@shared";
+import {
+  LINUX_GAME_EXECUTABLE_EXTENSIONS,
+  SteamContentDescriptor,
+  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
+} from "@shared";
 
 export const gameDetailsContext = createContext<GameDetailsContext>({
   game: null,
@@ -425,18 +429,7 @@ export function GameDetailsContextProvider({
         ? [
             {
               name: t("game_executable"),
-              extensions: [
-                "exe",
-                "lnk",
-                "bat",
-                "cmd",
-                "AppImage",
-                "sh",
-                "x86_64",
-                "x86",
-                "run",
-                "bin",
-              ],
+              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
             },
             { name: t("all_files"), extensions: ["*"] },
           ]
@@ -445,7 +438,7 @@ export function GameDetailsContextProvider({
           : [
               {
                 name: t("game_executable"),
-                extensions: ["exe", "lnk", "bat", "cmd"],
+                extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
               },
             ];
 

--- a/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
@@ -8,7 +8,13 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "@renderer/components";
-import { formatBytes, GAMEMODE_SITE_URL, MANGOHUD_SITE_URL } from "@shared";
+import {
+  formatBytes,
+  GAMEMODE_SITE_URL,
+  LINUX_GAME_EXECUTABLE_EXTENSIONS,
+  MANGOHUD_SITE_URL,
+  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
+} from "@shared";
 
 import type {
   CreateSteamShortcutOptions,
@@ -506,18 +512,7 @@ export function GameOptionsModal({
         ? [
             {
               name: t("game_executable"),
-              extensions: [
-                "exe",
-                "lnk",
-                "bat",
-                "cmd",
-                "AppImage",
-                "sh",
-                "x86_64",
-                "x86",
-                "run",
-                "bin",
-              ],
+              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
             },
             { name: t("all_files"), extensions: ["*"] },
           ]
@@ -526,7 +521,7 @@ export function GameOptionsModal({
           : [
               {
                 name: t("game_executable"),
-                extensions: ["exe", "lnk", "bat", "cmd"],
+                extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
               },
             ];
 

--- a/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
@@ -501,10 +501,39 @@ export function GameOptionsModal({
     const current = game.trackingExecutablePaths ?? [];
     if (current.length >= 2) return;
 
+    const filters =
+      globalThis.window.electron.platform === "linux"
+        ? [
+            {
+              name: t("game_executable"),
+              extensions: [
+                "exe",
+                "lnk",
+                "bat",
+                "cmd",
+                "AppImage",
+                "sh",
+                "x86_64",
+                "x86",
+                "run",
+                "bin",
+              ],
+            },
+            { name: t("all_files"), extensions: ["*"] },
+          ]
+        : globalThis.window.electron.platform === "darwin"
+          ? [{ name: t("game_executable"), extensions: ["app"] }]
+          : [
+              {
+                name: t("game_executable"),
+                extensions: ["exe", "lnk", "bat", "cmd"],
+              },
+            ];
+
     const { filePaths } = await globalThis.window.electron.showOpenDialog({
       properties: ["openFile"],
       defaultPath: game.executablePath ?? undefined,
-      filters: [{ name: t("game_executable"), extensions: ["exe"] }],
+      filters,
     });
 
     const path = filePaths?.[0];

--- a/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
@@ -11,9 +11,8 @@ import { Modal } from "@renderer/components";
 import {
   formatBytes,
   GAMEMODE_SITE_URL,
-  LINUX_GAME_EXECUTABLE_EXTENSIONS,
+  getGameExecutableFilters,
   MANGOHUD_SITE_URL,
-  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
 } from "@shared";
 
 import type {
@@ -507,23 +506,13 @@ export function GameOptionsModal({
     const current = game.trackingExecutablePaths ?? [];
     if (current.length >= 2) return;
 
-    const filters =
-      globalThis.window.electron.platform === "linux"
-        ? [
-            {
-              name: t("game_executable"),
-              extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS,
-            },
-            { name: t("all_files"), extensions: ["*"] },
-          ]
-        : globalThis.window.electron.platform === "darwin"
-          ? [{ name: t("game_executable"), extensions: ["app"] }]
-          : [
-              {
-                name: t("game_executable"),
-                extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
-              },
-            ];
+    const filters = getGameExecutableFilters(
+      globalThis.window.electron.platform,
+      {
+        executable: t("game_executable"),
+        allFiles: t("all_files"),
+      }
+    );
 
     const { filePaths } = await globalThis.window.electron.showOpenDialog({
       properties: ["openFile"],

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -86,5 +86,17 @@ export enum DownloadError {
 
 export const FILE_EXTENSIONS_TO_EXTRACT = [".rar", ".zip", ".7z"];
 
+export const WINDOWS_GAME_EXECUTABLE_EXTENSIONS = ["exe", "lnk", "bat", "cmd"];
+
+export const LINUX_GAME_EXECUTABLE_EXTENSIONS = [
+  ...WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
+  "AppImage",
+  "sh",
+  "x86_64",
+  "x86",
+  "run",
+  "bin",
+];
+
 export const GAMEMODE_SITE_URL = "https://github.com/FeralInteractive/gamemode";
 export const MANGOHUD_SITE_URL = "https://github.com/flightlessmango/MangoHud";

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -98,5 +98,32 @@ export const LINUX_GAME_EXECUTABLE_EXTENSIONS = [
   "bin",
 ];
 
+export const DARWIN_GAME_EXECUTABLE_EXTENSIONS = ["app"];
+
+export const getGameExecutableFilters = (
+  platform: string,
+  labels: { executable: string; allFiles: string }
+) => {
+  if (platform === "linux") {
+    return [
+      { name: labels.executable, extensions: LINUX_GAME_EXECUTABLE_EXTENSIONS },
+      { name: labels.allFiles, extensions: ["*"] },
+    ];
+  }
+
+  if (platform === "darwin") {
+    return [
+      {
+        name: labels.executable,
+        extensions: DARWIN_GAME_EXECUTABLE_EXTENSIONS,
+      },
+    ];
+  }
+
+  return [
+    { name: labels.executable, extensions: WINDOWS_GAME_EXECUTABLE_EXTENSIONS },
+  ];
+};
+
 export const GAMEMODE_SITE_URL = "https://github.com/FeralInteractive/gamemode";
 export const MANGOHUD_SITE_URL = "https://github.com/flightlessmango/MangoHud";


### PR DESCRIPTION
Fixes LBX-813.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

The recent change that added native Linux executable formats swapped the whole filter list instead of extending it, so `.exe`, `.lnk`, `.bat` and `.cmd` got dropped on Linux. Most games on Linux run through Wine/Proton and ship as `.exe`, so the file picker greyed them out, the executable path could never be set, and playtime tracking never kicked in.

Changes:
- Restore the Wine-runnable extensions next to the native Linux ones in the game executable and custom-game pickers.
- Make the tracking-executable picker and the Big Picture executable picker platform-aware, so native Linux binaries (`.sh`, `.AppImage`, `.x86_64`, etc.) can be selected there too instead of only `.exe`.
- Pull the per-OS game executable extension lists into `@shared` so the Linux list spreads the Windows one. Adding a Windows extension now carries over to Linux automatically and the arrays are no longer duplicated across the game details context, game options and Big Picture pickers.

All the game executable pickers now share the same source of truth: on Linux the filter lists both the Wine-runnable and native formats with an All files fallback, macOS lists `.app`, and Windows lists `.exe`/`.lnk`/`.bat`/`.cmd`. The custom-game picker keeps its own broader set since it also accepts installer formats (`.msi`, `.deb`, `.rpm`, `.dmg`).

Verified `yarn format`, `yarn lint` and `yarn typecheck` pass.