### PR TITLE
feat(dx): open DevTools in production builds when HYDRA_DEVTOOLS=1

### DIFF
--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -44,6 +44,13 @@ interface CreateMainWindowOptions {
   forceBigPicture?: boolean;
 }
 
+const HYDRA_DEVTOOLS_ENABLED_VALUE = "1";
+
+const shouldOpenDevTools = () =>
+  !app.isPackaged ||
+  isStaging ||
+  process.env.HYDRA_DEVTOOLS === HYDRA_DEVTOOLS_ENABLED_VALUE;
+
 export class WindowManager {
   private static mainWindowInstance: Electron.BrowserWindow | null = null;
   private static gameLauncherWindowInstance: Electron.BrowserWindow | null =
@@ -386,7 +393,7 @@ export class WindowManager {
     mainWindow.removeMenu();
 
     mainWindow.on("ready-to-show", () => {
-      if (!app.isPackaged || isStaging)
+      if (shouldOpenDevTools())
         WindowManager.mainWindow?.webContents.openDevTools();
       if (shouldLaunchInBigPicture) {
         void WindowManager.openBigPictureWindow();
@@ -472,7 +479,7 @@ export class WindowManager {
 
     this.bigPicture.removeMenu();
 
-    if (!app.isPackaged || isStaging) {
+    if (shouldOpenDevTools()) {
       this.bigPicture.webContents.openDevTools();
     }
 
@@ -542,7 +549,7 @@ export class WindowManager {
 
     this.friendsWindow.once("ready-to-show", () => {
       this.friendsWindow?.show();
-      if (!app.isPackaged || isStaging) {
+      if (shouldOpenDevTools()) {
         this.friendsWindow?.webContents.openDevTools();
       }
     });
@@ -823,7 +830,7 @@ export class WindowManager {
       editorWindow.once("ready-to-show", () => {
         editorWindow.show();
         this.mainWindow?.webContents.openDevTools();
-        if (!app.isPackaged || isStaging) {
+        if (shouldOpenDevTools()) {
           editorWindow.webContents.openDevTools();
         }
       });
@@ -903,7 +910,7 @@ export class WindowManager {
       this.gameLauncherWindowInstance = null;
     });
 
-    if (!app.isPackaged || isStaging) {
+    if (shouldOpenDevTools()) {
       gameLauncherWindow.webContents.openDevTools();
     }
   }


### PR DESCRIPTION
## Summary

DevTools currently opens only in dev (`!app.isPackaged`) or staging builds. In packaged production builds `Ctrl+Shift+I` doesn't work either (menu removed, no shortcut binding), so diagnosing a renderer crash reported by a user requires either shipping them a dev build or asking them to read `logs/error.txt` blind.

## Fix

Extract a shared `shouldOpenDevTools` predicate and use it in the DevTools gate of **every** renderer window (main, big picture, friends, notification, editor, game launcher), so the flag opens DevTools for whichever window is failing — not just the main one:

```ts
const HYDRA_DEVTOOLS_ENABLED_VALUE = "1";

const shouldOpenDevTools = () =>
  !app.isPackaged ||
  isStaging ||
  process.env.HYDRA_DEVTOOLS === HYDRA_DEVTOOLS_ENABLED_VALUE;
```

Auth windows keep their stricter `!app.isPackaged` gate (they never open DevTools in staging), so they're intentionally left out.

## Usage

Launch the packaged app with the env var set to enable it:

```powershell
# PowerShell
$env:HYDRA_DEVTOOLS="1"; .\Hydra.exe
```

```bat
:: CMD
set HYDRA_DEVTOOLS=1 && Hydra.exe
```

```bash
# bash (Linux / macOS)
HYDRA_DEVTOOLS=1 ./Hydra
```

Default behavior is unchanged — no env var, no DevTools.

## Test plan

- [x] Packaged build without env var — DevTools does NOT open (unchanged).
- [x] Packaged build with `HYDRA_DEVTOOLS=1` — DevTools opens on ready-to-show.
- [x] Dev / staging builds — DevTools still opens as before.
