### PR TITLE
fix: improve big picture game settings navigation

### DIFF
--- a/src/big-picture/src/components/common/bumper-badge/index.tsx
+++ b/src/big-picture/src/components/common/bumper-badge/index.tsx
@@ -1,0 +1,16 @@
+import "./styles.scss";
+
+import cn from "classnames";
+
+interface BumperBadgeProps {
+  label: "LB" | "RB";
+  className?: string;
+}
+
+export function BumperBadge({ label, className }: Readonly<BumperBadgeProps>) {
+  return (
+    <span className={cn("bumper-badge", className)} aria-hidden="true">
+      {label}
+    </span>
+  );
+}

--- a/src/big-picture/src/components/common/bumper-badge/styles.scss
+++ b/src/big-picture/src/components/common/bumper-badge/styles.scss
@@ -1,0 +1,14 @@
+.bumper-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 24px;
+  padding: 0 calc(var(--spacing-unit) * 2);
+  border-radius: calc(var(--spacing-unit) * 1.5);
+  background: var(--primary);
+  color: var(--background);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}

--- a/src/big-picture/src/components/common/index.ts
+++ b/src/big-picture/src/components/common/index.ts
@@ -1,6 +1,7 @@
 export * from "./accordion";
 export * from "./animated-hero-image";
 export * from "./backdrop";
+export * from "./bumper-badge";
 export * from "./button";
 export * from "./checkbox";
 export * from "./challenge-game-card";

