### PR TITLE
feat: wire retroachievements emulators guide article

### DIFF
--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -217,6 +217,7 @@ export function App() {
           "install-duckstation": 6441,
           "install-pcsx2": 6192,
           "install-rpcs3": 6510,
+          "retroachievements-emulators": 6629,
         },
         en: {
           "cannot-write-directory": 4122,
@@ -226,16 +227,19 @@ export function App() {
           "install-duckstation": 6465,
           "install-pcsx2": 6390,
           "install-rpcs3": 6524,
+          "retroachievements-emulators": 6692,
         },
         ru: {
           "install-duckstation": 6479,
           "install-pcsx2": 6429,
           "install-rpcs3": 6541,
+          "retroachievements-emulators": 6717,
         },
         es: {
           "install-duckstation": 6492,
           "install-pcsx2": 6410,
           "install-rpcs3": 6552,
+          "retroachievements-emulators": 6743,
         },
       };
 


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

The RetroAchievements integration settings already had a guide tooltip (`data-open-article="retroachievements-emulators"`), but the article key was never added to the `articleMapping` in `app.tsx`, so clicking it did nothing.

This wires up the emulators guide article IDs for each supported language:

- pt: 6629
- en: 6692
- ru: 6717
- es: 6743

Other languages fall back to `en`, matching the existing behavior for the other keys.
