### PR TITLE
fix: keep big picture sidebar open while virtual keyboard is active

### DIFF
--- a/src/big-picture/src/components/common/virtual-keyboard/index.tsx
+++ b/src/big-picture/src/components/common/virtual-keyboard/index.tsx
@@ -933,6 +933,14 @@ export function VirtualKeyboardProvider() {
     enter();
   }, [enter, pulseKey]);
 
+  const hotkeyBack = useCallback(() => {
+    const keepFocusOnTarget =
+      target instanceof HTMLElement &&
+      target.dataset.sidebarLibrarySearch === "true";
+
+    closeKeyboard(keepFocusOnTarget);
+  }, [closeKeyboard, target]);
+
   const handleKey = useCallback(
     (key: VirtualKeyboardKey) => {
       const keyId = getKeyId(key);
@@ -999,7 +1007,7 @@ export function VirtualKeyboardProvider() {
     isOpen
       ? {
           press: {
-            b: () => closeKeyboard(false),
+            b: hotkeyBack,
             y: hotkeySpace,
           },
         }

--- a/src/big-picture/src/layout/sidebar/index.tsx
+++ b/src/big-picture/src/layout/sidebar/index.tsx
@@ -52,7 +52,7 @@ import {
 } from "../../stores/downloads.store";
 import type { DownloadProgress, LibraryGame } from "@types";
 import type { FocusNode, FocusOverrides, FocusRegion } from "../../services";
-import { useNavigationSnapshot } from "../../stores";
+import { useNavigationSnapshot, useVirtualKeyboardStore } from "../../stores";
 import {
   BIG_PICTURE_SIDEBAR_EXIT_ID,
   BIG_PICTURE_SIDEBAR_ITEM_IDS,
@@ -919,11 +919,17 @@ function Sidebar() {
       ),
     [currentFocusId, nodes, regions]
   );
+  const virtualKeyboardTarget = useVirtualKeyboardStore(
+    (state) => state.target
+  );
+  const virtualKeyboardOnSidebarSearch =
+    virtualKeyboardTarget?.dataset.sidebarLibrarySearch === "true";
   const sidebarForcedOpen =
     notificationsOpen ||
     restoringNotificationsFocus ||
     sidebarHasNavigationFocus ||
-    contextMenuState.visible;
+    contextMenuState.visible ||
+    virtualKeyboardOnSidebarSearch;
   const sidebarExpanded =
     sidebarHovered || sidebarFocusWithin || sidebarForcedOpen;
 


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

### What

Fixes the Big Picture sidebar flickering (closing and reopening) every time you move around the virtual keyboard while typing in the sidebar search with a gamepad.

### Why it happened

In gamepad mode the sidebar is only kept open by `sidebarFocusWithin`, which tracks focus capture on the search input. Navigating a virtual keyboard key moves DOM focus onto the key button, which lives outside the sidebar, so `onBlurCapture` collapses the sidebar. The virtual keyboard then refocuses the search input on the next frame, reopening it. That blur/refocus on every key press is the flicker.

### The fix

While the virtual keyboard is open and targeting the sidebar search input, the sidebar is now forced open (`virtualKeyboardOnSidebarSearch`), so the transient blur no longer collapses it. The virtual keyboard store already tracks its target, and the search input already carries the `data-sidebar-library-search` marker, so no extra plumbing was needed. The target resets to `null` when the keyboard closes, so nothing stays pinned open afterwards.

### How to test

1. Open Big Picture with a gamepad.
2. Navigate to the sidebar search and open the virtual keyboard.
3. Move between keys / type. The sidebar should stay open with no flicker.