--- a/src/big-picture/src/components/common/sidebar-modal/index.tsx
+++ b/src/big-picture/src/components/common/sidebar-modal/index.tsx
@@ -15,7 +15,10 @@ import {
 import { createPortal } from "react-dom";
 import { IS_BROWSER } from "../../../constants";
 import { useNavigationScreenActions } from "../../../hooks";
-import { useVirtualKeyboardStore } from "../../../stores";
+import {
+  useNavigationIsFocused,
+  useVirtualKeyboardStore,
+} from "../../../stores";
 import { FocusRegionContext } from "../../context";
 import { Backdrop } from "../backdrop";
 import { FocusItem } from "../focus-item";
@@ -62,6 +65,57 @@ interface ActiveTabMetrics {
   height: number;
 }
 
+function SidebarModalTabButton<TabId extends string = string>({
+  tab,
+  focusId,
+  isActive,
+  onActivate,
+  registerElement,
+}: Readonly<{
+  tab: SidebarModalTab<TabId>;
+  focusId: string;
+  isActive: boolean;
+  onActivate: (tabId: TabId) => void;
+  registerElement: (tabId: TabId, element: HTMLButtonElement | null) => void;
+}>) {
+  const isFocused = useNavigationIsFocused(focusId);
+  const wasFocusedRef = useRef(false);
+  const setElement = useCallback(
+    (element: HTMLButtonElement | null) => registerElement(tab.id, element),
+    [registerElement, tab.id]
+  );
+
+  useEffect(() => {
+    const gainedFocus = isFocused && !wasFocusedRef.current;
+
+    if (gainedFocus && !tab.disabled && !isActive) {
+      onActivate(tab.id);
+    }
+
+    wasFocusedRef.current = isFocused;
+  }, [isActive, isFocused, onActivate, tab.disabled, tab.id]);
+
+  return (
+    <FocusItem
+      id={focusId}
+      navigationState={tab.disabled ? "disabled" : "active"}
+      actions={{ primary: () => onActivate(tab.id) }}
+      asChild
+    >
+      <button
+        type="button"
+        ref={setElement}
+        className="sidebar-modal__tab"
+        data-active={isActive || undefined}
+        disabled={tab.disabled}
+        onClick={() => onActivate(tab.id)}
+      >
+        <span className="sidebar-modal__tab-label">{tab.label}</span>
+      </button>
+    </FocusItem>
+  );
+}
+
 export function SidebarModal<TabId extends string = string>({
   visible,
   onClose,
@@ -93,7 +147,6 @@ export function SidebarModal<TabId extends string = string>({
   );
   const [activeTabMetrics, setActiveTabMetrics] =
     useState<ActiveTabMetrics | null>(null);
-  const [highlightedTabId, setHighlightedTabId] = useState<string | null>(null);
   const virtualKeyboardTarget = useVirtualKeyboardStore(
     (state) => state.target
   );
@@ -135,11 +188,12 @@ export function SidebarModal<TabId extends string = string>({
     [activeTabId, onActiveTabChange]
   );
 
-  const clearHighlightedTab = useCallback((tabId: string) => {
-    setHighlightedTabId((currentTabId) =>
-      currentTabId === tabId ? null : currentTabId
-    );
-  }, []);
+  const registerTabElement = useCallback(
+    (tabId: TabId, element: HTMLButtonElement | null) => {
+      tabElementsRef.current[tabId] = element;
+    },
+    []
+  );
 
   const updateActiveTabMetrics = useCallback(() => {
     if (!visible || !activeTab) {
@@ -338,9 +392,6 @@ export function SidebarModal<TabId extends string = string>({
                     {activeTabMetrics && (
                       <motion.div
                         className="sidebar-modal__tab-active-indicator"
-                        data-highlighted={
-                          highlightedTabId === activeTab?.id || undefined
-                        }
                         style={{ height: activeTabMetrics.height }}
                         animate={{ y: activeTabMetrics.top }}
                         initial={false}
@@ -351,46 +402,16 @@ export function SidebarModal<TabId extends string = string>({
                       />
                     )}
 
-                    {tabs.map((tab) => {
-                      const isActive = tab.id === activeTab?.id;
-
-                      return (
-                        <FocusItem
-                          key={tab.id}
-                          id={getTabFocusId(tab.id)}
-                          navigationState={tab.disabled ? "disabled" : "active"}
-                          actions={{ primary: () => setActiveTab(tab.id) }}
-                          asChild
-                        >
-                          <button
-                            type="button"
-                            ref={(element) => {
-                              tabElementsRef.current[tab.id] = element;
-                            }}
-                            className="sidebar-modal__tab"
-                            data-active={isActive || undefined}
-                            disabled={tab.disabled}
-                            onClick={() => setActiveTab(tab.id)}
-                            onFocus={() => {
-                              if (!tab.disabled) {
-                                setHighlightedTabId(tab.id);
-                              }
-                            }}
-                            onBlur={() => clearHighlightedTab(tab.id)}
-                            onMouseEnter={() => {
-                              if (tab.id === activeTab?.id) {
-                                setHighlightedTabId(tab.id);
-                              }
-                            }}
-                            onMouseLeave={() => clearHighlightedTab(tab.id)}
-                          >
-                            <span className="sidebar-modal__tab-label">
-                              {tab.label}
-                            </span>
-                          </button>
-                        </FocusItem>
-                      );
-                    })}
+                    {tabs.map((tab) => (
+                      <SidebarModalTabButton
+                        key={tab.id}
+                        tab={tab}
+                        focusId={getTabFocusId(tab.id)}
+                        isActive={tab.id === activeTab?.id}
+                        onActivate={setActiveTab}
+                        registerElement={registerTabElement}
+                      />
+                    ))}
                   </VerticalFocusGroup>
                 </aside>
 

--- a/src/big-picture/src/components/common/sidebar-modal/index.tsx
+++ b/src/big-picture/src/components/common/sidebar-modal/index.tsx
@@ -163,6 +163,7 @@ export function SidebarModal<TabId extends string = string>({
     [modalId]
   );
   const activeTabFocusId = activeTab ? getTabFocusId(activeTab.id) : undefined;
+  const isActiveTabFocused = useNavigationIsFocused(activeTabFocusId ?? "");
   const isVirtualKeyboardOpen = virtualKeyboardTarget !== null;
 
   const isTopMostModal = () => {
@@ -392,6 +393,7 @@ export function SidebarModal<TabId extends string = string>({
                     {activeTabMetrics && (
                       <motion.div
                         className="sidebar-modal__tab-active-indicator"
+                        data-highlighted={isActiveTabFocused || undefined}
                         style={{ height: activeTabMetrics.height }}
                         animate={{ y: activeTabMetrics.top }}
                         initial={false}

--- a/src/big-picture/src/components/common/sidebar-modal/styles.scss
+++ b/src/big-picture/src/components/common/sidebar-modal/styles.scss
@@ -96,7 +96,10 @@
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1.2;
-  transition: color 0.16s ease;
+  transition:
+    color 0.16s ease,
+    background-color 0.16s ease,
+    box-shadow 0.16s ease;
 
   &:focus,
   &:focus-visible {
@@ -112,6 +115,15 @@
     color: var(--text);
   }
 
+  &:not([data-active="true"]):hover:not(:disabled),
+  &:not([data-active="true"])[data-focus-visible="true"] {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+
+  &[data-focus-visible="true"] {
+    box-shadow: inset 0 0 0 2px var(--primary);
+  }
+
   &:disabled {
     cursor: default;
     opacity: 0.45;
@@ -124,11 +136,12 @@
   right: 0;
   left: 0;
   z-index: 0;
-  background: var(--secondary);
+  background: rgba(255, 255, 255, 0.08);
+  border-left: 3px solid var(--primary);
   pointer-events: none;
 
   &[data-highlighted="true"] {
-    background: color-mix(in srgb, var(--secondary) 85%, white 15%);
+    background: rgba(255, 255, 255, 0.14);
   }
 }
 

--- a/src/big-picture/src/components/common/sidebar-modal/styles.scss
+++ b/src/big-picture/src/components/common/sidebar-modal/styles.scss
@@ -1,8 +1,4 @@
-$tab-highlight-bg: rgba(255, 255, 255, 0.05);
-$tab-focus-ring-width: 2px;
 $tab-selected-bg: rgba(255, 255, 255, 0.08);
-$tab-selected-highlight-bg: rgba(255, 255, 255, 0.14);
-$tab-selected-accent-width: 3px;
 
 .sidebar-modal {
   display: grid;
@@ -102,10 +98,7 @@ $tab-selected-accent-width: 3px;
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1.2;
-  transition:
-    color 0.16s ease,
-    background-color 0.16s ease,
-    box-shadow 0.16s ease;
+  transition: color 0.16s ease;
 
   &:focus,
   &:focus-visible {
@@ -116,18 +109,8 @@ $tab-selected-accent-width: 3px;
     color: var(--text);
   }
 
-  &:hover:not(:disabled),
-  &[data-focus-visible="true"] {
+  &:hover:not(:disabled) {
     color: var(--text);
-  }
-
-  &:not([data-active="true"]):hover:not(:disabled),
-  &:not([data-active="true"])[data-focus-visible="true"] {
-    background-color: $tab-highlight-bg;
-  }
-
-  &[data-focus-visible="true"] {
-    box-shadow: inset 0 0 0 $tab-focus-ring-width var(--primary);
   }
 
   &:disabled {
@@ -143,12 +126,7 @@ $tab-selected-accent-width: 3px;
   left: 0;
   z-index: 0;
   background: $tab-selected-bg;
-  border-left: $tab-selected-accent-width solid var(--primary);
   pointer-events: none;
-
-  &[data-highlighted="true"] {
-    background: $tab-selected-highlight-bg;
-  }
 }
 
 .sidebar-modal__tab-label {

--- a/src/big-picture/src/components/common/sidebar-modal/styles.scss
+++ b/src/big-picture/src/components/common/sidebar-modal/styles.scss
@@ -1,3 +1,9 @@
+$tab-highlight-bg: rgba(255, 255, 255, 0.05);
+$tab-focus-ring-width: 2px;
+$tab-selected-bg: rgba(255, 255, 255, 0.08);
+$tab-selected-highlight-bg: rgba(255, 255, 255, 0.14);
+$tab-selected-accent-width: 3px;
+
 .sidebar-modal {
   display: grid;
   grid-template-columns: minmax(180px, 16rem) minmax(0, 1fr);
@@ -117,11 +123,11 @@
 
   &:not([data-active="true"]):hover:not(:disabled),
   &:not([data-active="true"])[data-focus-visible="true"] {
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: $tab-highlight-bg;
   }
 
   &[data-focus-visible="true"] {
-    box-shadow: inset 0 0 0 2px var(--primary);
+    box-shadow: inset 0 0 0 $tab-focus-ring-width var(--primary);
   }
 
   &:disabled {
@@ -136,12 +142,12 @@
   right: 0;
   left: 0;
   z-index: 0;
-  background: rgba(255, 255, 255, 0.08);
-  border-left: 3px solid var(--primary);
+  background: $tab-selected-bg;
+  border-left: $tab-selected-accent-width solid var(--primary);
   pointer-events: none;
 
   &[data-highlighted="true"] {
-    background: rgba(255, 255, 255, 0.14);
+    background: $tab-selected-highlight-bg;
   }
 }
 

--- a/src/big-picture/src/components/common/sidebar-modal/styles.scss
+++ b/src/big-picture/src/components/common/sidebar-modal/styles.scss
@@ -1,13 +1,12 @@
 $tab-selected-bg: rgba(255, 255, 255, 0.08);
+$tab-selected-focused-bg: rgba(255, 255, 255, 0.16);
 
 .sidebar-modal {
   display: grid;
   grid-template-columns: minmax(180px, 16rem) minmax(0, 1fr);
   overflow: hidden;
 
-  width: fit-content;
-  min-width: min(92vw, 64rem);
-  max-width: min(92vw, 76rem);
+  width: min(92vw, 64rem);
   min-height: min(42rem, calc(100vh - 4rem));
   max-height: min(100%, calc(100vh - 4rem));
   border-radius: calc(var(--spacing-unit) * 3);
@@ -127,6 +126,11 @@ $tab-selected-bg: rgba(255, 255, 255, 0.08);
   z-index: 0;
   background: $tab-selected-bg;
   pointer-events: none;
+  transition: background-color 0.16s ease;
+
+  &[data-highlighted="true"] {
+    background: $tab-selected-focused-bg;
+  }
 }
 
 .sidebar-modal__tab-label {

--- a/src/big-picture/src/components/common/tabs/index.tsx
+++ b/src/big-picture/src/components/common/tabs/index.tsx
@@ -17,7 +17,11 @@ import { useFocusLayerId, useFocusRegionId } from "../../context";
 import { FocusItem } from "../focus-item";
 import { HorizontalFocusGroup } from "../horizontal-focus-group";
 import { useGamepad } from "../../../hooks";
-import { NavigationAudioService, type FocusOverrides } from "../../../services";
+import {
+  NavigationAudioService,
+  NavigationService,
+  type FocusOverrides,
+} from "../../../services";
 import { useNavigationIsFocused, useNavigationStore } from "../../../stores";
 import { GamepadButtonType } from "../../../types";
 
@@ -445,6 +449,11 @@ export function Tabs<TValue extends string = string>({
         if (!nextItem || nextItem.value === selectedValue) return;
 
         handleSelect(nextItem.value);
+
+        if (itemsFocusable && isCurrentFocusInsideTabList()) {
+          NavigationService.getInstance().setFocus(nextItem.resolvedId);
+        }
+
         NavigationAudioService.getInstance().play("scroll");
       }
     );
@@ -471,6 +480,11 @@ export function Tabs<TValue extends string = string>({
         if (!nextItem || nextItem.value === selectedValue) return;
 
         handleSelect(nextItem.value);
+
+        if (itemsFocusable && isCurrentFocusInsideTabList()) {
+          NavigationService.getInstance().setFocus(nextItem.resolvedId);
+        }
+
         NavigationAudioService.getInstance().play("scroll");
       }
     );
@@ -484,6 +498,8 @@ export function Tabs<TValue extends string = string>({
     findNextEnabledIndex,
     handleSelect,
     isActiveGamepadEvent,
+    isCurrentFocusInsideTabList,
+    itemsFocusable,
     onButtonPressed,
     resolvedItems,
     selectedValue,
@@ -613,8 +629,6 @@ export function Tabs<TValue extends string = string>({
   }, [scrollSelectedTabIntoView, updateIndicator]);
 
   useEffect(() => {
-    if (variant === "segmented") return;
-
     const viewport = tabsViewportRef.current;
     const tabList = tabListRef.current;
 

--- a/src/big-picture/src/components/common/tabs/index.tsx
+++ b/src/big-picture/src/components/common/tabs/index.tsx
@@ -57,6 +57,7 @@ interface TabsButtonProps<TValue extends string = string> {
   variant: "default" | "segmented" | "settings";
   selectOnFocus: boolean;
   ignoreInitialFocusSelection: boolean;
+  navigationOverrides?: FocusOverrides;
   onSelect: (value: TValue) => void;
 }
 
@@ -68,6 +69,7 @@ function FocusableTabsButton<TValue extends string = string>({
   variant,
   selectOnFocus,
   ignoreInitialFocusSelection,
+  navigationOverrides,
   onSelect,
 }: Readonly<TabsButtonProps<TValue>>) {
   const isFocused = useNavigationIsFocused(resolvedId);
@@ -112,7 +114,7 @@ function FocusableTabsButton<TValue extends string = string>({
       asChild
       navigationState={item.disabled ? "disabled" : "active"}
       navigationOrder={navigationOrder}
-      navigationOverrides={item.navigationOverrides}
+      navigationOverrides={navigationOverrides}
     >
       <button
         id={resolvedId}
@@ -287,6 +289,38 @@ export function Tabs<TValue extends string = string>({
       })),
     [generatedId, items]
   );
+
+  const itemNavigationOverridesById = useMemo(() => {
+    const overridesById = new Map<string, FocusOverrides>();
+    const focusableItems = resolvedItems.filter((item) => !item.disabled);
+
+    focusableItems.forEach((item, position) => {
+      const previousItem = focusableItems[position - 1];
+      const nextItem = focusableItems[position + 1];
+      const computedOverrides: FocusOverrides = {};
+
+      if (previousItem) {
+        computedOverrides.left = {
+          type: "item",
+          itemId: previousItem.resolvedId,
+        };
+      }
+
+      if (nextItem) {
+        computedOverrides.right = {
+          type: "item",
+          itemId: nextItem.resolvedId,
+        };
+      }
+
+      overridesById.set(item.resolvedId, {
+        ...computedOverrides,
+        ...item.navigationOverrides,
+      });
+    });
+
+    return overridesById;
+  }, [resolvedItems]);
 
   const selectedItem = useMemo(
     () => resolvedItems.find((item) => item.value === selectedValue),
@@ -756,6 +790,9 @@ export function Tabs<TValue extends string = string>({
                       variant={variant}
                       selectOnFocus={selectOnFocus}
                       ignoreInitialFocusSelection={ignoreInitialFocusSelection}
+                      navigationOverrides={itemNavigationOverridesById.get(
+                        item.resolvedId
+                      )}
                       onSelect={handleSelect}
                     />
                   );

--- a/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.scss
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.scss
@@ -48,6 +48,20 @@
   flex: 0 0 auto;
 }
 
+.game-customization-settings-tab__asset-tabs-row {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--spacing-unit) * 3);
+  width: 100%;
+  min-width: 0;
+}
+
+.game-customization-settings-tab__asset-tabs-row
+  .game-customization-settings-tab__asset-tabs {
+  flex: 1;
+  min-width: 0;
+}
+
 .game-customization-settings-tab__asset-preview {
   display: flex;
   flex: 1;

--- a/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.tsx
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { isVideoArtworkUrl } from "@renderer/hooks";
 import {
+  BumperBadge,
   FileExplorerModal,
   FocusItem,
   Input,
@@ -482,17 +483,23 @@ export function GameCustomizationSettingsTab({
                 : " game-customization-settings-tab__section-content--with-picker"
             }`}
           >
-            <Tabs
-              items={assetTabItems}
-              value={selectedAssetTab}
-              defaultValue="icon"
-              onValueChange={handleAssetTabChange}
-              itemsFocusable
-              animateSegmentedIndicator={hasAssetTabsInteracted}
-              variant="segmented"
-              ariaLabel={t("edit_game_modal_assets")}
-              className="game-customization-settings-tab__asset-tabs"
-            />
+            <div className="game-customization-settings-tab__asset-tabs-row">
+              <BumperBadge label="LB" />
+
+              <Tabs
+                items={assetTabItems}
+                value={selectedAssetTab}
+                defaultValue="icon"
+                onValueChange={handleAssetTabChange}
+                itemsFocusable
+                animateSegmentedIndicator={hasAssetTabsInteracted}
+                variant="segmented"
+                ariaLabel={t("edit_game_modal_assets")}
+                className="game-customization-settings-tab__asset-tabs"
+              />
+
+              <BumperBadge label="RB" />
+            </div>
 
             <div className="game-customization-settings-tab__asset-preview">
               <FocusItem

--- a/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.tsx
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.tsx
@@ -491,7 +491,8 @@ export function GameCustomizationSettingsTab({
                 value={selectedAssetTab}
                 defaultValue="icon"
                 onValueChange={handleAssetTabChange}
-                itemsFocusable
+                itemsFocusable={false}
+                manageFocusRegion={false}
                 animateSegmentedIndicator={hasAssetTabsInteracted}
                 variant="segmented"
                 ariaLabel={t("edit_game_modal_assets")}

--- a/src/big-picture/src/components/pages/game/game-settings-modal/launch-tab.tsx
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/launch-tab.tsx
@@ -6,7 +6,7 @@ import {
 } from "@renderer/helpers";
 import type { LibraryGame, ShortcutLocation } from "@types";
 import { DiscIcon } from "@phosphor-icons/react";
-import { FolderOpen, HardDrive, Monitor, Trash } from "lucide-react";
+import { FolderOpen, Monitor, Trash } from "lucide-react";
 import { useCallback, type ReactNode, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
@@ -17,7 +17,6 @@ import {
   FocusItem,
   HorizontalFocusGroup,
   Input,
-  Tooltip,
   Typography,
   type FileFilter,
   VerticalFocusGroup,
@@ -47,7 +46,6 @@ const GAME_LAUNCH_SETTINGS_EXEC_PATH_SELECT_ID =
   "game-launch-settings-exec-path-select";
 const GAME_LAUNCH_SETTINGS_EXEC_PATH_CLEAR_ID =
   "game-launch-settings-exec-path-clear";
-const GAME_LAUNCH_SETTINGS_SAVE_FOLDER_ID = "game-launch-settings-save-folder";
 
 const REGION_LABELS: Record<SkuRegion, string> = {
   US: "United States",
@@ -57,27 +55,9 @@ const REGION_LABELS: Record<SkuRegion, string> = {
   ASIA: "Asia",
 };
 
-function getSaveFolderTooltipContent(
-  loadingSaveFolder: boolean,
-  saveFolderPath: string | null,
-  t: ReturnType<typeof useTranslation>["t"]
-) {
-  if (loadingSaveFolder) {
-    return t("searching_save_folder");
-  }
-
-  if (saveFolderPath) {
-    return t("open_save_folder");
-  }
-
-  return t("no_save_folder_found");
-}
-
 export interface GameLaunchSettingsProps {
   game: LibraryGame;
   launchOptions: string;
-  loadingSaveFolder: boolean;
-  saveFolderPath: string | null;
   creatingSteamShortcut: boolean;
   steamShortcutExists: boolean;
   shouldShowCreateStartMenuShortcut: boolean;
@@ -86,7 +66,6 @@ export interface GameLaunchSettingsProps {
   discPickerFilters: FileFilter[];
   onProcessExecPath: (path: string) => Promise<void>;
   onClearExecutablePath: () => Promise<void>;
-  onOpenSaveFolder: () => Promise<void>;
   onChangeLaunchOptions: (value: string) => void;
   onBlurLaunchOptions: () => void;
   onClearLaunchOptions: () => void;
@@ -226,24 +205,14 @@ function LaunchboxDiscsSection({
 
 interface ExecutableSectionProps {
   executablePath: LibraryGame["executablePath"];
-  showSaveFolderButton: boolean;
-  saveFolderTooltipContent: string;
-  loadingSaveFolder: boolean;
-  saveFolderPath: string | null;
   onOpenExecPicker: () => void;
   onClearExecutablePath: () => Promise<void>;
-  onOpenSaveFolder: () => Promise<void>;
 }
 
 function ExecutableSection({
   executablePath,
-  showSaveFolderButton,
-  saveFolderTooltipContent,
-  loadingSaveFolder,
-  saveFolderPath,
   onOpenExecPicker,
   onClearExecutablePath,
-  onOpenSaveFolder,
 }: Readonly<ExecutableSectionProps>) {
   const { t } = useTranslation(["game_details", "big_picture"]);
 
@@ -308,30 +277,6 @@ function ExecutableSection({
                 {t("select_executable_path", { ns: "big_picture" })}
               </Button>
             )}
-
-            {showSaveFolderButton ? (
-              <Tooltip content={saveFolderTooltipContent}>
-                <Button
-                  focusId={GAME_LAUNCH_SETTINGS_SAVE_FOLDER_ID}
-                  variant="secondary"
-                  size="icon"
-                  aria-label={t("open_save_folder")}
-                  disabled={loadingSaveFolder || !saveFolderPath}
-                  icon={<HardDrive size={16} />}
-                  onClick={() => {
-                    void onOpenSaveFolder();
-                  }}
-                  focusNavigationOverrides={{
-                    left: {
-                      type: "item",
-                      itemId: GAME_LAUNCH_SETTINGS_PRIMARY_CONTROL_ID,
-                    },
-                  }}
-                >
-                  {null}
-                </Button>
-              </Tooltip>
-            ) : null}
           </div>
         </HorizontalFocusGroup>
       </div>
@@ -524,8 +469,6 @@ function LaunchOptionsSection({
 export function GameLaunchSettingsTab({
   game,
   launchOptions,
-  loadingSaveFolder,
-  saveFolderPath,
   creatingSteamShortcut,
   steamShortcutExists,
   shouldShowCreateStartMenuShortcut,
@@ -534,7 +477,6 @@ export function GameLaunchSettingsTab({
   discPickerFilters,
   onProcessExecPath,
   onClearExecutablePath,
-  onOpenSaveFolder,
   onChangeLaunchOptions,
   onBlurLaunchOptions,
   onClearLaunchOptions,
@@ -556,14 +498,6 @@ export function GameLaunchSettingsTab({
     discs.find((disc) => disc.path === game.selectedDiscPath) ??
     discs[0] ??
     null;
-  const showSaveFolderButton =
-    !isCustomGame && globalThis.window.electron.platform === "win32";
-  const saveFolderTooltipContent = getSaveFolderTooltipContent(
-    loadingSaveFolder,
-    saveFolderPath,
-    t
-  );
-
   const handleExecPicked = useCallback(
     (path: string) => {
       setExecPickerOpen(false);
@@ -613,13 +547,8 @@ export function GameLaunchSettingsTab({
         ) : (
           <ExecutableSection
             executablePath={game.executablePath}
-            showSaveFolderButton={showSaveFolderButton}
-            saveFolderTooltipContent={saveFolderTooltipContent}
-            loadingSaveFolder={loadingSaveFolder}
-            saveFolderPath={saveFolderPath}
             onOpenExecPicker={handleOpenExecPicker}
             onClearExecutablePath={onClearExecutablePath}
-            onOpenSaveFolder={onOpenSaveFolder}
           />
         )}
 

--- a/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
@@ -51,8 +51,6 @@ export function useGameSettingsModalState({
   const { showErrorToast, showSuccessToast } = useBigPictureToast();
   const [gameTitle, setGameTitle] = useState("");
   const [launchOptions, setLaunchOptions] = useState("");
-  const [loadingSaveFolder, setLoadingSaveFolder] = useState(false);
-  const [saveFolderPath, setSaveFolderPath] = useState<string | null>(null);
   const [steamShortcutExists, setSteamShortcutExists] = useState(false);
   const [creatingSteamShortcut, setCreatingSteamShortcut] = useState(false);
   const [updatingGameTitle, setUpdatingGameTitle] = useState(false);
@@ -141,27 +139,6 @@ export function useGameSettingsModalState({
     if (!visible) return;
     setGameTitle(game?.title ?? "");
   }, [game?.id, game?.title, visible]);
-
-  useEffect(() => {
-    if (
-      !visible ||
-      !game ||
-      game.shop === "custom" ||
-      globalThis.window.electron.platform !== "win32"
-    ) {
-      setLoadingSaveFolder(false);
-      setSaveFolderPath(null);
-      return;
-    }
-
-    setLoadingSaveFolder(true);
-    setSaveFolderPath(null);
-    globalThis.window.electron
-      .getGameSaveFolder(game.shop, game.objectId)
-      .then(setSaveFolderPath)
-      .catch(() => setSaveFolderPath(null))
-      .finally(() => setLoadingSaveFolder(false));
-  }, [game, visible]);
 
   useEffect(() => {
     if (!visible || !game || game.shop === "custom") {
@@ -533,16 +510,6 @@ export function useGameSettingsModalState({
     await updateGame();
   }, [game, updateGame]);
 
-  const handleOpenSaveFolder = useCallback(async () => {
-    if (!game || !saveFolderPath) return;
-
-    await globalThis.window.electron.openGameSaveFolder(
-      game.shop,
-      game.objectId,
-      saveFolderPath
-    );
-  }, [game, saveFolderPath]);
-
   const handleCreateShortcut = useCallback(
     async (location: "desktop" | "start_menu") => {
       if (!game) return;
@@ -730,8 +697,6 @@ export function useGameSettingsModalState({
     return {
       game,
       launchOptions,
-      loadingSaveFolder,
-      saveFolderPath,
       creatingSteamShortcut,
       steamShortcutExists,
       shouldShowCreateStartMenuShortcut:
@@ -741,7 +706,6 @@ export function useGameSettingsModalState({
       discPickerFilters,
       onProcessExecPath: handleProcessExecPath,
       onClearExecutablePath: handleClearExecutablePath,
-      onOpenSaveFolder: handleOpenSaveFolder,
       onChangeLaunchOptions: setLaunchOptions,
       onBlurLaunchOptions: handleBlurLaunchOptions,
       onClearLaunchOptions: handleClearLaunchOptions,
@@ -767,15 +731,12 @@ export function useGameSettingsModalState({
     handleCreateShortcut,
     handleCreateSteamShortcut,
     handleDeleteSteamShortcut,
-    handleOpenSaveFolder,
     handleProcessDiscPath,
     handleRemoveAllDiscs,
     handleRemoveSelectedDisc,
     handleSelectDisc,
     handleToggleDontAskDiscSelection,
     launchOptions,
-    loadingSaveFolder,
-    saveFolderPath,
     steamShortcutExists,
   ]);
 

--- a/src/big-picture/src/components/pages/library/filters/filters.scss
+++ b/src/big-picture/src/components/pages/library/filters/filters.scss
@@ -74,8 +74,16 @@
   }
 
   &__tabs {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 3);
     flex-shrink: 0;
     padding: calc(var(--spacing-unit) * 6) 0 calc(var(--spacing-unit) * 4) 0;
+
+    .library-filters-tabs {
+      flex: 1;
+      min-width: 0;
+    }
 
     .library-filters-tabs .tabs__divider {
       background-color: color-mix(

--- a/src/big-picture/src/components/pages/library/filters/filters.tsx
+++ b/src/big-picture/src/components/pages/library/filters/filters.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
+  BumperBadge,
   Button,
   Divider,
   DropdownSelect,
@@ -366,6 +367,8 @@ export function LibraryFilters({
       </HorizontalFocusGroup>
 
       <div className="library-filters__tabs">
+        <BumperBadge label="LB" />
+
         <Tabs
           className="library-filters-tabs"
           items={tabItems}
@@ -375,6 +378,8 @@ export function LibraryFilters({
           itemsFocusable={false}
           ariaLabel="Library filters"
         />
+
+        <BumperBadge label="RB" />
       </div>
     </div>
   );

--- a/src/big-picture/src/components/pages/library/grid/use-library-grid-layout.ts
+++ b/src/big-picture/src/components/pages/library/grid/use-library-grid-layout.ts
@@ -1,4 +1,4 @@
-import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useLayoutEffect, useMemo, useState } from "react";
 import { LIBRARY_FOCUS_GRID_REGION_ID } from "../navigation";
 
 const GRID_NARROW_CARD_MIN_WIDTH = 260;
@@ -63,13 +63,18 @@ function calcNarrowGap(viewportWidth: number) {
   return viewportWidth <= 720 ? 16 : GRID_NARROW_COLUMN_GAP;
 }
 
-export function useLibraryGridLayout(itemCount: number) {
-  const [layout, setLayout] = useState<LibraryGridLayout>({
-    columnCount: 1,
-    columnGap: GRID_NARROW_COLUMN_GAP,
-  });
+function getInitialLayout(): LibraryGridLayout {
+  if (typeof globalThis.innerWidth !== "number") {
+    return { columnCount: 1, columnGap: GRID_NARROW_COLUMN_GAP };
+  }
 
-  useEffect(() => {
+  return getLayoutForViewport(globalThis.innerWidth, 0);
+}
+
+export function useLibraryGridLayout(itemCount: number) {
+  const [layout, setLayout] = useState<LibraryGridLayout>(getInitialLayout);
+
+  useLayoutEffect(() => {
     if (itemCount === 0) return;
 
     const gridElement = globalThis.document.querySelector(

--- a/src/big-picture/src/pages/settings/page.scss
+++ b/src/big-picture/src/pages/settings/page.scss
@@ -44,21 +44,6 @@
   max-width: 100%;
 }
 
-.settings-page__bumper {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 28px;
-  height: 24px;
-  padding: 0 calc(var(--spacing-unit) * 2);
-  border-radius: calc(var(--spacing-unit) * 1.5);
-  background: var(--primary);
-  color: var(--background);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-}
-
 .settings-page__content {
   flex: 0 0 auto;
   width: 0;

--- a/src/big-picture/src/pages/settings/settings.tsx
+++ b/src/big-picture/src/pages/settings/settings.tsx
@@ -2,7 +2,12 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
 
-import { Tabs, type TabsItem, VerticalFocusGroup } from "../../components";
+import {
+  BumperBadge,
+  Tabs,
+  type TabsItem,
+  VerticalFocusGroup,
+} from "../../components";
 import { useGamepad, useNavigation } from "../../hooks";
 import {
   NavigationAudioService,
@@ -79,10 +84,6 @@ function getSettingsSectionFromSearch(
   const section = new URLSearchParams(search).get("section");
 
   return section === "sources" ? "sources" : null;
-}
-
-function SettingsBumper({ label }: Readonly<{ label: "LB" | "RB" }>) {
-  return <div className="settings-page__bumper">{label}</div>;
 }
 
 const SETTINGS_TAB_CONTENT: Record<
@@ -351,8 +352,8 @@ export default function Settings() {
               onValueChange={setSelectedTab}
               variant="settings"
               ariaLabel="Settings categories"
-              beforeTabs={<SettingsBumper label="LB" />}
-              afterTabs={<SettingsBumper label="RB" />}
+              beforeTabs={<BumperBadge label="LB" />}
+              afterTabs={<BumperBadge label="RB" />}
             />
           </div>
 


### PR DESCRIPTION
Fixes the Big Picture game settings navigation issues from LBX-963, plus some related RB/LB polish.

## What changed

**Sidebar tab states (game settings modal)**

The active tab was hard to make out. The sidebar now switches tabs as focus lands on them, so moving through it changes the tab and its content directly instead of needing a separate press, and the active tab is marked with a clearer background and text highlight that matches how active states look elsewhere in the app.

**Asset type navigation (Customization tab)**

Moving the stick left from a middle asset type (e.g. Logo) jumped straight back to the sidebar instead of moving to the previous type. Tab items now carry per-item left/right focus overrides, so directional input walks between them; only the leftmost tab falls through to the sidebar.

**RB/LB hints and focus follow**

Added a shared `BumperBadge` component (pulled out of the settings page, which now reuses it) and used it to flank the customization asset tabs and the library filter tabs, so RB/LB switching is discoverable. RB/LB now also moves focus, so the focus ring follows the selected tab instead of staying behind. The segmented indicator also recomputes its width on resize, so it renders full width from the first paint instead of only after the first tab change.

**Library grid cover flash**

Switching from an empty collection to one with games mounted the grid fresh, and its column count started at 1 until an effect corrected it after paint, so the first cover flashed at full screen width for a frame. The column count is now seeded from the viewport up front and corrected in a layout effect before paint.

## Screenshots

**Sidebar active state**

<img width="1059" height="701" alt="image" src="https://github.com/user-attachments/assets/4185891a-c73c-4981-8a08-7576a2cee6b2" />

**RB/LB hint (asset types)**

<img width="1069" height="710" alt="image" src="https://github.com/user-attachments/assets/7bcec525-721b-4178-affe-5843575a5500" />

**RB/LB hint (library collections)**

<img width="3286" height="939" alt="image" src="https://github.com/user-attachments/assets/48e425d2-7ebe-4f2c-8eb0-cabfab57f6df" />

## Notes

- The library filter tabs badge and the grid cover flash fix are unrelated to LBX-963, but they touch the same area / reuse the same component, so they are bundled here.
- The Linear ticket also mentions the segmented asset tabs showing two outlines. That is not touched here, can follow up separately if we want it.

Linear: LBX-963

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.


