### PR TITLE
fix: make download speed chart span the full chart area

### DIFF
--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -18,4 +18,6 @@ export const DOWNLOADER_NAME = {
 
 export const MAX_MINUTES_TO_SHOW_IN_PLAYTIME = 120;
 
+export const MAX_DOWNLOAD_SPEED_HISTORY = 300;
+
 export const THEME_WEB_STORE_URL = "https://hydrathemes.shop";

--- a/src/renderer/src/features/download-slice.ts
+++ b/src/renderer/src/features/download-slice.ts
@@ -2,6 +2,8 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import type { DownloadProgress, GameShop } from "@types";
 
+import { MAX_DOWNLOAD_SPEED_HISTORY } from "@renderer/constants";
+
 export interface ExtractionInfo {
   visibleId: string;
   progress: number;
@@ -31,14 +33,10 @@ export const downloadSlice = createSlice({
   reducers: {
     setLastPacket: (state, action: PayloadAction<DownloadProgress | null>) => {
       state.lastPacket = action.payload;
-
-      // Ensure payload exists and has a valid gameId before accessing
       const payload = action.payload;
       if (!state.gameId && payload?.gameId) {
         state.gameId = payload.gameId;
       }
-
-      // Track peak speed and speed history atomically when packet arrives
       if (
         payload?.gameId &&
         payload.downloadSpeed != null &&
@@ -46,21 +44,19 @@ export const downloadSlice = createSlice({
         !payload.isDownloadingMetadata
       ) {
         const { gameId, downloadSpeed } = payload;
-
-        // Update peak speed if this is higher
         const currentPeak = state.peakSpeeds[gameId] || 0;
         if (downloadSpeed > currentPeak) {
           state.peakSpeeds[gameId] = downloadSpeed;
         }
-
-        // Update speed history for chart
         if (!state.speedHistory[gameId]) {
           state.speedHistory[gameId] = [];
         }
         state.speedHistory[gameId].push(downloadSpeed);
-        // Keep only last 120 entries
-        if (state.speedHistory[gameId].length > 120) {
-          state.speedHistory[gameId].shift();
+
+        const excess =
+          state.speedHistory[gameId].length - MAX_DOWNLOAD_SPEED_HISTORY;
+        if (excess > 0) {
+          state.speedHistory[gameId].splice(0, excess);
         }
       }
     },

--- a/src/renderer/src/pages/downloads/download-group.tsx
+++ b/src/renderer/src/pages/downloads/download-group.tsx
@@ -8,7 +8,10 @@ import {
 
 import { Downloader, formatBytes, formatBytesToMbps } from "@shared";
 import { addMilliseconds } from "date-fns";
-import { DOWNLOADER_NAME } from "@renderer/constants";
+import {
+  DOWNLOADER_NAME,
+  MAX_DOWNLOAD_SPEED_HISTORY,
+} from "@renderer/constants";
 import {
   useAppSelector,
   useDownload,
@@ -147,20 +150,31 @@ function SpeedChart({
 
     const draw = () => {
       const clientWidth = canvas.clientWidth;
+      const clientHeight = canvas.clientHeight;
+      if (clientWidth <= 0 || clientHeight <= 0) {
+        animationFrameId = requestAnimationFrame(draw);
+        return;
+      }
+
       const dpr = window.devicePixelRatio || 1;
 
       canvas.width = clientWidth * dpr;
-      canvas.height = 100 * dpr;
+      canvas.height = clientHeight * dpr;
       ctx.scale(dpr, dpr);
 
       const width = clientWidth;
-      const height = 100;
+      const height = clientHeight;
       const barWidth = 4;
-      const barGap = 10;
-      const barSpacing = barWidth + barGap;
-
-      // Calculate how many bars can fit in the available width
-      const totalBars = Math.max(1, Math.floor((width + barGap) / barSpacing));
+      const minBarGap = 10;
+      const totalBars = Math.max(
+        1,
+        Math.min(
+          MAX_DOWNLOAD_SPEED_HISTORY,
+          Math.floor((width + minBarGap) / (barWidth + minBarGap))
+        )
+      );
+      const barSpacing =
+        totalBars > 1 ? (width - barWidth) / (totalBars - 1) : 0;
       const maxHeight = peakSpeed || Math.max(...speeds, 1);
 
       ctx.clearRect(0, 0, width, height);
@@ -170,7 +184,6 @@ function SpeedChart({
         b = 255;
       if (color.startsWith("#")) {
         let hex = color.replace("#", "");
-        // Handle shorthand hex colors (e.g., "#fff" -> "#ffffff")
         if (hex.length === 3) {
           hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
         }
@@ -186,6 +199,7 @@ function SpeedChart({
         }
       }
       const displaySpeeds = speeds.slice(-totalBars);
+      const firstFilledBar = totalBars - displaySpeeds.length;
 
       for (let i = 0; i < totalBars; i++) {
         const x = i * barSpacing;
@@ -194,8 +208,8 @@ function SpeedChart({
         ctx.roundRect(x, 0, barWidth, height, 3);
         ctx.fill();
 
-        if (i < displaySpeeds.length) {
-          const speed = displaySpeeds[i] || 0;
+        if (i >= firstFilledBar) {
+          const speed = displaySpeeds[i - firstFilledBar] || 0;
           const filledHeight = (speed / maxHeight) * height;
 
           if (filledHeight > 0) {
@@ -220,14 +234,10 @@ function SpeedChart({
     };
 
     animationFrameId = requestAnimationFrame(draw);
-
-    // Handle resize - trigger redraw when canvas size changes
     resizeObserver = new ResizeObserver(() => {
-      // Cancel any pending animation frame to force immediate redraw
       if (animationFrameId) {
         cancelAnimationFrame(animationFrameId);
       }
-      // Trigger a redraw that will recalculate bars based on new width
       draw();
     });
     resizeObserver.observe(canvas);


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

The speed chart on the active download never fills the whole chart area. On wide windows the bars stop somewhere in the middle and stay there, leaving a big empty strip on the right side no matter how long the download runs.

Two things caused it:

- The number of bars is derived from the container width (`floor((width + gap) / (barWidth + gap))`), but the speed history in `download-slice` was hard capped at 120 samples. Anything wider than ~1.7k px asks for more bars than the history can ever provide, so the tail never fills.
- The bars are drawn left anchored, so any shortfall (the cap above, or just the first couple of minutes of a download) shows up as dead space on the right edge, which is the part people actually look at.

What changed:

- Added a shared `MAX_DOWNLOAD_SPEED_HISTORY` constant (300) so the slice and the chart agree on how much history exists, and clamped the bar count to it.
- Spread the bar spacing across the full width so the last bar lands exactly on the right edge instead of leaving the truncation remainder unused.
- Pinned the newest sample to the right edge, so the chart streams right to left and the empty placeholders sit on the left while the history warms up.
- Sized the canvas from its real client height instead of a hardcoded 100px (the CSS box is 80px, so the drawing was being squashed) and skipped drawing when the canvas has no size yet.
