### PR TITLE
fix: guard Work Wonders init race causing notifyUrlChange crash

### DIFF
--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -74,6 +74,7 @@ export function App() {
   const { clearDownload, setLastPacket, lastPacket } = useDownload();
 
   const workwondersRef = useRef<WorkWonders | null>(null);
+  const workwondersInitializingRef = useRef(false);
 
   const {
     hasActiveSubscription,
@@ -175,29 +176,39 @@ export function App() {
 
   const setupWorkWonders = useCallback(
     async (token?: string, locale?: string) => {
-      if (workwondersRef.current) return;
+      if (workwondersRef.current || workwondersInitializingRef.current) return;
 
-      workwondersRef.current = new WorkWonders();
+      workwondersInitializingRef.current = true;
 
       const possibleLocales = ["en", "pt", "ru"];
 
       const parsedLocale =
         possibleLocales.find((l) => l === locale?.slice(0, 2)) ?? "en";
 
-      await workwondersRef.current.init({
-        organization: "hydra",
-        token,
-        locale: parsedLocale,
-      });
+      try {
+        const workwonders = new WorkWonders();
 
-      workwondersRef.current.changelog.initChangelogWidget();
-      workwondersRef.current.changelog.initChangelogWidgetMini();
-      const workWondersWithKnowledge =
-        workwondersRef.current as WorkWondersWithKnowledge;
-      workWondersWithKnowledge.knowledge?.initKnowledgeWidget?.();
+        await workwonders.init({
+          organization: "hydra",
+          token,
+          locale: parsedLocale,
+        });
 
-      if (token) {
-        workwondersRef.current.feedback.initFeedbackWidget();
+        workwonders.changelog.initChangelogWidget();
+        workwonders.changelog.initChangelogWidgetMini();
+        const workWondersWithKnowledge =
+          workwonders as WorkWondersWithKnowledge;
+        workWondersWithKnowledge.knowledge?.initKnowledgeWidget?.();
+
+        if (token) {
+          workwonders.feedback.initFeedbackWidget();
+        }
+
+        workwondersRef.current = workwonders;
+      } catch (error) {
+        console.error("Failed to initialize Work Wonders SDK", error);
+      } finally {
+        workwondersInitializingRef.current = false;
       }
     },
     [workwondersRef]


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Fixes the runtime error `Cannot read properties of undefined (reading 'notifyUrlChange')` thrown from the Work Wonders SDK on route changes.

### Cause

In `app.tsx`, `workwondersRef.current` was assigned synchronously from `new WorkWonders()`, but the SDK only populates `changelog` after its async `init()` resolves. The route-change effect calls `workwondersRef.current?.notifyUrlChange?.()`, and `WorkWonders.notifyUrlChange` internally does `this.changelog.notifyUrlChange()`. The optional chaining guards the ref and the method, but not `changelog`, so:

- Navigating during the `init()` network request throws once (race), and
- If `init()` bails early or throws (org fetch fails, widgets feature disabled, private org without token), `changelog` is never set and every subsequent navigation throws until reload.

### Fix

- Assign `workwondersRef.current` only after `init()` and widget setup finish, so the ref stays `null` (and `notifyUrlChange` no-ops) until the SDK is actually ready.
- Add a `workwondersInitializingRef` guard so the existing "don't init twice" check still holds during the async gap.
- Wrap setup in try/catch so an early-bail or thrown `init()` leaves the ref `null` instead of stuck in a broken state.
