### PR TITLE
fix: support libtorrent 2.1 in the python rpc

### DIFF
--- a/python_rpc/torrent_downloader.py
+++ b/python_rpc/torrent_downloader.py
@@ -141,7 +141,7 @@ class TorrentDownloader:
             raise ValueError("invalid_magnet") from error
 
         params.save_path = save_path
-        params.flags = flags
+        params.flags = params.flags | flags
 
         trackers = list(params.trackers)
         known_trackers = set(trackers)

--- a/python_rpc/torrent_downloader.py
+++ b/python_rpc/torrent_downloader.py
@@ -146,15 +146,21 @@ class TorrentDownloader:
         trackers = list(params.trackers)
         known_trackers = set(trackers)
 
+        tiers = list(params.tracker_tiers)[: len(trackers)]
+        tiers.extend([0] * (len(trackers) - len(tiers)))
+
+        fallback_tier = max(tiers) + 1 if tiers else 0
+
         for tracker in self.trackers:
             if tracker in known_trackers:
                 continue
 
             trackers.append(tracker)
             known_trackers.add(tracker)
+            tiers.append(fallback_tier)
 
         params.trackers = trackers
-        params.tracker_tiers = [0] * len(trackers)
+        params.tracker_tiers = tiers
 
         return params
 

--- a/python_rpc/torrent_downloader.py
+++ b/python_rpc/torrent_downloader.py
@@ -122,9 +122,57 @@ class TorrentDownloader:
             max_download_speed if max_download_speed and max_download_speed > 0 else 0
         )
         try:
-            self.session.set_download_rate_limit(download_limit)
+            self.session.apply_settings({"download_rate_limit": download_limit})
+            return
         except Exception:
             pass
+
+        legacy_setter = getattr(self.session, "set_download_rate_limit", None)
+        if callable(legacy_setter):
+            try:
+                legacy_setter(download_limit)
+            except Exception:
+                pass
+
+    def _build_add_torrent_params(self, magnet: str, save_path: str, flags):
+        try:
+            params = lt.parse_magnet_uri(magnet)
+        except Exception as error:
+            raise ValueError("invalid_magnet") from error
+
+        params.save_path = save_path
+        params.flags = flags
+
+        trackers = list(params.trackers)
+        known_trackers = set(trackers)
+
+        for tracker in self.trackers:
+            if tracker in known_trackers:
+                continue
+
+            trackers.append(tracker)
+            known_trackers.add(tracker)
+
+        params.trackers = trackers
+        params.tracker_tiers = [0] * len(trackers)
+
+        return params
+
+    def _get_torrent_info(self):
+        if not self.torrent_handle or not self.torrent_handle.is_valid():
+            return None
+
+        getter = getattr(self.torrent_handle, "torrent_file", None) or getattr(
+            self.torrent_handle, "get_torrent_info", None
+        )
+
+        if not callable(getter):
+            return None
+
+        try:
+            return getter()
+        except RuntimeError:
+            return None
 
     def _wait_for_metadata(self, timeout_seconds: float = 30.0, poll_interval: float = 0.25):
         if not self.torrent_handle or not self.torrent_handle.is_valid():
@@ -221,12 +269,7 @@ class TorrentDownloader:
             else:
                 initial_flags |= lt.torrent_flags.auto_managed
 
-            params = {
-                "url": magnet,
-                "save_path": save_path,
-                "trackers": self.trackers,
-                "flags": initial_flags,
-            }
+            params = self._build_add_torrent_params(magnet, save_path, initial_flags)
 
             if self.torrent_handle is None or not self.torrent_handle.is_valid():
                 self.torrent_handle = self.session.add_torrent(params)
@@ -242,11 +285,11 @@ class TorrentDownloader:
                 if not self._wait_for_metadata(timeout_seconds=wait_timeout_seconds):
                     raise TimeoutError("metadata_timeout")
 
