### PR TITLE
style: soften error screen colors and make the log monospace

### DIFF
--- a/src/renderer/src/components/error-boundary/error-fallback.scss
+++ b/src/renderer/src/components/error-boundary/error-fallback.scss
@@ -1,5 +1,7 @@
 @use "../../scss/globals.scss";
 
+$mono-font: "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", monospace;
+
 .error-fallback {
   width: 100%;
   height: 100%;
@@ -25,7 +27,8 @@
   }
 
   &__icon {
-    color: globals.$error-color;
+    color: globals.$muted-color;
+    opacity: 0.8;
   }
 
   &__title {
@@ -39,23 +42,25 @@
 
   &__message {
     width: 100%;
-    color: globals.$error-color;
-    font-family: monospace;
+    color: globals.$muted-color;
+    font-family: $mono-font;
     font-size: globals.$body-font-size;
     overflow-wrap: break-word;
+    user-select: text;
   }
 
   &__origin {
     width: 100%;
-    font-family: monospace;
+    font-family: $mono-font;
     font-size: globals.$small-font-size;
-    color: globals.$muted-color;
+    color: globals.$body-color;
     overflow-wrap: break-word;
     user-select: text;
   }
 
   &__origin-label {
-    color: globals.$warning-color;
+    color: globals.$muted-color;
+    opacity: 0.5;
     margin-right: globals.$spacing-unit;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -84,6 +89,7 @@
     background-color: globals.$dark-background-color;
     border: 1px solid globals.$border-color;
     border-radius: 8px;
+    font-family: $mono-font;
     font-size: globals.$small-font-size;
     color: globals.$body-color;
     white-space: pre-wrap;

--- a/src/renderer/src/components/error-boundary/global-error-overlay.scss
+++ b/src/renderer/src/components/error-boundary/global-error-overlay.scss
@@ -1,5 +1,7 @@
 @use "../../scss/globals.scss";
 
+$mono-font: "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", monospace;
+
 .global-error-overlay {
   position: fixed;
   bottom: calc(globals.$spacing-unit * 2);
@@ -15,7 +17,7 @@
   &__card {
     pointer-events: auto;
     background-color: globals.$dark-background-color;
-    border: 1px solid globals.$error-color;
+    border: 1px solid globals.$border-color;
     border-radius: 8px;
     padding: calc(globals.$spacing-unit * 1.5);
     display: flex;
@@ -31,7 +33,8 @@
   }
 
   &__icon {
-    color: globals.$error-color;
+    color: globals.$muted-color;
+    opacity: 0.8;
     flex-shrink: 0;
   }
 
@@ -54,16 +57,16 @@
   }
 
   &__message {
-    color: globals.$body-color;
-    font-family: monospace;
+    color: globals.$muted-color;
+    font-family: $mono-font;
     font-size: globals.$small-font-size;
     overflow-wrap: break-word;
     user-select: text;
   }
 
   &__origin {
-    color: globals.$warning-color;
-    font-family: monospace;
+    color: globals.$body-color;
+    font-family: $mono-font;
     font-size: globals.$small-font-size;
     overflow-wrap: break-word;
     user-select: text;
@@ -85,6 +88,7 @@
     padding: globals.$spacing-unit;
     background-color: globals.$background-color;
     border-radius: 4px;
+    font-family: $mono-font;
     font-size: globals.$small-font-size;
     color: globals.$body-color;
     white-space: pre-wrap;


### PR DESCRIPTION
**When submitting this pull request, I confirm the following:**

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## What

Follow up to the error screen from #2439 based on review feedback.

The red and yellow accents read as a bit overkill, so this swaps them for muted neutral tones on both the fullscreen error screen and the async error overlay. It also sets an explicit monospace font on the message, origin and stack log so the trace reads as code instead of falling back to the body font.

Styling only, no behavior change.
