### PR TITLE
fix: guard non-array API responses to prevent renderer crashes

### DIFF
--- a/src/renderer/src/components/hero/hero.tsx
+++ b/src/renderer/src/components/hero/hero.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import type { TrendingGame } from "@types";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
+import { ensureArray } from "@renderer/helpers";
 import "./hero.scss";
 
 export function Hero() {
@@ -26,7 +27,9 @@ export function Hero() {
         needsAuth: false,
       })
       .then((result) => {
-        setFeaturedGameDetails(result.slice(0, 1));
+        setFeaturedGameDetails(
+          ensureArray<TrendingGame>(result, "/catalogue/featured").slice(0, 1)
+        );
       })
       .catch(() => {
         setFeaturedGameDetails([]);

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useEffect, useRef, useState } from "react";
 
 import { setHeaderTitle } from "@renderer/features";
 import { levelDBService } from "@renderer/services/leveldb.service";
+import { ensureArray } from "@renderer/helpers";
 import { orderBy } from "lodash-es";
 import {
   useAppDispatch,
@@ -423,7 +424,12 @@ export function GameDetailsContextProvider({
           }
         );
 
-        setRepacks(downloads);
+        setRepacks(
+          ensureArray<GameRepack>(
+            downloads,
+            `/games/${shop}/${objectId}/download-sources`
+          )
+        );
       } catch (error) {
         console.error("Failed to fetch download sources:", error);
       }

--- a/src/renderer/src/context/user-profile/user-profile.context.tsx
+++ b/src/renderer/src/context/user-profile/user-profile.context.tsx
@@ -1,4 +1,4 @@
-import { darkenColor } from "@renderer/helpers";
+import { darkenColor, ensureArray } from "@renderer/helpers";
 import { useAppSelector, useToast } from "@renderer/hooks";
 import type { Badge, UserProfile, UserStats, UserGame } from "@types";
 import { average } from "color.js";
@@ -252,7 +252,7 @@ export function UserProfileContextProvider({
       `/badges?${params.toString()}`,
       { needsAuth: false }
     );
-    setBadges(badges);
+    setBadges(ensureArray<Badge>(badges, "/badges"));
   }, [i18n]);
 
   useEffect(() => {

--- a/src/renderer/src/helpers.ts
+++ b/src/renderer/src/helpers.ts
@@ -17,7 +17,11 @@ import flagAsia from "./assets/flags/asia.png";
 export const ensureArray = <T>(value: unknown, source: string): T[] => {
   if (Array.isArray(value)) return value as T[];
 
-  logger.warn(`Expected an array from ${source}, received:`, value);
+  const preview =
+    typeof value === "string" ? value.slice(0, 200) : String(value);
+  logger.warn(
+    `Expected an array from ${source}, received (${typeof value}): ${preview}`
+  );
   return [];
 };
 

--- a/src/renderer/src/helpers.ts
+++ b/src/renderer/src/helpers.ts
@@ -5,6 +5,7 @@ import i18next from "i18next";
 import { v4 as uuidv4 } from "uuid";
 import { THEME_WEB_STORE_URL } from "./constants";
 import { levelDBService } from "./services/leveldb.service";
+import { logger } from "./logger";
 
 // Pixel-art flag icons from R74n PixelFlags (https://r74n.com/pixelflags).
 import flagUS from "./assets/flags/us.png";
@@ -12,6 +13,13 @@ import flagEU from "./assets/flags/eu.png";
 import flagJP from "./assets/flags/jp.png";
 import flagKR from "./assets/flags/kr.png";
 import flagAsia from "./assets/flags/asia.png";
+
+export const ensureArray = <T>(value: unknown, source: string): T[] => {
+  if (Array.isArray(value)) return value as T[];
+
+  logger.warn(`Expected an array from ${source}, received:`, value);
+  return [];
+};
 
 export const platformToSystem = (
   platform?: string | null

--- a/src/renderer/src/helpers.ts
+++ b/src/renderer/src/helpers.ts
@@ -18,7 +18,9 @@ export const ensureArray = <T>(value: unknown, source: string): T[] => {
   if (Array.isArray(value)) return value as T[];
 
   const preview =
-    typeof value === "string" ? value.slice(0, 200) : String(value);
+    typeof value === "string"
+      ? value.slice(0, 200)
+      : JSON.stringify(value)?.slice(0, 200);
   logger.warn(
     `Expected an array from ${source}, received (${typeof value}): ${preview}`
   );

--- a/src/renderer/src/helpers.ts
+++ b/src/renderer/src/helpers.ts
@@ -17,10 +17,16 @@ import flagAsia from "./assets/flags/asia.png";
 export const ensureArray = <T>(value: unknown, source: string): T[] => {
   if (Array.isArray(value)) return value as T[];
 
-  const preview =
-    typeof value === "string"
-      ? value.slice(0, 200)
-      : JSON.stringify(value)?.slice(0, 200);
+  let preview: string | undefined;
+  try {
+    preview =
+      typeof value === "string"
+        ? value.slice(0, 200)
+        : JSON.stringify(value)?.slice(0, 200);
+  } catch {
+    preview = `<unserializable ${typeof value}>`;
+  }
+
   logger.warn(
     `Expected an array from ${source}, received (${typeof value}): ${preview}`
   );

--- a/src/renderer/src/hooks/use-feature.ts
+++ b/src/renderer/src/hooks/use-feature.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 
 import { logger } from "@renderer/logger";
+import { ensureArray } from "@renderer/helpers";
 
 enum Feature {
   CheckDownloadWritePermission = "CHECK_DOWNLOAD_WRITE_PERMISSION",
@@ -27,7 +28,7 @@ export function useFeature() {
     window.electron.hydraApi
       .get<string[]>("/features", { needsAuth: false })
       .then((response) => {
-        const safeFeatures = Array.isArray(response) ? response : [];
+        const safeFeatures = ensureArray<string>(response, "/features");
         localStorage.setItem("features", JSON.stringify(safeFeatures));
         setFeatures(safeFeatures);
       })

--- a/src/renderer/src/hooks/use-game-collections.ts
+++ b/src/renderer/src/hooks/use-game-collections.ts
@@ -8,6 +8,7 @@ import {
   setCollectionsLoading,
   setGameCollectionIds,
 } from "@renderer/features";
+import { ensureArray } from "@renderer/helpers";
 
 const getNormalizedCollectionIds = (
   game: Partial<LibraryGame> | undefined
@@ -45,8 +46,13 @@ export function useGameCollections() {
           { needsAuth: true }
         );
 
-        dispatch(setCollections(response));
-        return response;
+        const collections = ensureArray<GameCollection>(
+          response,
+          "/profile/games/collections"
+        );
+
+        dispatch(setCollections(collections));
+        return collections;
       } catch (error) {
         void error;
         return [];

--- a/src/renderer/src/pages/home/home.tsx
+++ b/src/renderer/src/pages/home/home.tsx
@@ -13,7 +13,7 @@ import flameIconStatic from "@renderer/assets/icons/flame-static.png";
 import flameIconAnimated from "@renderer/assets/icons/flame-animated.gif";
 import starsIconAnimated from "@renderer/assets/icons/stars-animated.gif";
 
-import { buildGameDetailsPath } from "@renderer/helpers";
+import { buildGameDetailsPath, ensureArray } from "@renderer/helpers";
 import { CatalogueCategory } from "@shared";
 import "./home.scss";
 
@@ -61,7 +61,13 @@ export default function Home() {
         }
       );
 
-      setCatalogue((prev) => ({ ...prev, [category]: catalogue }));
+      setCatalogue((prev) => ({
+        ...prev,
+        [category]: ensureArray<ShopAssets>(
+          catalogue,
+          `/catalogue/${category}`
+        ),
+      }));
     } finally {
       setIsLoading(false);
     }

--- a/src/renderer/src/pages/notifications/notifications.tsx
+++ b/src/renderer/src/pages/notifications/notifications.tsx
@@ -6,6 +6,7 @@ import { Button } from "@renderer/components";
 import { useAppDispatch, useToast, useUserDetails } from "@renderer/hooks";
 import { setHeaderTitle } from "@renderer/features";
 import { logger } from "@renderer/logger";
+import { ensureArray } from "@renderer/helpers";
 
 import { NotificationItem } from "./notification-item";
 import { LocalNotificationItem } from "./local-notification-item";
@@ -67,7 +68,7 @@ export default function Notifications() {
         `/badges?${params.toString()}`,
         { needsAuth: false }
       );
-      setBadges(badgesResponse);
+      setBadges(ensureArray<Badge>(badgesResponse, "/badges"));
     } catch (error) {
       logger.error("Failed to fetch badges", error);
     }


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Users were hitting the error screen with `featuredGameDetails.map is not a function` on the home hero and `catalogue[currentCatalogueCategory].map is not a function` on the catalogue.

The origin API always returns arrays on success and rejects on errors, so those paths are safe. The bad value comes from the edge: the CDN can answer with an HTML body and a 200 status (challenge/WAF page), which resolves instead of rejecting. That non-array body then reaches components that call `.map` on it and the render throws, and since the error boundary is app-wide the whole app drops to the error screen.

This adds an `ensureArray` helper that returns `[]` and logs a warning when the value is not an array, then uses it at every place we map an API list: featured hero, home catalogue, game repacks, profile badges, notification badges and game collections. The UI now renders an empty state instead of crashing, and the warning keeps the underlying edge issue visible in the logs.

This is a client-side guard, not a cure for the CDN behavior itself.