### PR TITLE
fix: guard against undefined game title in library sort

### DIFF
--- a/src/renderer/src/pages/library/library.tsx
+++ b/src/renderer/src/pages/library/library.tsx
@@ -566,7 +566,7 @@ export default function Library() {
 
     const queryLower = deferredSearchQuery.toLowerCase();
     return filtered.filter((game) => {
-      const titleLower = game.title.toLowerCase();
+      const titleLower = (game.title ?? "").toLowerCase();
       let queryIndex = 0;
 
       for (

--- a/src/renderer/src/pages/library/library.tsx
+++ b/src/renderer/src/pages/library/library.tsx
@@ -517,7 +517,7 @@ export default function Library() {
         }
 
         case "title_desc": {
-          return b.title.localeCompare(a.title, undefined, {
+          return (b.title ?? "").localeCompare(a.title ?? "", undefined, {
             sensitivity: "base",
           });
         }
@@ -527,7 +527,7 @@ export default function Library() {
           break;
       }
 
-      return a.title.localeCompare(b.title, undefined, {
+      return (a.title ?? "").localeCompare(b.title ?? "", undefined, {
         sensitivity: "base",
       });
     });


### PR DESCRIPTION
## What this fixes

Sorting the library crashes the whole app when a game has an undefined `title`. `sortedLibrary` calls `title.localeCompare(...)`, and `getLibrary` returns `title: gameAssets?.title || game.title`, which is `undefined` when a game has neither a title nor cached shop assets (for example a game whose asset lookup failed, or a synced entry that came through without a title). `undefined.localeCompare` throws inside `Array.sort`, and the root error boundary turns that into the full "Algo deu errado" screen.

In production this surfaces as `Cannot read properties of undefined (reading 'localeCompare')` coming from the library title comparator.

## The change

Default the sort key to an empty string in both the ascending and descending title branches, so a game with a missing title sorts to the start instead of crashing:

```ts
(a.title ?? "").localeCompare(b.title ?? "", undefined, { sensitivity: "base" });
```

No change in behavior for games that already have a title.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
