### PR TITLE
fix: correct Russian translation for game hero label

### DIFF
--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -89,7 +89,7 @@
     "edit_game_modal_logo": "Логотип",
     "edit_game_modal_select_logo": "Выберите логотип",
     "edit_game_modal_logo_preview": "Предпросмотр логотипа",
-    "edit_game_modal_hero": "Изображение обложку игры",
+    "edit_game_modal_hero": "Баннер",
     "edit_game_modal_select_hero": "Выберите обложку игры",
     "edit_game_modal_hero_preview": "Предпросмотр обложки игры",
     "edit_game_modal_cancel": "Отмена",


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Fixes the Russian label for the game hero field in the edit game modal. It read "Изображение обложку игры" which is grammatically off, changed it to "Баннер".