### PR TITLE
fix: restart http download when server ignores range header on resume

### DIFF
--- a/src/main/services/download/js-http-downloader.ts
+++ b/src/main/services/download/js-http-downloader.ts
@@ -353,7 +353,8 @@ export class JsHttpDownloader {
 
     const contentLength = response.headers.get("content-length");
     if (contentLength) {
-      this.fileSize = startByte + Number.parseInt(contentLength, 10);
+      const length = Number.parseInt(contentLength, 10);
+      this.fileSize = response.status === HTTP_OK ? length : startByte + length;
     }
   }
 
@@ -426,21 +427,18 @@ export class JsHttpDownloader {
       );
     }
 
-    let effectiveStartByte = startByte;
+    this.parseFileSize(response, startByte);
+
     const serverIgnoredRange = startByte > 0 && response.status === HTTP_OK;
+    const bytesToSkip = serverIgnoredRange ? startByte : 0;
     if (serverIgnoredRange) {
       logger.log(
-        "[JsHttpDownloader] Server ignored the Range header and returned the full file (HTTP 200). Restarting from the beginning to avoid an oversized, corrupt file."
+        `[JsHttpDownloader] Server ignored the Range header and returned the full file (HTTP 200). Discarding the first ${startByte} bytes from the response and appending to the existing partial instead of restarting.`
       );
-      effectiveStartByte = 0;
-      this.bytesDownloaded = 0;
-      this.resetSpeedTracking();
     }
 
-    this.parseFileSize(response, effectiveStartByte);
-
     let actualFilePath = filePath;
