### PR TITLE
feat: allow custom covers for user-added games

### DIFF
--- a/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.tsx
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/customization-tab.tsx
@@ -250,7 +250,6 @@ export function GameCustomizationSettingsTab({
   const [pendingAssetTab, setPendingAssetTab] = useState<AssetTab | null>(null);
   const [assetPickerOpen, setAssetPickerOpen] = useState(false);
   const isCustomGame = game.shop === "custom";
-
   const refreshArtworkState = useCallback(async () => {
     if (game.shop === "custom") {
       setComposedAssets(null);
@@ -284,15 +283,13 @@ export function GameCustomizationSettingsTab({
       },
     ];
 
-    if (!isCustomGame) {
-      items.push({
-        value: "grid",
-        label: t("edit_game_modal_grid"),
-      });
-    }
+    items.push({
+      value: "grid",
+      label: t("edit_game_modal_grid"),
+    });
 
     return items;
-  }, [t, isCustomGame]);
+  }, [t]);
 
   const handleAssetTabChange = useCallback((value: AssetTab) => {
     setSelectedAssetTab(value);

--- a/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
+++ b/src/big-picture/src/components/pages/game/game-settings-modal/use-game-settings-modal-state.ts
@@ -192,20 +192,29 @@ export function useGameSettingsModalState({
   }, [game?.title, gameTitle]);
 
   const buildCustomGameAssetPayload = useCallback(
-    (assetType: CustomAssetType, assetValue: string | undefined) => {
+    (assetType: CustomAssetType, assetValue: string | null | undefined) => {
       if (!game) return null;
 
       return {
         shop: game.shop,
         objectId: game.objectId,
         title: getEffectiveGameTitle(),
-        iconUrl: assetType === "icon" ? assetValue : game.iconUrl || undefined,
+        iconUrl:
+          assetType === "icon"
+            ? assetValue || undefined
+            : game.iconUrl || undefined,
         logoImageUrl:
-          assetType === "logo" ? assetValue : game.logoImageUrl || undefined,
+          assetType === "logo"
+            ? assetValue || undefined
+            : game.logoImageUrl || undefined,
         libraryHeroImageUrl:
           assetType === "hero"
-            ? assetValue
+            ? assetValue || undefined
             : game.libraryHeroImageUrl || undefined,
+        customCoverImageUrl:
+          assetType === "grid"
+            ? assetValue
+            : game.customCoverImageUrl || undefined,
       };
     },
     [game, getEffectiveGameTitle]
@@ -250,10 +259,7 @@ export function useGameSettingsModalState({
       if (!game) return;
 
       if (game.shop === "custom") {
-        const payload = buildCustomGameAssetPayload(
-          assetType,
-          assetValue ?? undefined
-        );
+        const payload = buildCustomGameAssetPayload(assetType, assetValue);
 
         if (!payload) return;
 
@@ -403,7 +409,7 @@ export function useGameSettingsModalState({
         } else {
           await updateCustomizationAsset(
             assetType,
-            game.shop === "custom" ? undefined : null
+            game.shop === "custom" && assetType !== "grid" ? undefined : null
           );
         }
 

--- a/src/main/events/library/remove-game-from-library.ts
+++ b/src/main/events/library/remove-game-from-library.ts
@@ -15,7 +15,12 @@ const collectAssetPathsToDelete = (game: Game): string[] => {
 
   const assetUrls =
     game.shop === "custom"
-      ? [game.iconUrl, game.logoImageUrl, game.libraryHeroImageUrl]
+      ? [
+          game.iconUrl,
+          game.logoImageUrl,
+          game.libraryHeroImageUrl,
+          game.customCoverImageUrl,
+        ]
       : [
           game.customIconUrl,
           game.customLogoImageUrl,

--- a/src/main/events/library/update-custom-game.ts
+++ b/src/main/events/library/update-custom-game.ts
@@ -11,9 +11,11 @@ interface UpdateCustomGameParams {
   iconUrl?: string;
   logoImageUrl?: string;
   libraryHeroImageUrl?: string;
+  customCoverImageUrl?: string;
   originalIconPath?: string;
   originalLogoPath?: string;
   originalHeroPath?: string;
+  customOriginalCoverPath?: string;
 }
 
 const updateCustomGame = async (
@@ -27,9 +29,11 @@ const updateCustomGame = async (
     iconUrl,
     logoImageUrl,
     libraryHeroImageUrl,
+    customCoverImageUrl,
     originalIconPath,
     originalLogoPath,
     originalHeroPath,
+    customOriginalCoverPath,
   } = params;
   const gameKey = levelKeys.game(shop, objectId);
 
@@ -44,6 +48,7 @@ const updateCustomGame = async (
     { existing: existingGame.iconUrl, new: iconUrl },
     { existing: existingGame.logoImageUrl, new: logoImageUrl },
     { existing: existingGame.libraryHeroImageUrl, new: libraryHeroImageUrl },
+    { existing: existingGame.customCoverImageUrl, new: customCoverImageUrl },
   ];
 
   for (const { existing, new: newUrl } of assetPairs) {
@@ -58,9 +63,12 @@ const updateCustomGame = async (
     iconUrl: iconUrl || null,
     logoImageUrl: logoImageUrl || null,
     libraryHeroImageUrl: libraryHeroImageUrl || null,
+    customCoverImageUrl: customCoverImageUrl || null,
     originalIconPath: originalIconPath || existingGame.originalIconPath || null,
     originalLogoPath: originalLogoPath || existingGame.originalLogoPath || null,
     originalHeroPath: originalHeroPath || existingGame.originalHeroPath || null,
+    customOriginalCoverPath:
+      customOriginalCoverPath || existingGame.customOriginalCoverPath || null,
   };
 
   await gamesSublevel.put(gameKey, updatedGame);
@@ -74,7 +82,7 @@ const updateCustomGame = async (
       libraryHeroImageUrl: libraryHeroImageUrl || "",
       libraryImageUrl: iconUrl || "",
       logoImageUrl: logoImageUrl || "",
-      coverImageUrl: iconUrl || "",
+      coverImageUrl: customCoverImageUrl || iconUrl || "",
     };
 
     await gamesShopAssetsSublevel.put(gameKey, updatedAssets);

--- a/src/main/events/library/update-custom-game.ts
+++ b/src/main/events/library/update-custom-game.ts
@@ -11,7 +11,7 @@ interface UpdateCustomGameParams {
   iconUrl?: string;
   logoImageUrl?: string;
   libraryHeroImageUrl?: string;
-  customCoverImageUrl?: string;
+  customCoverImageUrl?: string | null;
   originalIconPath?: string;
   originalLogoPath?: string;
   originalHeroPath?: string;
@@ -48,8 +48,20 @@ const updateCustomGame = async (
     { existing: existingGame.iconUrl, new: iconUrl },
     { existing: existingGame.logoImageUrl, new: logoImageUrl },
     { existing: existingGame.libraryHeroImageUrl, new: libraryHeroImageUrl },
-    { existing: existingGame.customCoverImageUrl, new: customCoverImageUrl },
+    ...(customCoverImageUrl !== undefined
+      ? [
+          {
+            existing: existingGame.customCoverImageUrl,
+            new: customCoverImageUrl,
+          },
+        ]
+      : []),
   ];
+
+  const nextCustomCoverImageUrl =
+    customCoverImageUrl === undefined
+      ? existingGame.customCoverImageUrl
+      : customCoverImageUrl;
 
   for (const { existing, new: newUrl } of assetPairs) {
     if (existing?.startsWith("local:") && (!newUrl || existing !== newUrl)) {
@@ -63,7 +75,7 @@ const updateCustomGame = async (
     iconUrl: iconUrl || null,
     logoImageUrl: logoImageUrl || null,
     libraryHeroImageUrl: libraryHeroImageUrl || null,
-    customCoverImageUrl: customCoverImageUrl || null,
+    customCoverImageUrl: nextCustomCoverImageUrl || null,
     originalIconPath: originalIconPath || existingGame.originalIconPath || null,
     originalLogoPath: originalLogoPath || existingGame.originalLogoPath || null,
     originalHeroPath: originalHeroPath || existingGame.originalHeroPath || null,
@@ -82,7 +94,7 @@ const updateCustomGame = async (
       libraryHeroImageUrl: libraryHeroImageUrl || "",
       libraryImageUrl: iconUrl || "",
       logoImageUrl: logoImageUrl || "",
-      coverImageUrl: customCoverImageUrl || iconUrl || "",
+      coverImageUrl: nextCustomCoverImageUrl || iconUrl || "",
     };
 
     await gamesShopAssetsSublevel.put(gameKey, updatedAssets);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -554,9 +554,11 @@ contextBridge.exposeInMainWorld("electron", {
     iconUrl?: string;
     logoImageUrl?: string;
     libraryHeroImageUrl?: string;
+    customCoverImageUrl?: string;
     originalIconPath?: string;
     originalLogoPath?: string;
     originalHeroPath?: string;
+    customOriginalCoverPath?: string;
   }) => ipcRenderer.invoke("updateCustomGame", params),
   updateGameCustomAssets: (params: {
     shop: GameShop;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -554,7 +554,7 @@ contextBridge.exposeInMainWorld("electron", {
     iconUrl?: string;
     logoImageUrl?: string;
     libraryHeroImageUrl?: string;
-    customCoverImageUrl?: string;
+    customCoverImageUrl?: string | null;
     originalIconPath?: string;
     originalLogoPath?: string;
     originalHeroPath?: string;

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -204,7 +204,7 @@ declare global {
       iconUrl?: string;
       logoImageUrl?: string;
       libraryHeroImageUrl?: string;
-      customCoverImageUrl?: string;
+      customCoverImageUrl?: string | null;
       originalIconPath?: string;
       originalLogoPath?: string;
       originalHeroPath?: string;

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -204,9 +204,11 @@ declare global {
       iconUrl?: string;
       logoImageUrl?: string;
       libraryHeroImageUrl?: string;
+      customCoverImageUrl?: string;
       originalIconPath?: string;
       originalLogoPath?: string;
       originalHeroPath?: string;
+      customOriginalCoverPath?: string;
     }) => Promise<Game>;
     copyCustomGameAsset: (
       sourcePath: string,

--- a/src/renderer/src/pages/game-details/modals/game-assets-settings.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-assets-settings.tsx
@@ -350,7 +350,7 @@ export function GameAssetsSettings({
         icon: extractLocalPath(currentGame.iconUrl),
         logo: extractLocalPath(currentGame.logoImageUrl),
         hero: extractLocalPath(currentGame.libraryHeroImageUrl),
-        grid: "",
+        grid: extractLocalPath(currentGame.customCoverImageUrl),
       });
       setOriginalAssetPaths({
         icon:
@@ -362,14 +362,18 @@ export function GameAssetsSettings({
         hero:
           gameWithAssets.originalHeroPath ||
           extractLocalPath(currentGame.libraryHeroImageUrl),
-        grid: "",
+        grid:
+          currentGame.customOriginalCoverPath ||
+          extractLocalPath(currentGame.customCoverImageUrl),
       });
 
       setRemovedAssets({
         icon: iconRemoved,
         logo: logoRemoved,
         hero: heroRemoved,
-        grid: false,
+        grid:
+          !currentGame.customCoverImageUrl &&
+          Boolean(currentGame.customOriginalCoverPath),
       });
     },
     [extractLocalPath]
@@ -816,8 +820,18 @@ export function GameAssetsSettings({
         assetPaths.hero,
         currentGame.libraryHeroImageUrl
       );
+      const customCoverImageUrl = getCustomAssetUrl(
+        removedAssets.grid,
+        assetPaths.grid,
+        currentGame.customCoverImageUrl
+      );
 
-      return { iconUrl, logoImageUrl, libraryHeroImageUrl };
+      return {
+        iconUrl,
+        logoImageUrl,
+        libraryHeroImageUrl,
+        customCoverImageUrl,
+      };
     },
     [assetPaths, removedAssets]
   );
@@ -857,8 +871,12 @@ export function GameAssetsSettings({
 
   const updateCustomGame = useCallback(
     async (currentGame: LibraryGame | Game) => {
-      const { iconUrl, logoImageUrl, libraryHeroImageUrl } =
-        prepareCustomGameAssets(currentGame);
+      const {
+        iconUrl,
+        logoImageUrl,
+        libraryHeroImageUrl,
+        customCoverImageUrl,
+      } = prepareCustomGameAssets(currentGame);
 
       return window.electron.updateCustomGame({
         shop: currentGame.shop,
@@ -867,12 +885,21 @@ export function GameAssetsSettings({
         iconUrl: iconUrl || undefined,
         logoImageUrl: logoImageUrl || undefined,
         libraryHeroImageUrl: libraryHeroImageUrl || undefined,
+        customCoverImageUrl: customCoverImageUrl || undefined,
         originalIconPath: originalAssetPaths.icon || undefined,
         originalLogoPath: originalAssetPaths.logo || undefined,
         originalHeroPath: originalAssetPaths.hero || undefined,
+        customOriginalCoverPath: removedAssets.grid
+          ? undefined
+          : originalAssetPaths.grid || undefined,
       });
     },
-    [game.title, originalAssetPaths, prepareCustomGameAssets]
+    [
+      game.title,
+      originalAssetPaths,
+      prepareCustomGameAssets,
+      removedAssets.grid,
+    ]
   );
 
   const updateNonCustomGame = useCallback(
@@ -1098,14 +1125,12 @@ export function GameAssetsSettings({
     );
   };
 
-  const assetTabs = (
-    [
-      { type: "icon", labelKey: "edit_game_modal_icon" },
-      { type: "logo", labelKey: "edit_game_modal_logo" },
-      { type: "hero", labelKey: "edit_game_modal_hero" },
-      { type: "grid", labelKey: "edit_game_modal_grid" },
-    ] as const
-  ).filter((tab) => tab.type !== "grid" || !isCustomGame(game));
+  const assetTabs = [
+    { type: "icon", labelKey: "edit_game_modal_icon" },
+    { type: "logo", labelKey: "edit_game_modal_logo" },
+    { type: "hero", labelKey: "edit_game_modal_hero" },
+    { type: "grid", labelKey: "edit_game_modal_grid" },
+  ] as const;
 
   const updateTabIndicatorPosition = useCallback(() => {
     const activeTab = assetTabRefs.current[selectedAssetType];

--- a/src/renderer/src/pages/game-details/modals/game-assets-settings.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-assets-settings.tsx
@@ -885,7 +885,7 @@ export function GameAssetsSettings({
         iconUrl: iconUrl || undefined,
         logoImageUrl: logoImageUrl || undefined,
         libraryHeroImageUrl: libraryHeroImageUrl || undefined,
-        customCoverImageUrl: customCoverImageUrl || undefined,
+        customCoverImageUrl,
         originalIconPath: originalAssetPaths.icon || undefined,
         originalLogoPath: originalAssetPaths.logo || undefined,
         originalHeroPath: originalAssetPaths.hero || undefined,


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## What changed

- Expose the Cover artwork tab for user-added games.
- Reuse the existing image selection, drag-and-drop, and crop flow.
- Persist custom covers and original source paths for restoring or replacing artwork.
- Render the selected cover in the library while preserving Icon, Logo, and Library Hero behavior.

## Why

User-added games previously supported only Icon, Logo, and Library Hero customization, unlike catalog games. This gives both game types the same set of local artwork options.

## Validation

- `yarn typecheck`
- Repository pre-push ESLint hook (zero errors)
- Repository pre-push typecheck hook
- Manual Electron development launch

Linear: [LBX-968](https://linear.app/los-broxas/issue/LBX-968/allow-setting-a-cover-for-user-added-games)

Closes #2564
