### PR TITLE
feat: enhance retro achievements handling and caching

### DIFF
--- a/src/main/events/catalogue/get-game-shop-details.ts
+++ b/src/main/events/catalogue/get-game-shop-details.ts
@@ -63,7 +63,8 @@ interface LaunchboxShopDetailsEntry {
 const mapLaunchboxToShopDetails = (
   objectId: string,
   basic: LaunchboxBasic | null,
-  entry: LaunchboxShopDetailsEntry | null
+  entry: LaunchboxShopDetailsEntry | null,
+  cached: ShopDetailsWithAssets | null
 ): ShopDetails => {
   const data = entry?.data ?? null;
   const description = data?.description ?? "";
@@ -73,7 +74,8 @@ const mapLaunchboxToShopDetails = (
     name: data?.title ?? basic?.title ?? "",
     platform: entry?.platform ?? data?.platform ?? undefined,
     skus: entry?.skus ?? undefined,
-    retroAchievementsGameId: basic?.retroAchievementsGameId ?? null,
+    retroAchievementsGameId:
+      basic?.retroAchievementsGameId ?? cached?.retroAchievementsGameId ?? null,
     steam_appid: 0,
     detailed_description: description,
     about_the_game: description,
@@ -146,7 +148,12 @@ const getLaunchboxShopDetails = async (
 
   if (!data && !basic) return null;
 
-  const mapped = mapLaunchboxToShopDetails(objectId, basic, detailsEntry);
+  const mapped = mapLaunchboxToShopDetails(
+    objectId,
+    basic,
+    detailsEntry,
+    cachedData ? { ...cachedData, assets: cachedAssets ?? null } : null
+  );
 
   gamesShopCacheSublevel
     .put(levelKeys.gameShopCacheItem(shop, objectId, language), mapped)

--- a/src/main/events/catalogue/get-game-shop-details.ts
+++ b/src/main/events/catalogue/get-game-shop-details.ts
@@ -119,7 +119,7 @@ const getLaunchboxShopDetails = async (
   const cacheHasNewFields =
     cachedData &&
     (cachedData.platform || cachedData.skus) &&
-    "retroAchievementsGameId" in cachedData;
+    typeof cachedData.retroAchievementsGameId === "number";
   if (cachedData && cacheHasNewFields) {
     return { ...cachedData, assets: cachedAssets ?? null };
   }

--- a/src/main/events/user/get-retroachievements-achievements.ts
+++ b/src/main/events/user/get-retroachievements-achievements.ts
@@ -1,4 +1,5 @@
 import type { GameShop, UserAchievement } from "@types";
+import { syncAndGetUnlockedAchievements } from "./get-unlocked-achievements";
 import { registerEvent } from "../register-event";
 import { syncRetroAchievements } from "@main/services/retro-achievements/retro-achievements-sync";
 
@@ -6,13 +7,17 @@ const getRetroAchievementsAchievements = async (
   _event: Electron.IpcMainInvokeEvent,
   objectId: string,
   shop: GameShop,
-  retroAchievementsGameId: number
+  retroAchievementsGameId?: number
 ): Promise<UserAchievement[] | null> => {
   const result = await syncRetroAchievements({
     objectId,
     shop,
     retroAchievementsGameId,
   });
+
+  if (result.status === "no_mapping") {
+    return syncAndGetUnlockedAchievements(objectId, shop);
+  }
 
   return result.achievements;
 };

--- a/src/main/events/user/get-unlocked-achievements.ts
+++ b/src/main/events/user/get-unlocked-achievements.ts
@@ -75,13 +75,20 @@ export const getUnlockedAchievements = async (
     });
 };
 
-const getUnlockedAchievementsEvent = async (
-  _event: Electron.IpcMainInvokeEvent,
+export const syncAndGetUnlockedAchievements = async (
   objectId: string,
   shop: GameShop
 ): Promise<UserAchievement[]> => {
   await AchievementWatcherManager.firstSyncWithRemoteIfNeeded(shop, objectId);
   return getUnlockedAchievements(objectId, shop, false);
+};
+
+const getUnlockedAchievementsEvent = async (
+  _event: Electron.IpcMainInvokeEvent,
+  objectId: string,
+  shop: GameShop
+): Promise<UserAchievement[]> => {
+  return syncAndGetUnlockedAchievements(objectId, shop);
 };
 
 registerEvent("getUnlockedAchievements", getUnlockedAchievementsEvent);

--- a/src/main/services/retro-achievements/retro-achievements-sync.ts
+++ b/src/main/services/retro-achievements/retro-achievements-sync.ts
@@ -7,7 +7,12 @@ import type {
 } from "@types";
 import { UserNotLoggedInError } from "@shared";
 
-import { db, gameAchievementsSublevel, levelKeys } from "@main/level";
+import {
+  db,
+  gameAchievementsSublevel,
+  gamesShopCacheSublevel,
+  levelKeys,
+} from "@main/level";
 import { HydraApi } from "../hydra-api";
 import { logger } from "../logger";
 import { getGameAchievementData } from "../achievements/get-game-achievement-data";
@@ -70,6 +75,31 @@ const resolveRetroAchievementsGameId = async (
     return retroAchievementsGameId;
   }
 
+  const language = await db
+    .get<string, string>(levelKeys.language, {
+      valueEncoding: "utf8",
+    })
+    .then((value) => value || "en")
+    .catch(() => "en");
+
+  const cachedShopDetails = await gamesShopCacheSublevel
+    .get(levelKeys.gameShopCacheItem(shop, objectId, language))
+    .catch(() => null);
+
+  if (typeof cachedShopDetails?.retroAchievementsGameId === "number") {
+    return cachedShopDetails.retroAchievementsGameId;
+  }
+
+  const cachedEntries = await gamesShopCacheSublevel.iterator().all();
+  for (const [key, details] of cachedEntries) {
+    if (
+      key.startsWith(`${shop}:${objectId}:`) &&
+      typeof details?.retroAchievementsGameId === "number"
+    ) {
+      return details.retroAchievementsGameId;
+    }
+  }
+
   const game = await HydraApi.get<{
     retroAchievementsGameId: number | null;
   } | null>(`/games/${shop}/${objectId}`, null, { needsAuth: false }).catch(
@@ -85,9 +115,17 @@ interface SyncRetroAchievementsParams {
   retroAchievementsGameId?: number;
 }
 
+type RetroAchievementsSyncStatus =
+  | "success"
+  | "missing_credentials"
+  | "no_mapping"
+  | "catalogue_unavailable"
+  | "progress_unavailable";
+
 interface RetroAchievementsSyncResult {
   achievements: UserAchievement[];
   didChange: boolean;
+  status: RetroAchievementsSyncStatus;
 }
 
 const buildRetroAchievementsView = (
@@ -125,13 +163,10 @@ export const syncRetroAchievements = async ({
   const username = userPreferences?.retroAchievementsUsername;
 
   if (!webApiKey || !username) {
-    logger.info("RetroAchievements sync skipped: missing credentials", {
-      hasWebApiKey: Boolean(webApiKey),
-      hasUsername: Boolean(username),
-    });
     return {
       achievements: await buildAchievementsFromCache(objectId, shop),
       didChange: false,
+      status: "missing_credentials",
     };
   }
 
@@ -142,17 +177,15 @@ export const syncRetroAchievements = async ({
   );
 
   if (!gameId) {
-    logger.info("RetroAchievements sync skipped: no game mapping", {
-      objectId,
-      shop,
-    });
     return {
       achievements: await buildAchievementsFromCache(objectId, shop),
       didChange: false,
+      status: "no_mapping",
     };
   }
 
   let catalogue: SteamAchievement[];
+  let catalogueStatus: RetroAchievementsSyncResult["status"] = "success";
   try {
     catalogue = await getGameAchievementData(objectId, shop, false);
   } catch (err) {
@@ -160,7 +193,15 @@ export const syncRetroAchievements = async ({
     return {
       achievements: await buildAchievementsFromCache(objectId, shop),
       didChange: false,
+      status: "catalogue_unavailable",
     };
+  }
+
+  if (catalogue.length === 0) {
+    const cachedAchievements = await gameAchievementsSublevel.get(gameKey);
+    if ((cachedAchievements?.achievements?.length ?? 0) === 0) {
+      catalogueStatus = "catalogue_unavailable";
+    }
   }
 
   let data: RetroAchievementsGameInfoAndUserProgress;
@@ -175,6 +216,7 @@ export const syncRetroAchievements = async ({
     return {
       achievements: await buildAchievementsFromCache(objectId, shop),
       didChange: false,
+      status: "progress_unavailable",
     };
   }
 
@@ -258,5 +300,6 @@ export const syncRetroAchievements = async ({
   return {
     achievements,
     didChange,
+    status: catalogueStatus,
   };
 };

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -139,7 +139,6 @@ export function GameDetailsContextProvider({
         if (userDetails && shop !== "custom") {
           const useRetroAchievements =
             shop === "launchbox" &&
-            Boolean(result?.retroAchievementsGameId) &&
             Boolean(userPreferences?.retroAchievementsWebApiKey);
 
           if (useRetroAchievements) {
@@ -147,7 +146,7 @@ export function GameDetailsContextProvider({
               .getRetroAchievementsAchievements(
                 objectId,
                 shop,
-                result!.retroAchievementsGameId!
+                result?.retroAchievementsGameId ?? undefined
               )
               .then((achievements) => {
                 if (abortController.signal.aborted) return;

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -801,7 +801,7 @@ declare global {
     getRetroAchievementsAchievements: (
       objectId: string,
       shop: GameShop,
-      raGameId: number
+      raGameId?: number
     ) => Promise<UserAchievement[] | null>;
     resetRetroAchievementsAchievements: () => Promise<void>;
 

--- a/src/renderer/src/pages/game-details/sidebar/sidebar.tsx
+++ b/src/renderer/src/pages/game-details/sidebar/sidebar.tsx
@@ -11,7 +11,12 @@ import { Link } from "@renderer/components/link/link";
 import { StarRating } from "@renderer/components/star-rating/star-rating";
 
 import { gameDetailsContext } from "@renderer/context";
-import { useDate, useFormat, useUserDetails } from "@renderer/hooks";
+import {
+  useAppSelector,
+  useDate,
+  useFormat,
+  useUserDetails,
+} from "@renderer/hooks";
 import {
   CloudOfflineIcon,
   DownloadIcon,
@@ -120,11 +125,20 @@ export function Sidebar() {
 
   const { gameTitle, shopDetails, objectId, shop, stats, achievements } =
     useContext(gameDetailsContext);
+  const userPreferences = useAppSelector(
+    (state) => state.userPreferences.value
+  );
 
   const { showHydraCloudModal } = useSubscription();
   const { t } = useTranslation("game_details");
   const { formatDateTime } = useDate();
   const { numberFormatter } = useFormat();
+  const achievementsCount = achievements?.length ?? 0;
+  const shouldRenderAchievementsSection =
+    (!!userDetails && achievementsCount > 0) ||
+    (shop === "launchbox" &&
+      !!shopDetails?.retroAchievementsGameId &&
+      !userPreferences?.retroAchievementsWebApiKey);
 
   useEffect(() => {
     if (objectId) {
@@ -176,7 +190,7 @@ export function Sidebar() {
         </Suspense>
       )}
 
-      {userDetails === null && (
+      {userDetails === null && !shouldRenderAchievementsSection && (
         <SidebarSection title={t("achievements")}>
           <div className="achievements-placeholder">
             <LockIcon size={36} />
@@ -207,17 +221,22 @@ export function Sidebar() {
         </SidebarSection>
       )}
 
-      {userDetails && achievements && achievements.length > 0 && (
+      {shouldRenderAchievementsSection && (
         <SidebarSection
-          title={t("achievements_count", {
-            unlockedCount: achievements.filter((a) => a.unlocked).length,
-            achievementsCount: achievements.length,
-          })}
+          title={
+            achievementsCount > 0
+              ? t("achievements_count", {
+                  unlockedCount:
+                    achievements?.filter((a) => a.unlocked).length ?? 0,
+                  achievementsCount,
+                })
+              : t("achievements")
+          }
         >
           <ul className="list">
             <RetroAchievementsConnectBanner />
 
-            {!hasActiveSubscription && (
+            {!hasActiveSubscription && achievementsCount > 0 && (
               <button
                 className="subscription-required-button"
                 onClick={() => showHydraCloudModal("achievements")}
@@ -227,7 +246,7 @@ export function Sidebar() {
               </button>
             )}
 
-            {achievements.slice(0, 4).map((achievement) => (
+            {(achievements ?? []).slice(0, 4).map((achievement) => (
               <li key={achievement.displayName}>
                 <Link
                   to={buildGameAchievementPath({
@@ -256,15 +275,17 @@ export function Sidebar() {
               </li>
             ))}
 
-            <Link
-              to={buildGameAchievementPath({
-                shop: shop,
-                objectId: objectId!,
-                title: gameTitle,
-              })}
-            >
-              {t("see_all_achievements")}
-            </Link>
+            {achievementsCount > 0 && (
+              <Link
+                to={buildGameAchievementPath({
+                  shop: shop,
+                  objectId: objectId!,
+                  title: gameTitle,
+                })}
+              >
+                {t("see_all_achievements")}
+              </Link>
+            )}
           </ul>
         </SidebarSection>
       )}


### PR DESCRIPTION
- Updated `mapLaunchboxToShopDetails` to include cached retro achievements game ID.
- Modified `getRetroAchievementsAchievements` to handle optional retro achievements game ID.
- Improved `syncRetroAchievements` to return detailed status for synchronization results.
- Adjusted `GameDetailsContextProvider` to use optional chaining for retro achievements game ID.

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [ ] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [ ] I have checked that there are no duplicate pull requests related to this request.
- [ ] I have considered, and confirm that this submission is valuable to others.
- [ ] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**
