### PR TITLE
fix: keep local SteamGridDB artwork through library sync without cloud

### DIFF
--- a/src/main/services/library-sync/merge-with-remote-games.ts
+++ b/src/main/services/library-sync/merge-with-remote-games.ts
@@ -145,7 +145,8 @@ const mergeExistingGame = (
   localGame: Game,
   remoteGame: ProfileGame,
   collectionIds: string[],
-  remoteAddedToLibraryAt: Date | null
+  remoteAddedToLibraryAt: Date | null,
+  canReconcileCustomArtwork: boolean
 ): Game => ({
   ...localGame,
   remoteId: remoteGame.id,
@@ -161,22 +162,26 @@ const mergeExistingGame = (
   achievementCount: remoteGame.achievementCount,
   unlockedAchievementCount: remoteGame.unlockedAchievementCount,
   platform: remoteGame.platform ?? localGame.platform,
-  customIconUrl: reconcileCustomAsset(
-    localGame.customIconUrl,
-    remoteGame.customIconUrl
-  ),
-  customLogoImageUrl: reconcileCustomAsset(
-    localGame.customLogoImageUrl,
-    remoteGame.customLogoImageUrl
-  ),
-  customHeroImageUrl: reconcileCustomAsset(
-    localGame.customHeroImageUrl,
-    remoteGame.customLibraryHeroImageUrl
-  ),
-  customCoverImageUrl: reconcileCustomAsset(
-    localGame.customCoverImageUrl,
-    remoteGame.customLibraryImageUrl
-  ),
+  ...(canReconcileCustomArtwork
+    ? {
+        customIconUrl: reconcileCustomAsset(
+          localGame.customIconUrl,
+          remoteGame.customIconUrl
+        ),
+        customLogoImageUrl: reconcileCustomAsset(
+          localGame.customLogoImageUrl,
+          remoteGame.customLogoImageUrl
+        ),
+        customHeroImageUrl: reconcileCustomAsset(
+          localGame.customHeroImageUrl,
+          remoteGame.customLibraryHeroImageUrl
+        ),
+        customCoverImageUrl: reconcileCustomAsset(
+          localGame.customCoverImageUrl,
+          remoteGame.customLibraryImageUrl
+        ),
+      }
+    : {}),
 });
 
 const createLocalGame = (
@@ -208,7 +213,10 @@ const createLocalGame = (
   customCoverImageUrl: remoteGame.customLibraryImageUrl ?? null,
 });
 
-const mergeRemoteGame = async (remoteGame: ProfileGame) => {
+const mergeRemoteGame = async (
+  remoteGame: ProfileGame,
+  canReconcileCustomArtwork: boolean
+) => {
   const gameKey = levelKeys.game(remoteGame.shop, remoteGame.objectId);
   const localGame = await gamesSublevel.get(gameKey);
   const hasRemoteCollectionField =
@@ -225,12 +233,16 @@ const mergeRemoteGame = async (remoteGame: ProfileGame) => {
         localGame,
         remoteGame,
         collectionIds,
-        remoteAddedToLibraryAt
+        remoteAddedToLibraryAt,
+        canReconcileCustomArtwork
       )
     : createLocalGame(remoteGame, collectionIds, remoteAddedToLibraryAt);
 
   await gamesSublevel.put(gameKey, mergedGame);
-  await syncArtworkSelectionWithRemote(gameKey, localGame, remoteGame);
+
+  if (canReconcileCustomArtwork) {
+    await syncArtworkSelectionWithRemote(gameKey, localGame, remoteGame);
+  }
 
   const localGameShopAsset = await gamesShopAssetsSublevel.get(gameKey);
   await gamesShopAssetsSublevel.put(gameKey, {
@@ -251,9 +263,11 @@ const mergeRemoteGame = async (remoteGame: ProfileGame) => {
 
 export const mergeWithRemoteGames = async () => {
   try {
+    const canReconcileCustomArtwork =
+      HydraApi.isLoggedIn() && HydraApi.hasActiveSubscription();
     const remoteGames = await fetchRemoteGames();
     for (const game of remoteGames) {
-      await mergeRemoteGame(game);
+      await mergeRemoteGame(game, canReconcileCustomArtwork);
     }
   } catch {
     // Keep local library available when remote sync fails.


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

### The bug

A user without Hydra Cloud sets an animated SteamGridDB asset (e.g. a hero) on a game. If they then open the game page from the **library** page, the hero snaps back to its default. Opening the same game from the **profile** page keeps the custom hero.

### Why it happens

Animated SteamGridDB picks aren't stored the same way as static ones. A static pick is downloaded, cropped and copied to a `local:` file on `customHeroImageUrl`. An animated pick is stored only as a selection record in `gamesArtworkSelectionSublevel`, and `customHeroImageUrl` is left null. The image is composed back into `assets.libraryHeroImageUrl` at read time.

The library page is the only place that calls `refreshLibraryAssets()` -> `mergeWithRemoteGames()`. That merge runs `reconcileRemoteArtworkSelection` against the remote profile. For a user without a subscription the pick is never uploaded, so the remote asset is always null, and the reconcile treats the local selection as a stale remote reset and deletes it. The animated hero then has nothing left to compose and falls back to the default. The profile page never triggers this merge, which is why that route stays fine.

### The fix

Gate custom artwork reconciliation (both the `customXUrl` fields and the artwork selection sync) behind `isLoggedIn() && hasActiveSubscription()`, the same gate the upload path in `game-artwork-cloud.ts` already uses. Without a subscription nothing is synced, so the remote is not authoritative and local picks are left untouched.

- Subscribed users: unchanged, cross-device reset still reconciles.
- Static `local:` assets: unchanged, already preserved by the `local:` guard.
- Non-cloud animated/selection assets: now survive library navigation.

### Testing

- `yarn typecheck:node`
- existing `reconcile-remote-artwork-selection` tests still pass (the pure function is unchanged; the fix is in the merge orchestration)