-                try:
-                    info = self.torrent_handle.get_torrent_info()
-                    files_storage = info.files()
-                except RuntimeError as error:
-                    raise RuntimeError("metadata_incomplete") from error
+                info = self._get_torrent_info()
+                if info is None:
+                    raise RuntimeError("metadata_incomplete")
+
+                files_storage = info.files()
 
                 self.torrent_handle.pause()
                 self.torrent_handle.unset_flags(lt.torrent_flags.auto_managed)
@@ -267,10 +310,9 @@ class TorrentDownloader:
         if not self._wait_for_metadata(timeout_seconds=timeout_seconds):
             raise TimeoutError("metadata_timeout")
 
-        try:
-            info = self.torrent_handle.get_torrent_info()
-        except RuntimeError as error:
-            raise RuntimeError("metadata_incomplete") from error
+        info = self._get_torrent_info()
+        if info is None:
+            raise RuntimeError("metadata_incomplete")
 
         files_storage = info.files()
         file_count = files_storage.num_files()
@@ -311,7 +353,11 @@ class TorrentDownloader:
 
     def abort_session(self):
         self.cancel_download()
-        self.session.abort()
+
+        abort = getattr(self.session, "abort", None)
+        if callable(abort):
+            abort()
+
         self.torrent_handle = None
         self.selected_file_indices = None
         self.selected_size_bytes = None
@@ -332,10 +378,7 @@ class TorrentDownloader:
         if not status.has_metadata:
             return None
 
-        try:
-            return self.torrent_handle.get_torrent_info()
-        except RuntimeError:
-            return None
+        return self._get_torrent_info()
 
     def _get_file_size(self, status, info):
         total_wanted = getattr(status, "total_wanted", 0)


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Every download fails in dev on machines whose system Python has libtorrent 2.1:

```
ERROR hydra.rpc: Unhandled RPC error: 'unknown name in torrent params: url'
  File "python_rpc/torrent_downloader.py", line 232, in start_download
    self.torrent_handle = self.session.add_torrent(params)
KeyError: 'unknown name in torrent params: url'
```

Packaged builds are not affected: CI freezes the RPC with libtorrent 2.0 from PyPI, which still exposes the deprecated fields. Dev spawns the system `python3` instead (`src/main/services/python-rpc.ts`), so on distros shipping 2.1 (Arch/CachyOS, among others) it hits a build compiled without the deprecated ABI, where `add_torrent_params::url` no longer exists.

Three more calls in the same file are gone in 2.1 for the same reason. They were latent behind the first failure, except the rate limit one, which was already failing silently inside a bare `except`:

- `torrent_handle.get_torrent_info()` -> `torrent_file()`
- `session.set_download_rate_limit()` -> `apply_settings({"download_rate_limit": ...})`
- `session.abort()` -> removed with no replacement

**What changed**

- Build the params through `lt.parse_magnet_uri()` and set `save_path` / `flags` on the returned `add_torrent_params`, instead of the `url` dict key. The trackers the magnet already carries are kept and ours are appended without duplicates, which the old `trackers` key would have overwritten.
- Read metadata through `torrent_file()` when present, falling back to `get_torrent_info()`, and treat a missing `torrent_info` as `metadata_incomplete` rather than relying on a `RuntimeError`.
- Apply the download limit via `apply_settings`, keeping the legacy setter as a fallback.
- Guard `session.abort()` behind a `getattr` check.

An invalid magnet now surfaces as `invalid_magnet` instead of `internal_error`, since `parse_magnet_uri` raises where the old code deferred to `add_torrent`.

**Compatibility**

Works on 1.2 through 2.1. Every API used here landed in 1.2 at the latest, which is the floor the file already had through `lt.torrent_flags`, `set_flags`/`unset_flags` and `session.delete_partfile`, so the supported range is unchanged apart from gaining 2.1.

**Testing**

- Ran the downloader against libtorrent 2.1.0 directly: `add_torrent` succeeds, the tracker list merges as expected, flags and `save_path` land on the handle, the status payload is unchanged, and `metadata_timeout` / `invalid_magnet` / cancel / abort all behave.
- Started a download from the app in dev on 2.1.0 and it went through with no RPC error.
- Could not exercise 2.0 locally, so that side rests on the API review above plus CI.
