### PR TITLE
feat: open desktop settings as modal

### DIFF
--- a/src/renderer/src/components/game-context-menu/use-game-actions.ts
+++ b/src/renderer/src/components/game-context-menu/use-game-actions.ts
@@ -10,6 +10,8 @@ import {
 import { useNavigate, useLocation } from "react-router-dom";
 import {
   buildGameDetailsPath,
+  buildSettingsLocationState,
+  buildSettingsPath,
   getClassicsLaunchErrorCode,
 } from "@renderer/helpers";
 import { logger } from "@renderer/logger";
@@ -71,10 +73,14 @@ export function useGameActions(game: LibraryGame) {
         const code = getClassicsLaunchErrorCode(error);
         if (code === "EMULATOR_NOT_CONFIGURED") {
           showErrorToast(t("emulator_not_configured_toast"));
-          navigate("/settings?tab=emulation");
+          navigate(buildSettingsPath({ tab: "emulation" }), {
+            state: buildSettingsLocationState(location),
+          });
         } else if (code === "BIOS_NOT_CONFIGURED") {
           showErrorToast(t("bios_not_configured_toast"));
-          navigate("/settings?tab=emulation");
+          navigate(buildSettingsPath({ tab: "emulation" }), {
+            state: buildSettingsLocationState(location),
+          });
         } else if (code === "PLATFORM_UNKNOWN") {
           showErrorToast(t("platform_unknown_toast"));
         } else if (code === "NO_DISC") {
@@ -89,7 +95,7 @@ export function useGameActions(game: LibraryGame) {
         }
       }
     },
-    [game.shop, game.objectId, navigate, showErrorToast, t]
+    [game.shop, game.objectId, location, navigate, showErrorToast, t]
   );
 
   const handleConfirmRpcs3Launch = useCallback(async () => {

--- a/src/renderer/src/components/sidebar/sidebar.tsx
+++ b/src/renderer/src/components/sidebar/sidebar.tsx
@@ -17,7 +17,10 @@ import { routes } from "./routes";
 
 import "./sidebar.scss";
 
-import { buildGameDetailsPath } from "@renderer/helpers";
+import {
+  buildGameDetailsPath,
+  buildSettingsLocationState,
+} from "@renderer/helpers";
 import { useFormat } from "@renderer/hooks/use-format";
 
 import {
@@ -267,7 +270,19 @@ export function Sidebar() {
   };
 
   const handleSidebarItemClick = (path: string) => {
+    if (
+      path === "/settings" &&
+      globalThis.location.hash.startsWith("#/settings")
+    ) {
+      return;
+    }
+
     if (path !== location.pathname) {
+      if (path === "/settings") {
+        navigate(path, { state: buildSettingsLocationState(location) });
+        return;
+      }
+
       navigate(path);
     }
   };

--- a/src/renderer/src/helpers.ts
+++ b/src/renderer/src/helpers.ts
@@ -1,4 +1,5 @@
 import type { EmulatorBinary, EmulatorSystem, GameShop } from "@types";
+import type { Location } from "react-router-dom";
 
 import Color from "color";
 import i18next from "i18next";
@@ -78,6 +79,17 @@ export const buildGameAchievementPath = (
 
   return `/achievements/?${searchParams.toString()}`;
 };
+
+export const buildSettingsPath = (params: Record<string, string> = {}) => {
+  const searchParams = new URLSearchParams(params);
+  const search = searchParams.toString();
+
+  return search ? `/settings?${search}` : "/settings";
+};
+
+export const buildSettingsLocationState = (location: Location) => ({
+  backgroundLocation: location,
+});
 
 export const darkenColor = (color: string, amount: number, alpha: number = 1) =>
   new Color(color).darken(amount).alpha(alpha).toString();

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useCallback } from "react";
 import ReactDOM from "react-dom/client";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import { Provider } from "react-redux";
 import LanguageDetector from "i18next-browser-languagedetector";
-import { HashRouter, Route, Routes } from "react-router-dom";
+import {
+  HashRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 
 import "@fontsource/noto-sans/400.css";
 import "@fontsource/noto-sans/500.css";
@@ -109,48 +115,76 @@ globalThis.electron.onUserPreferencesUpdated((preferences) => {
   }
 });
 
+function AppRoutes() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const backgroundLocation = (
+    location.state as { backgroundLocation?: typeof location } | null
+  )?.backgroundLocation;
+  const isSettingsModal = location.pathname === "/settings";
+
+  const routesLocation = isSettingsModal
+    ? (backgroundLocation ?? { ...location, pathname: "/", search: "" })
+    : location;
+
+  const closeSettings = useCallback(() => {
+    if (backgroundLocation) {
+      navigate(-1);
+    } else {
+      navigate("/", { replace: true });
+    }
+  }, [backgroundLocation, navigate]);
+
+  return (
+    <>
+      <AchievementNotificationOverlay />
+      <Routes location={routesLocation}>
+        <Route element={<App />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/catalogue" element={<Catalogue />} />
+          <Route path="/library" element={<Library />} />
+          <Route path="/downloads" element={<Downloads />} />
+          <Route path="/game/:shop/:objectId" element={<GameDetails />} />
+          <Route path="/profile/:userId" element={<Profile />} />
+          <Route path="/achievements" element={<Achievements />} />
+          <Route path="/notifications" element={<Notifications />} />
+        </Route>
+
+        <Route path="/theme-editor" element={<ThemeEditor />} />
+        <Route
+          path="/achievement-notification"
+          element={<AchievementNotification />}
+        />
+        <Route path="/game-launcher" element={<GameLauncher />} />
+        <Route path="/friends-window" element={<FriendsWindow />} />
+        <Route path="/auth-window" element={<AuthWindow />} />
+
+        <Route path="/big-picture" element={<BigPictureApp />}>
+          <Route index element={<BigPictureHome />} />
+          <Route path="catalogue" element={<BigPictureCatalogue />} />
+          <Route path="component-lab" element={<BigPictureComponentLab />} />
+          <Route path="downloads" element={<BigPictureDownloads />} />
+          <Route path="settings" element={<BigPictureSettings />} />
+          <Route path="library" element={<BigPictureLibrary />} />
+          <Route path="profile/:userId?" element={<BigPictureProfile />} />
+          <Route path="game/:shop/:objectId" element={<BigPictureGame />} />
+          <Route
+            path="game/:shop/:objectId/achievements"
+            element={<BigPictureGameAchievements />}
+          />
+        </Route>
+      </Routes>
+
+      {isSettingsModal && <Settings onClose={closeSettings} />}
+    </>
+  );
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <Provider store={store}>
       <HashRouter>
-        <AchievementNotificationOverlay />
-        <Routes>
-          <Route element={<App />}>
-            <Route path="/" element={<Home />} />
-            <Route path="/catalogue" element={<Catalogue />} />
-            <Route path="/library" element={<Library />} />
-            <Route path="/downloads" element={<Downloads />} />
-            <Route path="/game/:shop/:objectId" element={<GameDetails />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="/profile/:userId" element={<Profile />} />
-            <Route path="/achievements" element={<Achievements />} />
-            <Route path="/notifications" element={<Notifications />} />
-          </Route>
-
-          <Route path="/theme-editor" element={<ThemeEditor />} />
-          <Route
-            path="/achievement-notification"
-            element={<AchievementNotification />}
-          />
-          <Route path="/game-launcher" element={<GameLauncher />} />
-          <Route path="/friends-window" element={<FriendsWindow />} />
-          <Route path="/auth-window" element={<AuthWindow />} />
-
-          <Route path="/big-picture" element={<BigPictureApp />}>
-            <Route index element={<BigPictureHome />} />
-            <Route path="catalogue" element={<BigPictureCatalogue />} />
-            <Route path="component-lab" element={<BigPictureComponentLab />} />
-            <Route path="downloads" element={<BigPictureDownloads />} />
-            <Route path="settings" element={<BigPictureSettings />} />
-            <Route path="library" element={<BigPictureLibrary />} />
-            <Route path="profile/:userId?" element={<BigPictureProfile />} />
-            <Route path="game/:shop/:objectId" element={<BigPictureGame />} />
-            <Route
-              path="game/:shop/:objectId/achievements"
-              element={<BigPictureGameAchievements />}
-            />
-          </Route>
-        </Routes>
+        <AppRoutes />
       </HashRouter>
     </Provider>
   </React.StrictMode>

--- a/src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.tsx
+++ b/src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   ClockIcon,
   CodeIcon,
@@ -16,6 +16,8 @@ import {
 
 import { Button, ConfirmationModal } from "@renderer/components";
 import {
+  buildSettingsLocationState,
+  buildSettingsPath,
   getSkuRegion,
   getSkuRegionFlag,
   getSkuRegionFromSaveIdentity,
@@ -55,6 +57,7 @@ export function GameEmulationSaves({
   const { showSuccessToast, showErrorToast } = useToast();
   const { hasActiveSubscription } = useUserDetails();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [cloudSaves, setCloudSaves] = useState<EmulationCloudSave[]>([]);
   const [records, setRecords] = useState<MemoryCardSaveRecord[]>([]);
@@ -171,7 +174,12 @@ export function GameEmulationSaves({
           <Button
             theme="outline"
             onClick={() =>
-              navigate(`/settings?tab=emulation&system=${platform}`)
+              navigate(
+                buildSettingsPath({ tab: "emulation", system: platform }),
+                {
+                  state: buildSettingsLocationState(location),
+                }
+              )
             }
           >
             <PlusIcon size={14} />

--- a/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
+++ b/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
@@ -18,9 +18,13 @@ import {
 } from "@renderer/hooks";
 import { useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { gameDetailsContext } from "@renderer/context";
-import { getClassicsLaunchErrorCode } from "@renderer/helpers";
+import {
+  buildSettingsLocationState,
+  buildSettingsPath,
+  getClassicsLaunchErrorCode,
+} from "@renderer/helpers";
 import { DiscSelectionModal } from "../modals/disc-selection-modal";
 
 import "./hero-panel-actions.scss";
@@ -60,6 +64,7 @@ export function HeroPanelActions() {
   const { showSuccessToast, showErrorToast } = useToast();
 
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [showDiscSelectionModal, setShowDiscSelectionModal] = useState(false);
   const [pendingClassicsLaunch, setPendingClassicsLaunch] = useState<{
@@ -216,7 +221,9 @@ export function HeroPanelActions() {
       const code = getClassicsLaunchErrorCode(error);
       if (code === "EMULATOR_NOT_CONFIGURED") {
         showErrorToast(t("emulator_not_configured_toast"));
-        navigate("/settings?tab=emulation");
+        navigate(buildSettingsPath({ tab: "emulation" }), {
+          state: buildSettingsLocationState(location),
+        });
       } else if (code === "PLATFORM_UNKNOWN") {
         showErrorToast(t("platform_unknown_toast"));
       } else if (code === "NO_DISC") {

--- a/src/renderer/src/pages/game-details/modals/download-settings-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/download-settings-modal.tsx
@@ -42,11 +42,16 @@ import {
   useState,
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 import { Tooltip } from "react-tooltip";
 import "./download-settings-modal.scss";
 import { RealDebridInfoModal } from "./real-debrid-info-modal";
 import { gameDetailsContext } from "@renderer/context";
-import { platformToSystem } from "@renderer/helpers";
+import {
+  buildSettingsLocationState,
+  buildSettingsPath,
+  platformToSystem,
+} from "@renderer/helpers";
 
 export interface DownloadSettingsModalProps {
   visible: boolean;
@@ -239,6 +244,7 @@ export function DownloadSettingsModal({
   repack,
 }: Readonly<DownloadSettingsModalProps>) {
   const { t } = useTranslation("game_details");
+  const location = useLocation();
 
   const { game, shopDetails, shop } = useContext(gameDetailsContext);
 
@@ -1428,7 +1434,10 @@ export function DownloadSettingsModal({
 
           <p className="download-settings-modal__hint-text">
             <Trans i18nKey="select_folder_hint" ns="game_details">
-              <Link to="/settings" />
+              <Link
+                to={buildSettingsPath({ tab: "downloads" })}
+                state={buildSettingsLocationState(location)}
+              />
             </Trans>
           </p>
         </div>

--- a/src/renderer/src/pages/game-details/modals/real-debrid-info-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/real-debrid-info-modal.tsx
@@ -1,7 +1,11 @@
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Button, Link, Modal } from "@renderer/components";
 import { LinkExternalIcon } from "@primer/octicons-react";
+import {
+  buildSettingsLocationState,
+  buildSettingsPath,
+} from "@renderer/helpers";
 import "./real-debrid-info-modal.scss";
 
 const realDebridReferralId = import.meta.env
@@ -23,6 +27,7 @@ export function RealDebridInfoModal({
   const { t } = useTranslation("game_details");
   const { t: tSettings } = useTranslation("settings");
   const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <Modal
@@ -47,7 +52,9 @@ export function RealDebridInfoModal({
         <Button
           onClick={() => {
             onClose();
-            navigate("/settings?tab=4");
+            navigate(buildSettingsPath({ tab: "integrations" }), {
+              state: buildSettingsLocationState(location),
+            });
           }}
         >
           {t("go_to_settings")}

--- a/src/renderer/src/pages/game-details/modals/repacks-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/repacks-modal.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   PlusCircleIcon,
   ChevronDownIcon,
@@ -24,7 +24,11 @@ import { orderBy } from "lodash-es";
 import { useDate, useAppDispatch, useAppSelector } from "@renderer/hooks";
 import { clearNewDownloadOptions } from "@renderer/features";
 import { levelDBService } from "@renderer/services/leveldb.service";
-import { getGameKey } from "@renderer/helpers";
+import {
+  buildSettingsLocationState,
+  buildSettingsPath,
+  getGameKey,
+} from "@renderer/helpers";
 import "./repacks-modal.scss";
 
 export interface RepacksModalProps {
@@ -71,6 +75,7 @@ export function RepacksModal({
 
   const { formatDate } = useDate();
   const navigate = useNavigate();
+  const location = useLocation();
   const dispatch = useAppDispatch();
   const userPreferences = useAppSelector(
     (state) => state.userPreferences.value
@@ -323,7 +328,9 @@ export function RepacksModal({
                     theme="primary"
                     onClick={() => {
                       onClose();
-                      navigate("/settings?tab=2");
+                      navigate(buildSettingsPath({ tab: "downloads" }), {
+                        state: buildSettingsLocationState(location),
+                      });
                     }}
                   >
                     <PlusCircleIcon />

--- a/src/renderer/src/pages/profile/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/renderer/src/pages/profile/edit-profile-modal/edit-profile-modal.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 
 import { DeviceCameraIcon } from "@primer/octicons-react";
 import {
@@ -18,6 +19,10 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
 import { userProfileContext } from "@renderer/context";
+import {
+  buildSettingsLocationState,
+  buildSettingsPath,
+} from "@renderer/helpers";
 import { getProfileImageMetadata } from "../profile-image-metadata";
 import { ProfileImageCropModal } from "../profile-image-crop-modal/profile-image-crop-modal";
 import "./edit-profile-modal.scss";
@@ -31,6 +36,7 @@ export function EditProfileModal(
   props: Omit<ModalProps, "children" | "title">
 ) {
   const { t } = useTranslation("user_profile");
+  const location = useLocation();
 
   const schema = yup.object({
     displayName: yup
@@ -195,7 +201,10 @@ export function EditProfileModal(
 
         <small className="edit-profile-modal__hint">
           <Trans i18nKey="privacy_hint" ns="user_profile">
-            <Link to="/settings" />
+            <Link
+              to={buildSettingsPath({ tab: "account_privacy" })}
+              state={buildSettingsLocationState(location)}
+            />
           </Trans>
         </small>
 

--- a/src/renderer/src/pages/settings/appearance/settings-appearance.tsx
+++ b/src/renderer/src/pages/settings/appearance/settings-appearance.tsx
@@ -6,6 +6,7 @@ import { ImportThemeModal } from "./modals/import-theme-modal";
 import { settingsContext } from "@renderer/context";
 import { useNavigate } from "react-router-dom";
 import { levelDBService } from "@renderer/services/leveldb.service";
+import { buildSettingsPath } from "@renderer/helpers";
 
 interface SettingsAppearanceProps {
   appearance: {
@@ -63,7 +64,7 @@ export function SettingsAppearance({
       });
       setHasShownModal(true);
 
-      navigate("/settings", { replace: true });
+      navigate(buildSettingsPath(), { replace: true });
       clearTheme();
     }
   }, [

--- a/src/renderer/src/pages/settings/settings.scss
+++ b/src/renderer/src/pages/settings/settings.scss
@@ -1,10 +1,40 @@
 @use "../../scss/globals.scss";
 
+$settings-overlay-padding: calc(globals.$spacing-unit * 3);
+$settings-overlay-backdrop-opacity: 0.55;
+
 .settings {
-  &__container {
-    padding: 24px;
-    width: 100%;
+  &__overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
     display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: $settings-overlay-padding;
+    background: rgba(0, 0, 0, $settings-overlay-backdrop-opacity);
+  }
+
+  &__container {
+    width: min(1120px, 100%);
+    height: min(760px, 100%);
+    display: flex;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+  }
+
+  &__modal-container {
+    width: min(1120px, 100%);
+    height: min(760px, 100%);
+    display: flex;
+
+    .settings__container {
+      width: 100%;
+      height: 100%;
+    }
   }
 
   &__content {
@@ -16,6 +46,24 @@
     border-radius: 8px;
     display: flex;
     overflow: hidden;
+    position: relative;
+  }
+
+  &__close-button {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: globals.$body-color;
+    cursor: pointer;
+    transition: all ease 0.2s;
+
+    &:hover {
+      opacity: 0.75;
+    }
   }
 
   &__sidebar {
@@ -111,7 +159,8 @@
     flex-direction: column;
     gap: calc(globals.$spacing-unit * 2.5);
     min-width: 0;
-    padding: calc(globals.$spacing-unit * 2.5);
+    padding: calc(globals.$spacing-unit * 2.5) calc(globals.$spacing-unit * 7)
+      calc(globals.$spacing-unit * 2.5) calc(globals.$spacing-unit * 2.5);
     overflow: auto;
   }
 

--- a/src/renderer/src/pages/settings/settings.tsx
+++ b/src/renderer/src/pages/settings/settings.tsx
@@ -5,7 +5,7 @@ import {
 } from "@renderer/context";
 import { SettingsAccount } from "./settings-account";
 import { useUserDetails } from "@renderer/hooks";
-import { Fragment, useMemo } from "react";
+import { Fragment, useEffect, useMemo } from "react";
 import "./settings.scss";
 import {
   BellIcon,
@@ -15,6 +15,7 @@ import {
   PlayIcon,
   VideoIcon,
   ShieldCheckIcon,
+  XIcon,
 } from "@primer/octicons-react";
 import { Gamepad2, Wrench } from "lucide-react";
 import { SettingsContextGeneral } from "./settings-context-general";
@@ -26,10 +27,28 @@ import { SettingsContextCompatibility } from "./settings-context-compatibility";
 import { SettingsContextBigPicture } from "./settings-context-big-picture";
 import { SettingsContextEmulation } from "./emulation/settings-context-emulation";
 
-export default function Settings() {
+export interface SettingsProps {
+  onClose?: () => void;
+}
+
+export default function Settings({ onClose }: Readonly<SettingsProps>) {
   const { t } = useTranslation("settings");
 
   const { userDetails } = useUserDetails();
+
+  useEffect(() => {
+    if (!onClose) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    globalThis.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      globalThis.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onClose]);
 
   const categories = useMemo(
     () => [
@@ -133,9 +152,20 @@ export default function Settings() {
             return <SettingsAccount />;
           };
 
-          return (
-            <section className="settings__container">
+          const contentBody = (
+            <>
               <div className="settings__content">
+                {onClose && (
+                  <button
+                    type="button"
+                    className="settings__close-button"
+                    onClick={onClose}
+                    aria-label="Close"
+                  >
+                    <XIcon size={24} />
+                  </button>
+                )}
+
                 <aside className="settings__sidebar">
                   {categories.map((category, index) => {
                     const prevGroup =
@@ -192,8 +222,27 @@ export default function Settings() {
                   {renderCategory()}
                 </div>
               </div>
-            </section>
+            </>
           );
+
+          if (onClose) {
+            return (
+              <div className="settings__overlay">
+                <div className="settings__modal-container">
+                  <dialog
+                    className="settings__container"
+                    open
+                    aria-modal
+                    data-hydra-dialog
+                  >
+                    {contentBody}
+                  </dialog>
+                </div>
+              </div>
+            );
+          }
+
+          return <section className="settings__container">{contentBody}</section>;
         }}
       </SettingsContextConsumer>
     </SettingsContextProvider>


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Changes the desktop settings screen from a full page into a modal-style overlay. The settings panel keeps its existing visual structure, but now opens above the current page instead of replacing it.

The settings overlay can be closed with the close button or by pressing `Escape`.

Also centralizes desktop settings navigation so links and buttons that open settings use the same path/state helpers. This lets settings open over the current page and makes links target the intended settings tab.

Main changes:
- Renders `/settings` as an overlay on top of the previous route.
- Preserves the previous route as the modal background with `backgroundLocation`.
- Adds close behavior to the settings overlay:
  - close button
  - `Escape`
- Adds centralized settings navigation helpers:
  - `buildSettingsPath`
  - `buildSettingsLocationState`
- Updates desktop settings navigation entry points to use the centralized helpers.
- Updates settings links to open directly on the intended tabs:
  - `downloads`
  - `integrations`
  - `account_privacy`
  - `emulation`

Files changed:
- `src/renderer/src/main.tsx` - renders settings as an overlay route and preserves the background route.
- `src/renderer/src/pages/settings/settings.tsx` - adds modal behavior, close button, and `Escape` handling.
- `src/renderer/src/pages/settings/settings.scss` - adds overlay sizing, positioning, and close button styling.
- `src/renderer/src/helpers.ts` - adds centralized settings path and route-state helpers.
- `src/renderer/src/components/sidebar/sidebar.tsx` - uses centralized settings state when opening settings from the sidebar.
- `src/renderer/src/components/game-context-menu/use-game-actions.ts` - opens the emulation settings tab when emulator or BIOS setup is required.
- `src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx` - opens the emulation settings tab when emulator setup is required.
- `src/renderer/src/pages/game-details/cloud-sync/game-emulation-saves.tsx` - opens the emulation settings tab with the selected system.
- `src/renderer/src/pages/game-details/modals/repacks-modal.tsx` - opens the downloads settings tab when adding download sources.
- `src/renderer/src/pages/game-details/modals/real-debrid-info-modal.tsx` - opens the integrations settings tab for Real-Debrid setup.
- `src/renderer/src/pages/game-details/modals/download-settings-modal.tsx` - points the settings link to the downloads tab.
- `src/renderer/src/pages/profile/edit-profile-modal/edit-profile-modal.tsx` - points the privacy settings link to the account/privacy tab.
- `src/renderer/src/pages/settings/appearance/settings-appearance.tsx` - uses the centralized settings path helper when clearing theme import query state.

Validation:
- `yarn typecheck:web` passed.
- Pre-push `eslint` completed with existing warnings only.
- Pre-push `typecheck:node` passed.
- Pre-push `typecheck:web` passed.