-    if (effectiveStartByte === 0) {
+    if (startByte === 0) {
       const urlDerivedFilename = path.basename(filePath);
       const headerFilename = this.parseContentDisposition(response);
       if (headerFilename) {
@@ -465,32 +463,17 @@ export class JsHttpDownloader {
       }
     }
 
-    if (
-      serverIgnoredRange &&
-      actualFilePath !== filePath &&
-      fs.existsSync(filePath)
-    ) {
-      try {
-        fs.unlinkSync(filePath);
-        logger.log(
-          `[JsHttpDownloader] Removed stale partial file after filename changed on restart: ${filePath}`
-        );
-      } catch (err) {
-        logger.error(
-          "[JsHttpDownloader] Failed to remove stale partial file on restart:",
-          err
-        );
-      }
-    }
-
     if (!response.body) {
       throw new Error("Response body is null");
     }
 
-    const flags = effectiveStartByte > 0 ? "a" : "w";
+    const flags = startByte > 0 ? "a" : "w";
     this.writeStream = fs.createWriteStream(actualFilePath, { flags });
 
-    const readableStream = this.createReadableStream(response.body.getReader());
+    const readableStream = this.createReadableStream(
+      response.body.getReader(),
+      bytesToSkip
+    );
     await pipeline(readableStream, this.writeStream);
 
     this.status = "complete";
@@ -549,9 +532,14 @@ export class JsHttpDownloader {
   }
 
   private createReadableStream(
-    reader: ReadableStreamDefaultReader<Uint8Array>
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    bytesToSkip = 0
   ): Readable {
     const applyThrottle = this.applyThrottle.bind(this);
+    let remainingToSkip = bytesToSkip;
+    const markActivity = () => {
+      this.lastDataReceivedAt = Date.now();
+    };
     const onChunk = (length: number) => {
       this.bytesDownloaded += length;
       this.lastDataReceivedAt = Date.now();
@@ -562,15 +550,29 @@ export class JsHttpDownloader {
       read() {
         void (async () => {
           try {
-            const { done, value } = await reader.read();
-            if (done) {
-              this.push(null);
-              return;
-            }
+            let pushed = false;
+            while (!pushed) {
+              const { done, value } = await reader.read();
+              if (done) {
+                this.push(null);
+                return;
+              }
 
-            await applyThrottle(value.length);
-            onChunk(value.length);
-            this.push(Buffer.from(value));
+              markActivity();
+              await applyThrottle(value.length);
+
+              if (remainingToSkip >= value.length) {
+                remainingToSkip -= value.length;
+                continue;
+              }
+
+              const chunk =
+                remainingToSkip > 0 ? value.subarray(remainingToSkip) : value;
+              remainingToSkip = 0;
+              onChunk(chunk.length);
+              this.push(Buffer.from(chunk));
+              pushed = true;
+            }
           } catch (err) {
             this.destroy(err as Error);
           }

--- a/src/main/services/download/js-http-downloader.ts
+++ b/src/main/services/download/js-http-downloader.ts
@@ -422,10 +422,20 @@ export class JsHttpDownloader {
       );
     }
 
-    this.parseFileSize(response, startByte);
+    let effectiveStartByte = startByte;
+    if (startByte > 0 && response.status === 200) {
+      logger.log(
+        "[JsHttpDownloader] Server ignored the Range header and returned the full file (HTTP 200). Restarting from the beginning to avoid an oversized, corrupt file."
+      );
+      effectiveStartByte = 0;
+      this.bytesDownloaded = 0;
+      this.resetSpeedTracking();
+    }
+
+    this.parseFileSize(response, effectiveStartByte);
 
     let actualFilePath = filePath;
-    if (startByte === 0) {
+    if (effectiveStartByte === 0) {
       const urlDerivedFilename = path.basename(filePath);
       const headerFilename = this.parseContentDisposition(response);
       if (headerFilename) {
@@ -454,7 +464,7 @@ export class JsHttpDownloader {
       throw new Error("Response body is null");
     }
 
-    const flags = startByte > 0 ? "a" : "w";
+    const flags = effectiveStartByte > 0 ? "a" : "w";
     this.writeStream = fs.createWriteStream(actualFilePath, { flags });
 
     const readableStream = this.createReadableStream(response.body.getReader());

--- a/src/main/services/download/js-http-downloader.ts
+++ b/src/main/services/download/js-http-downloader.ts
@@ -27,6 +27,10 @@ const INITIAL_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 15000;
 const STALL_TIMEOUT_MS = 8000;
 const STALL_CHECK_INTERVAL_MS = 2000;
+const HTTP_OK = 200;
+const HTTP_PARTIAL_CONTENT = 206;
+const HTTP_RANGE_NOT_SATISFIABLE = 416;
+const HTTP_CLIENT_ERROR_THRESHOLD = 400;
 export const DEFAULT_DOWNLOAD_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:144.0) Gecko/20100101 Firefox/144.0";
 
@@ -383,7 +387,7 @@ export class JsHttpDownloader {
       `[JsHttpDownloader] Response status=${response.status} content-type=${contentType} content-length=${contentLength}`
     );
 
-    if (response.status === 416 && startByte > 0) {
+    if (response.status === HTTP_RANGE_NOT_SATISFIABLE && startByte > 0) {
       const remoteTotalSize = this.parseTotalSizeFrom416(response);
 
       if (remoteTotalSize !== null && startByte === remoteTotalSize) {
@@ -404,11 +408,11 @@ export class JsHttpDownloader {
       );
     }
 
-    if (response.status >= 400) {
+    if (response.status >= HTTP_CLIENT_ERROR_THRESHOLD) {
       throw new HttpDownloadStatusError(response.status);
     }
 
-    if (!response.ok && response.status !== 206) {
+    if (!response.ok && response.status !== HTTP_PARTIAL_CONTENT) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
@@ -423,7 +427,8 @@ export class JsHttpDownloader {
     }
 
     let effectiveStartByte = startByte;
-    if (startByte > 0 && response.status === 200) {
+    const serverIgnoredRange = startByte > 0 && response.status === HTTP_OK;
+    if (serverIgnoredRange) {
       logger.log(
         "[JsHttpDownloader] Server ignored the Range header and returned the full file (HTTP 200). Restarting from the beginning to avoid an oversized, corrupt file."
       );
@@ -456,6 +461,24 @@ export class JsHttpDownloader {
       } else if (usedFallback) {
         logger.log(
           "[JsHttpDownloader] Content-Disposition filename not found, using fallback filename"
+        );
+      }
+    }
+
+    if (
+      serverIgnoredRange &&
+      actualFilePath !== filePath &&
+      fs.existsSync(filePath)
+    ) {
+      try {
+        fs.unlinkSync(filePath);
+        logger.log(
+          `[JsHttpDownloader] Removed stale partial file after filename changed on restart: ${filePath}`
+        );
+      } catch (err) {
+        logger.error(
+          "[JsHttpDownloader] Failed to remove stale partial file on restart:",
+          err
         );
       }
     }


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Closes #2388

### Problem

When an HTTP download resumes after an interruption, we send a `Range` header asking the server to continue from where we stopped. We assumed the server always honors that. Some servers ignore it and respond `200` with the full file from byte 0 instead of `206`.

When that happened:
- `parseFileSize` computed `startByte + content-length`, inflating the total. A download sitting at ~140GB jumped to ~300GB (this is the report in #2388).
- The writer was in append mode, so the full file got glued onto the existing partial, producing an oversized, corrupt file on disk.

### Fix

In `executeDownload`, detect a `200` response on a resume (`startByte > 0`). That means the server ignored our range and is sending the whole file again. In that case:

- `parseFileSize` uses the raw `content-length` as the total instead of adding `startByte`, so the size is no longer inflated.
- We keep the existing partial on disk and discard the first `startByte` bytes off the response stream, then append only the remainder. The stream skips those bytes in `createReadableStream` via a new `bytesToSkip` parameter, so they never reach the write stream. This avoids both the corruption and re-writing the bytes we already have.
- During the skip phase we still mark activity so the stall watchdog does not trip while we are draining the leading bytes.

Genuine `206` resumes are untouched.

### Notes

- Tradeoff: when a server ignores the range, the skipped bytes are still re-transferred over the network (we just drop them instead of writing them), so resume does not save bandwidth in that case. It does avoid the corrupt file and avoids rewriting the existing partial. This only triggers on servers that ignore range requests.
- Considered clamping the measured size against the catalog size in the download manager as a backstop, but skipped it: the catalog size is often approximate and clamping would risk breaking legitimate downloads. The root cause is fixed at the source, so the backstop is not needed.
- HTTP status codes used in this path were extracted into named constants (`HTTP_OK`, `HTTP_PARTIAL_CONTENT`, `HTTP_RANGE_NOT_SATISFIABLE`, `HTTP_CLIENT_ERROR_THRESHOLD`).

### Testing

- `yarn typecheck` passes
- `yarn test` passes (4/4)
- `yarn format` clean
