### PR TITLE
Feature: track installed repack version and show update-available action

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -246,6 +246,7 @@
     "download_options_one": "{{count}} download option",
     "download_options_other": "{{count}} download options",
     "updated_at": "Updated {{updated_at}}",
+    "update_available": "Update available ({{version}})",
     "install": "Install",
     "resume": "Resume",
     "pause": "Pause",

--- a/src/main/events/torrenting/add-game-to-queue.ts
+++ b/src/main/events/torrenting/add-game-to-queue.ts
@@ -31,6 +31,7 @@ const addGameToQueue = async (
     fileSize,
     fileIndices,
     selectedFilesSize,
+    version,
   } = payload;
 
   const parsedFileSize = parseBytes(fileSize ?? null);
@@ -72,7 +73,7 @@ const addGameToQueue = async (
     return handleDownloadError(err, downloader);
   }
 
-  await prepareGameEntry({ gameKey, title, objectId, shop });
+  await prepareGameEntry({ gameKey, title, objectId, shop, version });
 
   try {
     await downloadsSublevel.put(gameKey, download);

--- a/src/main/events/torrenting/start-game-download.ts
+++ b/src/main/events/torrenting/start-game-download.ts
@@ -29,6 +29,7 @@ const startGameDownload = async (
     automaticallyDeleteArchiveFiles,
     fileIndices,
     selectedFilesSize,
+    version,
   } = payload;
 
   const gameKey = levelKeys.game(shop, objectId);
@@ -61,7 +62,7 @@ const startGameDownload = async (
 
   try {
     await DownloadManager.validateDownloadUrl(download);
-    await prepareGameEntry({ gameKey, title, objectId, shop });
+    await prepareGameEntry({ gameKey, title, objectId, shop, version });
     await DownloadManager.cancelDownload(gameKey);
     await downloadsSublevel.put(gameKey, download);
     await DownloadOrchestrator.startPreparedDownload(download);

--- a/src/main/helpers/download-game-helper.ts
+++ b/src/main/helpers/download-game-helper.ts
@@ -10,6 +10,7 @@ interface PrepareGameEntryParams {
   title: string;
   objectId: string;
   shop: GameShop;
+  version?: string | null;
 }
 
 export const prepareGameEntry = async ({
@@ -17,6 +18,7 @@ export const prepareGameEntry = async ({
   title,
   objectId,
   shop,
+  version,
 }: PrepareGameEntryParams): Promise<void> => {
   const game = await gamesSublevel.get(gameKey);
   const gameAssets = await gamesShopAssetsSublevel.get(gameKey);
@@ -27,6 +29,7 @@ export const prepareGameEntry = async ({
     await gamesSublevel.put(gameKey, {
       ...game,
       isDeleted: false,
+      version: version ?? game.version ?? null,
     });
   } else {
     await gamesSublevel.put(gameKey, {
@@ -41,6 +44,7 @@ export const prepareGameEntry = async ({
       lastTimePlayed: null,
       addedToLibraryAt: new Date(),
       isDeleted: false,
+      version: version ?? null,
     });
   }
 };

--- a/src/main/helpers/download-game-helper.ts
+++ b/src/main/helpers/download-game-helper.ts
@@ -29,7 +29,7 @@ export const prepareGameEntry = async ({
     await gamesSublevel.put(gameKey, {
       ...game,
       isDeleted: false,
-      version: version ?? game.version ?? null,
+      version: version ?? null,
     });
   } else {
     await gamesSublevel.put(gameKey, {

--- a/src/renderer/src/pages/game-details/game-details.tsx
+++ b/src/renderer/src/pages/game-details/game-details.tsx
@@ -21,7 +21,11 @@ import {
 } from "@renderer/context";
 import { useDownload } from "@renderer/hooks";
 import { GameOptionsModal, RepacksModal } from "./modals";
-import { Downloader, getDownloadersForUri } from "@shared";
+import {
+  Downloader,
+  extractVersionFromTitle,
+  getDownloadersForUri,
+} from "@shared";
 import { CloudSyncFilesModal } from "./cloud-sync-files-modal/cloud-sync-files-modal";
 import "./game-details.scss";
 import "./hero.scss";
@@ -108,6 +112,8 @@ export default function GameDetails() {
             automaticallyDeleteArchiveFiles = false,
             signal?: AbortSignal
           ) => {
+            const version = extractVersionFromTitle(repack.title);
+
             const response = addToQueueOnly
               ? await addGameToQueue(
                   {
@@ -122,6 +128,7 @@ export default function GameDetails() {
                     fileSize: repack.fileSize,
                     fileIndices,
                     selectedFilesSize,
+                    version,
                   },
                   signal
                 )
@@ -138,6 +145,7 @@ export default function GameDetails() {
                     fileSize: repack.fileSize,
                     fileIndices,
                     selectedFilesSize,
+                    version,
                   },
                   signal
                 );

--- a/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
+++ b/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
@@ -329,7 +329,9 @@ export function HeroPanelActions() {
       if (diffFromInstalled === null || diffFromInstalled <= 0) return newest;
 
       if (!newest) return repackVersion;
-      return (compareGameVersions(repackVersion, newest) ?? 0) > 0
+      const VERSIONS_EQUAL = 0;
+      return (compareGameVersions(repackVersion, newest) ?? VERSIONS_EQUAL) >
+        VERSIONS_EQUAL
         ? repackVersion
         : newest;
     }, null);

--- a/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
+++ b/src/renderer/src/pages/game-details/hero/hero-panel-actions.tsx
@@ -16,10 +16,11 @@ import {
   useToast,
   useUserDetails,
 } from "@renderer/hooks";
-import { useContext, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { gameDetailsContext } from "@renderer/context";
+import { compareGameVersions, extractVersionFromTitle } from "@shared";
 import {
   getClassicsLaunchErrorCode,
   getClassicsLaunchErrorSystem,
@@ -313,6 +314,27 @@ export function HeroPanelActions() {
 
   const deleting = game ? isGameDeleting(game?.id) : false;
 
+  const availableUpdateVersion = useMemo(() => {
+    const installedVersion = game?.version;
+    if (!installedVersion) return null;
+
+    return repacks.reduce<string | null>((newest, repack) => {
+      const repackVersion = extractVersionFromTitle(repack.title);
+      if (!repackVersion) return newest;
+
+      const diffFromInstalled = compareGameVersions(
+        repackVersion,
+        installedVersion
+      );
+      if (diffFromInstalled === null || diffFromInstalled <= 0) return newest;
+
+      if (!newest) return repackVersion;
+      return (compareGameVersions(repackVersion, newest) ?? 0) > 0
+        ? repackVersion
+        : newest;
+    }, null);
+  }, [game?.version, repacks]);
+
   const addGameToLibraryButton = (
     <Button
       theme="outline"
@@ -428,6 +450,18 @@ export function HeroPanelActions() {
             className="hero-panel-actions__action"
           >
             {game.isPinned ? <PinSlashIcon /> : <PinIcon />}
+          </Button>
+        )}
+
+        {availableUpdateVersion && (
+          <Button
+            onClick={() => setShowRepacksModal(true)}
+            theme="outline"
+            disabled={deleting || isGameDownloading}
+            className="hero-panel-actions__action"
+          >
+            <DownloadIcon />
+            {t("update_available", { version: availableUpdateVersion })}
           </Button>
         )}
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -109,6 +109,40 @@ export const replaceNbspWithSpace = (name: string) =>
 export const replaceUnderscoreWithSpace = (name: string) =>
   name.replace(/_/g, " ");
 
+export const extractVersionFromTitle = (title: string): string | null => {
+  const versionMatch = /\bv(?:er(?:sion)?)?\.?\s*(\d+(?:\.\d+){0,3})\b/i.exec(
+    title
+  );
+  if (versionMatch) return versionMatch[1];
+
+  const buildMatch = /\bbuild\s*#?(\d+)\b/i.exec(title);
+  if (buildMatch) return `Build ${buildMatch[1]}`;
+
+  return null;
+};
+
+/**
+ * Compares two version strings extracted by `extractVersionFromTitle` by
+ * their numeric segments (e.g. "1.10.1" > "1.9"). Returns a negative number
+ * when `a` is older than `b`, positive when newer, 0 when equal, and null
+ * when either side has no numeric segments to compare.
+ */
+export const compareGameVersions = (a: string, b: string): number | null => {
+  const parse = (version: string) => version.match(/\d+/g)?.map(Number) ?? null;
+
+  const segmentsA = parse(a);
+  const segmentsB = parse(b);
+  if (!segmentsA || !segmentsB) return null;
+
+  const length = Math.max(segmentsA.length, segmentsB.length);
+  for (let i = 0; i < length; i++) {
+    const diff = (segmentsA[i] ?? 0) - (segmentsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+};
+
 export const formatName = pipe<string>(
   (str) =>
     str.replace(

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -128,6 +128,9 @@ export const extractVersionFromTitle = (title: string): string | null => {
  * when either side has no numeric segments to compare.
  */
 export const compareGameVersions = (a: string, b: string): number | null => {
+  const isBuild = (version: string) => version.toLowerCase().startsWith("build");
+  if (isBuild(a) !== isBuild(b)) return null;
+
   const parse = (version: string) => version.match(/\d+/g)?.map(Number) ?? null;
 
   const segmentsA = parse(a);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -153,6 +153,7 @@ export interface StartGameDownloadPayload {
   fileSize?: string | null;
   fileIndices?: number[];
   selectedFilesSize?: number | null;
+  version?: string | null;
 }
 
 export interface UserFriend {

--- a/src/types/level.types.ts
+++ b/src/types/level.types.ts
@@ -82,6 +82,7 @@ export interface Game {
   selectedDiscPath?: string | null;
   dontAskDiscSelection?: boolean;
   romSizeBytes?: number | null;
+  version?: string | null;
 }
 
 export interface Download {


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Closes the first slice of #2045 (version tracker). With a lot of games in the library it's hard to know what version is installed, or whether the download source has since pushed a newer build.

This PR:

- Extracts a best-effort version string (`v1.2.3` / `Build 12345`) from the title of the repack the user picks when starting a download, and stores it on the `Game` record (`version?: string | null`).
- Compares that stored version numerically (not string equality — `1.10` correctly sorts after `1.9`) against every repack currently offered by the download source.
- When a strictly newer version is found, shows an "Update available (vX.Y.Z)" action button in the game's hero panel, styled and placed identically to the other action buttons (Play/Download, favorite, pin, options) rather than replacing the primary action — clicking it opens the repacks modal so the user can grab the new version.

Deliberately out of scope for this first PR (happy to follow up):
- Manual version editing by the user.
- Treating "different" as "newer" via anything beyond numeric segment comparison (no full semver parsing).
- Any integration with external version sources (e.g. SteamDB).

No new dependencies, no DB migration needed (LevelDB is schemaless — new field is optional and simply absent on old records).