### PR TITLE
fix: guard /features response against non-array payloads

### DIFF
--- a/src/renderer/src/hooks/use-feature.ts
+++ b/src/renderer/src/hooks/use-feature.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 
+import { logger } from "@renderer/logger";
+
 enum Feature {
   CheckDownloadWritePermission = "CHECK_DOWNLOAD_WRITE_PERMISSION",
   TorBox = "TORBOX",
@@ -9,26 +11,32 @@ enum Feature {
   NimbusPreview = "NIMBUS_PREVIEW",
 }
 
+const readCachedFeatures = (): string[] => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem("features") ?? "[]");
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
 export function useFeature() {
   const [features, setFeatures] = useState<string[] | null>(null);
 
   useEffect(() => {
     window.electron.hydraApi
       .get<string[]>("/features", { needsAuth: false })
-      .then((features) => {
-        localStorage.setItem("features", JSON.stringify(features || []));
-        setFeatures(features || []);
-      });
+      .then((response) => {
+        const safeFeatures = Array.isArray(response) ? response : [];
+        localStorage.setItem("features", JSON.stringify(safeFeatures));
+        setFeatures(safeFeatures);
+      })
+      .catch(logger.error);
   }, []);
 
   const isFeatureEnabled = useCallback(
     (feature: Feature) => {
-      if (!features) {
-        const features = JSON.parse(localStorage.getItem("features") ?? "[]");
-        return features.includes(feature);
-      }
-
-      return features.includes(feature);
+      return (features ?? readCachedFeatures()).includes(feature);
     },
     [features]
   );


### PR DESCRIPTION
### What

Hardens `useFeature` so a non-array `/features` response can no longer crash the app.

### Why

`/features` is typed as `string[]` but never validated at runtime. If a non-array body reaches the client (e.g. an error or HTML payload injected by a proxy/CDN on a `200`), `features || []` kept the truthy non-array and cached it to `localStorage`. On the next render `isFeatureEnabled` parsed it back and called `.includes` on a non-array, throwing:

```
TypeError: features2.includes is not a function
  at DownloadSettingsModal (useMemo -> Array.filter -> isFeatureEnabled)
```

It is intermittent because it only triggers once the bad value is cached, and the cache survives restarts until a good response overwrites it. The new error boundary in v4.0.4 caught it in prod.

The backend `GET /features` always returns an array on the happy path, so this is client-side hardening only, no API change.

### How

- `Array.isArray` guard on both the write (cache) and read paths, falling back to `[]`.
- `.catch(logger.error)` so a failed fetch no longer rejects unhandled.
- The read-side guard self-heals users whose `localStorage` was already poisoned on next load.

`useFeature` is the only consumer of the `"features"` localStorage key, so no other reader needs a matching guard.

**When submitting this pull request, I confirm the following:**

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.