### PR TITLE
fix: prevent undefined game title from crashing search suggestions

### DIFF
--- a/src/main/events/library/get-library.ts
+++ b/src/main/events/library/get-library.ts
@@ -113,6 +113,7 @@ const getLibrary = async (): Promise<LibraryGame[]> => {
               achievementCount: game.achievementCount ?? 0,
               // Spread gameAssets last to ensure all image URLs are properly set
               ...gameAssets,
+              title: gameAssets?.title || game.title,
               // Preserve custom image URLs from game if they exist
               customIconUrl: game.customIconUrl,
               customLogoImageUrl: game.customLogoImageUrl,

--- a/src/renderer/src/hooks/use-search-suggestions.ts
+++ b/src/renderer/src/hooks/use-search-suggestions.ts
@@ -27,10 +27,12 @@ export function useSearchSuggestions(
   const cacheRef = useRef<Map<string, SearchSuggestion[]>>(new Map());
   const librarySearchIndex = useMemo(
     () =>
-      library.map((game) => ({
-        titleLower: game.title.toLowerCase(),
-        game,
-      })),
+      library
+        .filter((game) => Boolean(game.title))
+        .map((game) => ({
+          titleLower: game.title.toLowerCase(),
+          game,
+        })),
     [library]
   );
 


### PR DESCRIPTION
### What

Stops a library game with a missing `title` from crashing the app via the header search.

### Why

Reported crash on the v4.0.4 build:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
  at useSearchSuggestions (useMemo -> Array.map -> game.title.toLowerCase())
  at Header
```

`useSearchSuggestions` runs in the header, so a single library entry with `title === undefined` takes the whole app down (surfaced by the v4.0.4 error boundary).

The title goes missing in `getLibrary`. It spreads the game's shop assets record **after** the game, and `ShopAssets.title` (typed `string`) can be `undefined` at runtime: `merge-with-remote-games` writes `title: localGame?.title || game.title`, which resolves to `undefined` when a remote game has no title and there is no matching local game. That undefined asset title then overwrites the game's real title in the merged result.

### How

- `get-library.ts`: keep the game's own title when the asset record has none (`gameAssets?.title || game.title`). A valid asset title still wins. The stored game record was never corrupted, only the merged view, so this re-heals affected libraries on the next load.
- `use-search-suggestions.ts`: skip title-less entries when building the search index, so a bad record can no longer crash the header even if one slips through.

Client/main hardening only, no API change.

**When submitting this pull request, I confirm the following:**

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.