### PR TITLE
Fix Steam locale cache and SSE reconnect bursts

### DIFF
--- a/src/main/events/catalogue/get-game-shop-details.ts
+++ b/src/main/events/catalogue/get-game-shop-details.ts
@@ -1,4 +1,9 @@
-import { getSteamAppDetails, HydraApi, logger } from "@main/services";
+import {
+  getSteamAppDetails,
+  getSteamLanguage,
+  HydraApi,
+  logger,
+} from "@main/services";
 
 import type {
   ShopDetails,
@@ -196,17 +201,6 @@ const getLaunchboxShopDetails = async (
   return { ...mapped, assets };
 };
 
-const getLocalizedSteamAppDetails = async (
-  objectId: string,
-  language: string
-): Promise<ShopDetails | null> => {
-  if (language === "english") {
-    return getSteamAppDetails(objectId, language);
-  }
-
-  return getSteamAppDetails(objectId, language);
-};
-
 const getGameShopDetails = async (
   _event: Electron.IpcMainInvokeEvent,
   objectId: string,
@@ -220,33 +214,33 @@ const getGameShopDetails = async (
   }
 
   if (shop === "steam") {
+    const steamLanguage = getSteamLanguage(language);
+
     const [cachedData, cachedAssets] = await Promise.all([
       gamesShopCacheSublevel.get(
-        levelKeys.gameShopCacheItem(shop, objectId, language)
+        levelKeys.gameShopCacheItem(shop, objectId, steamLanguage)
       ),
       gamesShopAssetsSublevel.get(levelKeys.game(shop, objectId)),
     ]);
 
-    const appDetails = getLocalizedSteamAppDetails(objectId, language).then(
-      (result) => {
-        if (result) {
-          result.name = cachedAssets?.title ?? result.name;
+    const appDetails = getSteamAppDetails(objectId, language).then((result) => {
+      if (result) {
+        result.name = cachedAssets?.title ?? result.name;
 
-          gamesShopCacheSublevel
-            .put(levelKeys.gameShopCacheItem(shop, objectId, language), result)
-            .catch((err) => {
-              logger.error("Could not cache game details", err);
-            });
+        gamesShopCacheSublevel
+          .put(levelKeys.gameShopCacheItem(shop, objectId, steamLanguage), result)
+          .catch((err) => {
+            logger.error("Could not cache game details", err);
+          });
 
-          return {
-            ...result,
-            assets: cachedAssets ?? null,
-          };
-        }
-
-        return null;
+        return {
+          ...result,
+          assets: cachedAssets ?? null,
+        };
       }
-    );
+
+      return null;
+    });
 
     if (cachedData) {
       return {

--- a/src/main/events/catalogue/get-game-shop-details.ts
+++ b/src/main/events/catalogue/get-game-shop-details.ts
@@ -228,7 +228,10 @@ const getGameShopDetails = async (
         result.name = cachedAssets?.title ?? result.name;
 
         gamesShopCacheSublevel
-          .put(levelKeys.gameShopCacheItem(shop, objectId, steamLanguage), result)
+          .put(
+            levelKeys.gameShopCacheItem(shop, objectId, steamLanguage),
+            result
+          )
           .catch((err) => {
             logger.error("Could not cache game details", err);
           });

--- a/src/main/services/sse/resync.ts
+++ b/src/main/services/sse/resync.ts
@@ -1,4 +1,5 @@
 import type { FriendRequest, NotificationCountResponse } from "@types";
+import { randomInt } from "node:crypto";
 import { HydraApi } from "@main/services/hydra-api";
 import { WindowManager } from "@main/services/window-manager";
 import { logger } from "@main/services/logger";
@@ -29,7 +30,7 @@ const sleep = (ms: number, signal: AbortSignal) =>
    where pushes may have been missed while the stream was down. Each step is
    independent: one failed fetch must not block the others. */
 export const resyncAfterReconnect = async (signal: AbortSignal) => {
-  await sleep(Math.random() * RESYNC_JITTER_MS, signal);
+  await sleep(randomInt(RESYNC_JITTER_MS + 1), signal);
 
   if (signal.aborted) return;
 

--- a/src/main/services/sse/resync.ts
+++ b/src/main/services/sse/resync.ts
@@ -5,14 +5,33 @@ import { logger } from "@main/services/logger";
 
 const RESYNC_JITTER_MS = 15_000;
 
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number, signal: AbortSignal) =>
+  new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 
 /* Renderers fetch their own state at mount, so this only runs on RE-connects,
    where pushes may have been missed while the stream was down. Each step is
    independent: one failed fetch must not block the others. */
-export const resyncAfterReconnect = async () => {
-  await sleep(Math.random() * RESYNC_JITTER_MS);
+export const resyncAfterReconnect = async (signal: AbortSignal) => {
+  await sleep(Math.random() * RESYNC_JITTER_MS, signal);
+
+  if (signal.aborted) return;
 
   try {
     WindowManager.sendToAppWindows("on-friends-updated");

--- a/src/main/services/sse/resync.ts
+++ b/src/main/services/sse/resync.ts
@@ -3,10 +3,17 @@ import { HydraApi } from "@main/services/hydra-api";
 import { WindowManager } from "@main/services/window-manager";
 import { logger } from "@main/services/logger";
 
+const RESYNC_JITTER_MS = 15_000;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 /* Renderers fetch their own state at mount, so this only runs on RE-connects,
    where pushes may have been missed while the stream was down. Each step is
    independent: one failed fetch must not block the others. */
 export const resyncAfterReconnect = async () => {
+  await sleep(Math.random() * RESYNC_JITTER_MS);
+
   try {
     WindowManager.sendToAppWindows("on-friends-updated");
   } catch (err) {

--- a/src/main/services/sse/sse-client.ts
+++ b/src/main/services/sse/sse-client.ts
@@ -82,7 +82,7 @@ export class SSEClient {
           streamedThisAttempt = true;
 
           if (hasConnectedBefore) {
-            void resyncAfterReconnect();
+            void resyncAfterReconnect(attemptAbort.signal);
           }
 
           hasConnectedBefore = true;

--- a/src/main/services/sse/sse-client.ts
+++ b/src/main/services/sse/sse-client.ts
@@ -17,6 +17,7 @@ import type {
 export class SSEClient {
   private static readonly initialReconnectDelay = 1_000;
   private static readonly maxReconnectDelay = 30_000;
+  private static readonly droppedStreamReconnectSpread = 30_000;
   /* Server heartbeats every 20s; 60s without a single byte means the
      connection is dead even if the socket still looks open. */
   private static readonly stallTimeout = 60_000;
@@ -73,10 +74,12 @@ export class SSEClient {
       this.currentAttemptAbort = attemptAbort;
 
       let reconnectRequested = false;
+      let streamedThisAttempt = false;
 
       try {
         reconnectRequested = await this.streamOnce(attemptAbort, () => {
           attempt = 0;
+          streamedThisAttempt = true;
 
           if (hasConnectedBefore) {
             void resyncAfterReconnect();
@@ -120,7 +123,9 @@ export class SSEClient {
       }
 
       attempt++;
-      const delay = this.getReconnectDelay(attempt);
+      const delay = streamedThisAttempt
+        ? this.getDroppedStreamReconnectDelay()
+        : this.getReconnectDelay(attempt);
 
       logger.info(`SSE reconnecting in ${Math.round(delay / 1000)}s...`);
 
@@ -254,6 +259,13 @@ export class SSEClient {
     } catch (err) {
       logger.error(`Failed to parse SSE ${eventName} event:`, err);
     }
+  }
+
+  private static getDroppedStreamReconnectDelay() {
+    return (
+      this.initialReconnectDelay +
+      Math.random() * this.droppedStreamReconnectSpread
+    );
   }
 
   private static getReconnectDelay(attempt: number) {

--- a/src/main/services/sse/sse-client.ts
+++ b/src/main/services/sse/sse-client.ts
@@ -1,4 +1,5 @@
 import { createParser } from "eventsource-parser";
+import { randomInt } from "node:crypto";
 import { UserNotLoggedInError } from "@shared";
 import { HydraApi } from "../hydra-api";
 import { logger } from "../logger";
@@ -264,7 +265,7 @@ export class SSEClient {
   private static getDroppedStreamReconnectDelay() {
     return (
       this.initialReconnectDelay +
-      Math.random() * this.droppedStreamReconnectSpread
+      randomInt(this.droppedStreamReconnectSpread + 1)
     );
   }
 

--- a/src/main/services/steam.ts
+++ b/src/main/services/steam.ts
@@ -56,13 +56,49 @@ export const getSteamLocation = async () => {
   });
 };
 
+const steamLanguageByLocale: Record<string, string> = {
+  ar: "arabic",
+  bg: "bulgarian",
+  cs: "czech",
+  da: "danish",
+  de: "german",
+  en: "english",
+  es: "spanish",
+  fi: "finnish",
+  fr: "french",
+  hu: "hungarian",
+  id: "indonesian",
+  it: "italian",
+  ja: "japanese",
+  ko: "koreana",
+  nb: "norwegian",
+  nl: "dutch",
+  pl: "polish",
+  "pt-BR": "brazilian",
+  "pt-PT": "portuguese",
+  ro: "romanian",
+  ru: "russian",
+  sv: "swedish",
+  tr: "turkish",
+  uk: "ukrainian",
+  zh: "schinese",
+};
+
+export const getSteamLanguage = (language: string) => {
+  return (
+    steamLanguageByLocale[language] ??
+    steamLanguageByLocale[language.split("-")[0]] ??
+    "english"
+  );
+};
+
 export const getSteamAppDetails = async (
   objectId: string,
   language: string
 ) => {
   const searchParams = new URLSearchParams({
     appids: objectId,
-    l: language,
+    l: getSteamLanguage(language),
     cc: "us",
   });
 

--- a/src/main/services/steam.ts
+++ b/src/main/services/steam.ts
@@ -81,6 +81,8 @@ const steamLanguageByLocale: Record<string, string> = {
   sv: "swedish",
   tr: "turkish",
   uk: "ukrainian",
+  "zh-CN": "schinese",
+  "zh-TW": "tchinese",
   zh: "schinese",
 };
 


### PR DESCRIPTION
## Summary
- normalize Steam appdetails language values and cache keys to avoid stale locale cache hits
- spread reconnect attempts after dropped SSE streams
- add jitter before reconnect resync fetches

## Tests
- npm run typecheck:node
- pre-push hook: eslint (warnings only), typecheck:node, typecheck:web