### PR TITLE
feat: add similar games recommendations

### DIFF
--- a/src/big-picture/src/components/common/context-menu/index.tsx
+++ b/src/big-picture/src/components/common/context-menu/index.tsx
@@ -254,7 +254,16 @@ export function ContextMenu({
               const focusId = `${menuRegionId}-${item.id}`;
 
               return (
-                <FocusItem key={item.id} id={focusId} asChild>
+                <FocusItem
+                  key={item.id}
+                  id={focusId}
+                  actions={{
+                    primary: () => {
+                      void handleItemSelect(item);
+                    },
+                  }}
+                  asChild
+                >
                   <button
                     type="button"
                     role="menuitem"

--- a/src/big-picture/src/components/pages/game/navigation.ts
+++ b/src/big-picture/src/components/pages/game/navigation.ts
@@ -9,6 +9,7 @@ export const GAME_MEDIA_CAROUSEL_REGION_ID = "game-media-carousel";
 export const GAME_DESCRIPTION_REGION_ID = "game-description";
 export const GAME_DESCRIPTION_BODY_ID = "game-description-body";
 export const GAME_DESCRIPTION_BOTTOM_ENTRY_ID = "game-description-bottom-entry";
+export const GAME_SIMILAR_GAMES_REGION_ID = "game-similar-games";
 export const GAME_COMMENTS_REGION_ID = "game-comments";
 export const GAME_COMMENTS_ACTION_ROWS_REGION_ID = "game-comments-action-rows";
 export const GAME_COMMENTS_LOAD_MORE_ID = "game-comments-load-more";
@@ -25,6 +26,15 @@ export const GAME_SIDEBAR_LANGUAGES_ID = "game-sidebar-languages";
 
 export function getGameMediaCarouselItemId(index: number) {
   return `game-media-carousel-item-${index}`;
+}
+
+export function getGameSimilarGameItemId(
+  sourceShop: string,
+  sourceObjectId: string,
+  gameShop: string,
+  gameObjectId: string
+) {
+  return `game-similar-${sourceShop}-${sourceObjectId}-${gameShop}-${gameObjectId}`;
 }
 
 export function getGameCommentVoteItemId(

--- a/src/big-picture/src/layout/sidebar/index.tsx
+++ b/src/big-picture/src/layout/sidebar/index.tsx
@@ -315,13 +315,6 @@ function SidebarRouter() {
     },
     right: contentEntryTarget,
   };
-  const getRouteNavigationOverrides = (itemId: string): FocusOverrides =>
-    itemId === BIG_PICTURE_SIDEBAR_ITEM_IDS.home
-      ? {
-          ...sidebarItemNavigationOverrides,
-          up: getItemFocusTarget(BIG_PICTURE_SIDEBAR_PROFILE_ID),
-        }
-      : sidebarItemNavigationOverrides;
   const handleExitBigPicture = () => {
     if (IS_DESKTOP) {
       globalThis.close();
@@ -380,9 +373,33 @@ function SidebarRouter() {
     return route.key !== "componentLab";
   });
 
+  const getRouteNavigationOverrides = (index: number): FocusOverrides => {
+    const previousRoute = routes[index - 1];
+    const nextRoute = routes[index + 1];
+
+    return {
+      ...sidebarItemNavigationOverrides,
+      up: previousRoute
+        ? getItemFocusTarget(BIG_PICTURE_SIDEBAR_ITEM_IDS[previousRoute.key])
+        : getItemFocusTarget(BIG_PICTURE_SIDEBAR_PROFILE_ID),
+      down: nextRoute
+        ? getItemFocusTarget(BIG_PICTURE_SIDEBAR_ITEM_IDS[nextRoute.key])
+        : getItemFocusTarget(BIG_PICTURE_SIDEBAR_EXIT_ID),
+    };
+  };
+
+  const lastRoute = routes.at(-1);
+  const exitNavigationOverrides: FocusOverrides = {
+    ...sidebarItemNavigationOverrides,
+    up: lastRoute
+      ? getItemFocusTarget(BIG_PICTURE_SIDEBAR_ITEM_IDS[lastRoute.key])
+      : getItemFocusTarget(BIG_PICTURE_SIDEBAR_PROFILE_ID),
+    down: getItemFocusTarget(BIG_PICTURE_SIDEBAR_LIBRARY_FILTER_ALL_ID),
+  };
+
   return (
     <div className="sidebar-router-container">
-      {routes.map((route) => {
+      {routes.map((route, index) => {
         const itemId = BIG_PICTURE_SIDEBAR_ITEM_IDS[route.key];
 
         return (
@@ -393,7 +410,8 @@ function SidebarRouter() {
             icon={<route.icon size={24} />}
             active={activeSidebarItemId === itemId}
             focusId={itemId}
-            focusNavigationOverrides={getRouteNavigationOverrides(itemId)}
+            focusActions={{ primary: () => navigate(route.path) }}
+            focusNavigationOverrides={getRouteNavigationOverrides(index)}
           />
         );
       })}
@@ -401,7 +419,8 @@ function SidebarRouter() {
       <div className="state-wrapper">
         <FocusItem
           id={BIG_PICTURE_SIDEBAR_EXIT_ID}
-          navigationOverrides={sidebarItemNavigationOverrides}
+          actions={{ primary: handleExitBigPicture }}
+          navigationOverrides={exitNavigationOverrides}
           asChild
         >
           <button
@@ -569,6 +588,7 @@ function SidebarLibrary({
               index,
               filter.focusId
             )}
+            actions={{ primary: () => setSelectedLibraryFilter(filter.value) }}
             asChild
           >
             <button

--- a/src/big-picture/src/locales/en/translation.json
+++ b/src/big-picture/src/locales/en/translation.json
@@ -735,6 +735,8 @@
     "download_sources_removed_other": "{{count}} download sources were removed",
     "download_sources_count_one": "{{count}} download source",
     "download_sources_count_other": "{{count}} download sources",
+    "similar_games": "More like this",
+    "no_similar_games": "No similar games found",
     "game_review_played_for": "after playing for {{time}}",
     "game_review_rating_only": "rating",
     "remove_from_library": "Remove from Library",

--- a/src/big-picture/src/locales/es/translation.json
+++ b/src/big-picture/src/locales/es/translation.json
@@ -710,6 +710,7 @@
     "steamgriddb_artwork_reset": "Arte restablecido al valor predeterminado"
   },
   "format": {
+    "similar_games": "Juegos similares",
     "playtime_hours_one": "{{count}} hora",
     "playtime_hours_other": "{{count}} horas",
     "playtime_minutes_one": "{{count}} minuto",

--- a/src/big-picture/src/locales/fr/translation.json
+++ b/src/big-picture/src/locales/fr/translation.json
@@ -721,6 +721,7 @@
     "steamgriddb_artwork_reset": "Illustration réinitialisée par défaut"
   },
   "format": {
+    "similar_games": "Jeux similaires",
     "playtime_hours_one": "{{count}} heure",
     "playtime_hours_other": "{{count}} heures",
     "playtime_minutes_one": "{{count}} minute",

--- a/src/big-picture/src/locales/pt-BR/translation.json
+++ b/src/big-picture/src/locales/pt-BR/translation.json
@@ -731,6 +731,7 @@
     "download_options_unavailable_other": "{{formattedCount}} opções de download não estão mais disponíveis.",
     "download_sources_removed_one": "{{count}} fonte de download foi removida",
     "download_sources_removed_other": "{{count}} fontes de download foram removidas",
+    "similar_games": "Ver similares",
     "edit_game_modal_section_title": "Título do Jogo",
     "edit_game_modal_section_title_description": "Edite o título exibido para este jogo na sua biblioteca.",
     "edit_game_modal_section_assets_description": "Escolha qual arte você quer personalizar para este jogo.",

--- a/src/big-picture/src/locales/ru/translation.json
+++ b/src/big-picture/src/locales/ru/translation.json
@@ -715,6 +715,7 @@
     "steamgriddb_artwork_reset": "Оформление сброшено по умолчанию"
   },
   "format": {
+    "similar_games": "Похожие игры",
     "playtime_hours_one": "{{count}} час",
     "playtime_hours_few": "{{count}} часа",
     "playtime_hours_many": "{{count}} часов",

--- a/src/big-picture/src/pages/game/game-metadata.test.ts
+++ b/src/big-picture/src/pages/game/game-metadata.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { extractGenreNames } from "./game-metadata.js";
+
+describe("extractGenreNames", () => {
+  it("extracts, trims, and deduplicates supported genre shapes", () => {
+    assert.deepEqual(
+      extractGenreNames([
+        { name: " RPG " },
+        { description: "Strategy" },
+        "strategy",
+        null,
+      ]),
+      ["RPG", "Strategy"]
+    );
+  });
+});

--- a/src/big-picture/src/pages/game/game-metadata.ts
+++ b/src/big-picture/src/pages/game/game-metadata.ts
@@ -1,0 +1,24 @@
+export function extractGenreNames(genres: readonly unknown[]) {
+  const seen = new Set<string>();
+
+  return genres
+    .map((genre) => {
+      if (typeof genre === "string") return genre.trim();
+      if (!genre || typeof genre !== "object") return "";
+
+      const { name, description } = genre as {
+        name?: unknown;
+        description?: unknown;
+      };
+      const value = typeof name === "string" ? name : description;
+
+      return typeof value === "string" ? value.trim() : "";
+    })
+    .filter((genre) => {
+      const normalizedGenre = genre.toLocaleLowerCase();
+      if (!normalizedGenre || seen.has(normalizedGenre)) return false;
+
+      seen.add(normalizedGenre);
+      return true;
+    });
+}

--- a/src/big-picture/src/pages/game/game.scss
+++ b/src/big-picture/src/pages/game/game.scss
@@ -107,6 +107,68 @@
     }
   }
 
+  &__similar-games {
+    width: 100%;
+    min-width: 0;
+
+    .focus-carousel {
+      padding: 0 0 calc(var(--spacing-unit) * 8);
+    }
+
+    .focus-carousel__slide {
+      flex-basis: calc(260px + var(--focus-carousel-ring-space) * 2);
+    }
+  }
+
+  &__similar-games-skeleton-actions {
+    display: flex;
+    gap: calc(var(--spacing-unit) * 3);
+
+    .skeleton {
+      width: 44px;
+      height: 44px;
+      border-radius: var(--spacing-unit);
+    }
+  }
+
+  &__similar-games-skeleton-card {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 5);
+    width: 100%;
+  }
+
+  &__similar-games-skeleton-cover {
+    width: 100%;
+    aspect-ratio: 268 / 400;
+    border-radius: var(--spacing-unit);
+  }
+
+  &__similar-games-skeleton-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-unit);
+    padding-bottom: calc(var(--spacing-unit) * 2);
+  }
+
+  &__similar-games-skeleton-title,
+  &__similar-games-skeleton-subtitle {
+    height: 17px;
+    border-radius: var(--spacing-unit);
+  }
+
+  &__similar-games-skeleton-title {
+    width: 72%;
+  }
+
+  &__similar-games-skeleton-subtitle {
+    width: 48%;
+  }
+
+  &__similar-games-empty-state {
+    min-height: 450px;
+  }
+
   &__sidebar-stats {
     display: flex;
     gap: 16px;

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -6,16 +6,29 @@ import {
   getSkuRegionFlag,
   type SkuRegion,
 } from "@renderer/helpers";
-import type { GameShop } from "@types";
+import type { GameShop, ShopAssets } from "@types";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { buildLibraryToastOptions, getItemFocusTarget } from "../../helpers";
+import {
+  buildLibraryToastOptions,
+  getBigPictureGameDetailsPath,
+  getItemFocusTarget,
+} from "../../helpers";
+import {
+  getSimilarGamesSectionState,
+  SIMILAR_GAMES_LIMIT,
+} from "@renderer/hooks/similar-games";
+import { useSimilarGames } from "@renderer/hooks/use-similar-games";
 import type { LibraryToastSource } from "../../helpers/library-toast";
 import {
   Typography,
   VerticalFocusGroup,
   Divider,
   FocusItem,
+  FocusCarousel,
+  Skeleton,
+  EmptyState,
 } from "../../components";
 import {
   ConfirmationModal,
@@ -55,6 +68,7 @@ import {
   GAME_HERO_ACTIONS_REGION_ID,
   GAME_MEDIA_CAROUSEL_REGION_ID,
   GAME_PAGE_REGION_ID,
+  GAME_SIMILAR_GAMES_REGION_ID,
   GAME_SIDEBAR_ACHIEVEMENTS_ID,
   GAME_SIDEBAR_CONTROLLER_SUPPORT_ID,
   GAME_SIDEBAR_HLTB_ID,
@@ -64,9 +78,11 @@ import {
   GAME_SIDEBAR_REGION_ID,
   GAME_SIDEBAR_REQUIREMENTS_ID,
   GAME_SIDEBAR_STATS_ID,
+  getGameSimilarGameItemId,
 } from "../../components/pages/game/navigation";
 import { NavigationService, type FocusOverrideTarget } from "../../services";
 import { useNavigationStore } from "../../stores";
+import { extractGenreNames } from "./game-metadata";
 import "./game.scss";
 
 const DESCRIPTION_HEADING_SELECTOR = "h1, h2, h3, h4, h5, h6";
@@ -99,7 +115,6 @@ const DESCRIPTION_SCROLL_EDGE_TOLERANCE = 4;
 const DESCRIPTION_FOCUS_ENTRY_MARGIN = 32;
 const DESCRIPTION_SCROLL_ANIMATION_DURATION = 220;
 const DESCRIPTION_RETURN_MIN_VISIBLE_RATIO = 0.5;
-
 type ClassicsLaunchErrorCode = NonNullable<
   ReturnType<typeof getClassicsLaunchErrorCode>
 >;
@@ -415,7 +430,69 @@ function buildDescriptionSections(document: Document | null) {
   return sections;
 }
 
+function SimilarGamesSkeleton({ title }: Readonly<{ title: string }>) {
+  return (
+    <section
+      className="focus-carousel game-page__similar-games-skeleton"
+      data-card-variant="vertical"
+      aria-label={title}
+      aria-busy="true"
+    >
+      <div className="focus-carousel__header">
+        <h2 className="focus-carousel__title">{title}</h2>
+        <div
+          className="game-page__similar-games-skeleton-actions"
+          aria-hidden="true"
+        >
+          <Skeleton />
+          <Skeleton />
+        </div>
+      </div>
+
+      <div className="focus-carousel__viewport-wrapper">
+        <div className="focus-carousel__viewport">
+          <div className="focus-carousel__container">
+            {Array.from({ length: SIMILAR_GAMES_LIMIT }, (_, index) => (
+              <article
+                className="focus-carousel__slide"
+                key={`similar-game-skeleton-${index}`}
+              >
+                <div className="game-page__similar-games-skeleton-card">
+                  <Skeleton className="game-page__similar-games-skeleton-cover" />
+                  <div className="game-page__similar-games-skeleton-body">
+                    <Skeleton className="game-page__similar-games-skeleton-title" />
+                    <Skeleton className="game-page__similar-games-skeleton-subtitle" />
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SimilarGamesEmptyState({
+  title,
+  message,
+}: Readonly<{ title: string; message: string }>) {
+  return (
+    <section className="focus-carousel game-page__similar-games-empty">
+      <div className="focus-carousel__header">
+        <h2 className="focus-carousel__title">{title}</h2>
+      </div>
+
+      <EmptyState
+        className="game-page__similar-games-empty-state"
+        title={message}
+      />
+    </section>
+  );
+}
+
 export default function Game() {
+  const { t } = useTranslation("big_picture");
   const { showErrorToast, showSuccessToast } = useBigPictureToast();
   const { shop, objectId } = useParams<{ shop: GameShop; objectId: string }>();
   const navigate = useNavigate();
@@ -548,19 +625,40 @@ export default function Game() {
   const developer = shopDetails?.developers?.[0] ?? "";
   const publisher = shopDetails?.publishers?.[0] ?? "";
   const releaseDate = shopDetails?.release_date?.date ?? "";
-  const launchboxGenres = useMemo(() => {
-    return ((shopDetails?.genres ?? []) as unknown[])
-      .map((genre) => {
-        if (typeof genre === "string") return genre;
-        if (genre && typeof genre === "object" && "name" in genre) {
-          const { name } = genre as { name?: unknown };
-          return typeof name === "string" ? name : "";
-        }
-
-        return "";
-      })
-      .filter((genre) => genre.trim().length > 0);
+  const shopGenres = useMemo(() => {
+    return extractGenreNames(shopDetails?.genres ?? []);
   }, [shopDetails?.genres]);
+  const {
+    games: similarGames,
+    isLoading: areSimilarGamesLoading,
+    isEligible: areSimilarGamesEligible,
+  } = useSimilarGames({
+    objectId: objectId ?? "",
+    shop: shop ?? "custom",
+  });
+  const similarCarouselGames = useMemo<ShopAssets[]>(
+    () =>
+      similarGames.map((similarGame) => ({
+        objectId: similarGame.objectId,
+        shop: similarGame.shop,
+        title: similarGame.title,
+        iconUrl: similarGame.iconUrl,
+        libraryHeroImageUrl: similarGame.libraryHeroImageUrl,
+        libraryImageUrl: similarGame.libraryImageUrl,
+        logoImageUrl: similarGame.logoImageUrl,
+        logoPosition: null,
+        coverImageUrl: similarGame.coverImageUrl,
+        downloadSources: similarGame.downloadSources,
+      })),
+    [similarGames]
+  );
+  const similarGamesSectionState = getSimilarGamesSectionState(
+    areSimilarGamesEligible,
+    areSimilarGamesLoading,
+    similarCarouselGames.length
+  );
+  const hasSimilarGames = similarGamesSectionState === "ready";
+  const shouldRenderSimilarGames = similarGamesSectionState !== "hidden";
   const launchboxRegions = useMemo(
     () =>
       shopDetails?.skus && shopDetails.skus.length > 0
@@ -592,6 +690,16 @@ export default function Game() {
       preferRememberedFocus: true,
     };
   }, [hasNavigableComments]);
+  const similarGamesEntryTarget = useMemo(() => {
+    if (!hasSimilarGames) return undefined;
+
+    return {
+      type: "region" as const,
+      regionId: GAME_SIMILAR_GAMES_REGION_ID,
+      entryDirection: "down" as const,
+      preferRememberedFocus: true,
+    };
+  }, [hasSimilarGames]);
   const bodyUpNavigationTarget = useMemo<FocusOverrideTarget>(() => {
     if (activeMediaItemId) {
       return getItemFocusTarget(activeMediaItemId);
@@ -635,12 +743,15 @@ export default function Game() {
       };
     }
 
-    return descriptionEntryTarget ?? commentsEntryTarget;
+    return (
+      descriptionEntryTarget ?? similarGamesEntryTarget ?? commentsEntryTarget
+    );
   }, [
     activeMediaItemId,
     commentsEntryTarget,
     descriptionEntryTarget,
     hasMedia,
+    similarGamesEntryTarget,
   ]);
   const sidebarEntryTarget = useMemo(
     () => sidebarStatsEntryTarget,
@@ -656,6 +767,13 @@ export default function Game() {
     []
   );
   const commentsTopNavigationTarget = useMemo(() => {
+    if (similarGamesEntryTarget) {
+      return {
+        ...similarGamesEntryTarget,
+        entryDirection: "up" as const,
+      };
+    }
+
     if (descriptionBottomEntryTarget) {
       return descriptionBottomEntryTarget;
     }
@@ -670,7 +788,53 @@ export default function Game() {
     descriptionBottomEntryTarget,
     hasMedia,
     heroActionsLeftNavigationTarget,
+    similarGamesEntryTarget,
   ]);
+
+  const similarGamesTopNavigationTarget = useMemo<FocusOverrideTarget>(() => {
+    if (descriptionBottomEntryTarget) return descriptionBottomEntryTarget;
+    if (activeMediaItemId) return getItemFocusTarget(activeMediaItemId);
+
+    if (hasMedia) {
+      return {
+        type: "region",
+        regionId: GAME_MEDIA_CAROUSEL_REGION_ID,
+        entryDirection: "up",
+        preferRememberedFocus: true,
+      };
+    }
+
+    return heroActionsLeftNavigationTarget;
+  }, [
+    activeMediaItemId,
+    descriptionBottomEntryTarget,
+    hasMedia,
+    heroActionsLeftNavigationTarget,
+  ]);
+
+  const getSimilarGameNavigationOverrides = useCallback(
+    (_similarGame: ShopAssets, index: number, games: ShopAssets[]) => ({
+      up: similarGamesTopNavigationTarget,
+      down: commentsEntryTarget ?? ({ type: "block" } as const),
+      ...(index === 0
+        ? { left: getItemFocusTarget(BIG_PICTURE_SIDEBAR_ITEM_IDS.home) }
+        : {}),
+      ...(index === games.length - 1
+        ? { right: { type: "block" as const } }
+        : {}),
+    }),
+    [commentsEntryTarget, similarGamesTopNavigationTarget]
+  );
+  const getSimilarGameItemId = useCallback(
+    (similarGame: ShopAssets) =>
+      getGameSimilarGameItemId(
+        shop!,
+        objectId!,
+        similarGame.shop,
+        similarGame.objectId
+      ),
+    [objectId, shop]
+  );
   useHeaderTitle(resolvedGameTitle);
 
   const handleOpenDownloadModal = useCallback(() => {
@@ -1046,7 +1210,9 @@ export default function Game() {
                 return;
               }
 
-              focusNavigationTarget(commentsEntryTarget);
+              focusNavigationTarget(
+                similarGamesEntryTarget ?? commentsEntryTarget
+              );
             },
             left: () => {
               navigation.setFocus(BIG_PICTURE_SIDEBAR_ITEM_IDS.home);
@@ -1121,6 +1287,10 @@ export default function Game() {
       previousRegionId,
       GAME_COMMENTS_ACTION_ROWS_REGION_ID
     );
+    const enteredFromSimilarGames = isRegionWithinTree(
+      previousRegionId,
+      GAME_SIMILAR_GAMES_REGION_ID
+    );
     const enteredFromSidebar = isRegionWithinTree(
       previousRegionId,
       GAME_SIDEBAR_REGION_ID
@@ -1134,11 +1304,12 @@ export default function Game() {
       return;
     }
 
-    const targetScrollTop = enteredFromComments
-      ? bounds.descriptionBottom -
-        bounds.pageClientHeight +
-        DESCRIPTION_FOCUS_ENTRY_MARGIN
-      : bounds.descriptionTop - DESCRIPTION_FOCUS_ENTRY_MARGIN;
+    const targetScrollTop =
+      enteredFromComments || enteredFromSimilarGames
+        ? bounds.descriptionBottom -
+          bounds.pageClientHeight +
+          DESCRIPTION_FOCUS_ENTRY_MARGIN
+        : bounds.descriptionTop - DESCRIPTION_FOCUS_ENTRY_MARGIN;
     const nextScrollTop = Math.min(
       Math.max(0, targetScrollTop),
       bounds.maxScrollTop
@@ -1309,7 +1480,9 @@ export default function Game() {
                 screenshots={shopDetails.screenshots ?? []}
                 onActiveItemChange={setActiveMediaItemId}
                 nextContentEntryTarget={
-                  descriptionEntryTarget ?? commentsEntryTarget
+                  descriptionEntryTarget ??
+                  similarGamesEntryTarget ??
+                  commentsEntryTarget
                 }
                 sidebarEntryTarget={sidebarStatsEntryTarget}
               />
@@ -1372,6 +1545,39 @@ export default function Game() {
                   </FocusItem>
                 </VerticalFocusGroup>
               )}
+
+              {shouldRenderSimilarGames ? (
+                <>
+                  <Divider />
+                  <div className="game-page__similar-games">
+                    {similarGamesSectionState === "loading" ? (
+                      <SimilarGamesSkeleton title={t("similar_games")} />
+                    ) : null}
+                    {similarGamesSectionState === "empty" ? (
+                      <SimilarGamesEmptyState
+                        title={t("similar_games")}
+                        message={t("no_similar_games")}
+                      />
+                    ) : null}
+                    {similarGamesSectionState === "ready" ? (
+                      <FocusCarousel
+                        title={t("similar_games")}
+                        cardVariant="vertical"
+                        games={similarCarouselGames}
+                        regionId={GAME_SIMILAR_GAMES_REGION_ID}
+                        getItemId={getSimilarGameItemId}
+                        getItemNavigationOverrides={
+                          getSimilarGameNavigationOverrides
+                        }
+                        onItemActivate={(similarGame) =>
+                          navigate(getBigPictureGameDetailsPath(similarGame))
+                        }
+                        showRightFade
+                      />
+                    ) : null}
+                  </div>
+                </>
+              ) : null}
 
               <Divider />
 
@@ -1498,13 +1704,13 @@ export default function Game() {
                       </div>
                     ) : null}
 
-                    {isLaunchboxGame && launchboxGenres.length > 0 ? (
+                    {isLaunchboxGame && shopGenres.length > 0 ? (
                       <div className="game-page__metadata-row">
                         <Typography className="game-page__metadata-label">
                           Genres
                         </Typography>
                         <Typography className="game-page__metadata-value">
-                          {launchboxGenres.join(", ")}
+                          {shopGenres.join(", ")}
                         </Typography>
                       </div>
                     ) : null}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -296,6 +296,8 @@
     "last_time_played": "Last played {{period}}",
     "not_played_yet": "You haven't played {{title}} yet",
     "next_suggestion": "Next suggestion",
+    "similar_games": "More like this",
+    "no_similar_games": "No similar games found",
     "play": "Play",
     "deleting": "Deleting installer…",
     "close": "Close",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -237,6 +237,7 @@
     "mode_modern_games": "Juegos modernos"
   },
   "game_details": {
+    "similar_games": "Juegos similares",
     "bios_not_configured_toast": "BIOS no encontrada. Añade la carpeta de BIOS en los ajustes de Emulación.",
     "open_download_options": "Abrir opciones de descargas",
     "download_options_zero": "Sin opciones de descargas",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -247,6 +247,7 @@
     "platforms": "Plateformes"
   },
   "game_details": {
+    "similar_games": "Jeux similaires",
     "open_download_options": "Ouvrir les options de téléchargement",
     "download_options_zero": "Aucune option de téléchargement",
     "download_options_one": "{{count}} option de téléchargement",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -259,6 +259,7 @@
     "no_downloads": "Nenhum download disponível",
     "play_time": "Jogou por {{amount}}",
     "next_suggestion": "Próxima sugestão",
+    "similar_games": "Ver similares",
     "install": "Instalar",
     "last_time_played": "Última sessão {{period}}",
     "play": "Jogar",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -251,6 +251,7 @@
     "platforms": "Платформы"
   },
   "game_details": {
+    "similar_games": "Похожие игры",
     "bios_not_configured_toast": "BIOS не найден. Добавьте папку BIOS в настройках эмуляции.",
     "open_download_options": "Открыть источники",
     "download_options_zero": "Нет источников",

--- a/src/renderer/src/components/index.ts
+++ b/src/renderer/src/components/index.ts
@@ -14,6 +14,7 @@ export * from "./radio-field/radio-field";
 export * from "./link/link";
 export * from "./select-field/select-field";
 export * from "./toast/toast";
+export * from "./vertical-cover-card/vertical-cover-card";
 export * from "./badge/badge";
 export * from "./confirmation-modal/confirmation-modal";
 export * from "./suspense-wrapper/suspense-wrapper";

--- a/src/renderer/src/components/vertical-cover-card/vertical-cover-card-image-sources.ts
+++ b/src/renderer/src/components/vertical-cover-card/vertical-cover-card-image-sources.ts
@@ -1,0 +1,14 @@
+export const getVerticalCoverCardImageSources = (
+  sources: readonly (string | null | undefined)[]
+) => {
+  const seen = new Set<string>();
+
+  return sources.reduce<string[]>((result, source) => {
+    const normalizedSource = source?.trim();
+    if (!normalizedSource || seen.has(normalizedSource)) return result;
+
+    seen.add(normalizedSource);
+    result.push(normalizedSource);
+    return result;
+  }, []);
+};

--- a/src/renderer/src/components/vertical-cover-card/vertical-cover-card.scss
+++ b/src/renderer/src/components/vertical-cover-card/vertical-cover-card.scss
@@ -1,0 +1,113 @@
+@use "../../scss/globals.scss";
+
+.vertical-cover-card {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  padding: 0;
+  overflow: hidden;
+  color: inherit;
+  background: globals.$background-color;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: 0 8px 10px -2px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+  transition: all ease 0.2s;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 172%;
+    background: linear-gradient(
+      35deg,
+      rgba(0, 0, 0, 0.1) 0%,
+      rgba(0, 0, 0, 0.07) 51.5%,
+      rgba(255, 255, 255, 0.15) 54%,
+      rgba(255, 255, 255, 0.15) 100%
+    );
+    opacity: 0.5;
+    pointer-events: none;
+    transform: translateY(-36%);
+    transition: all ease 0.3s;
+  }
+
+  &:hover::before {
+    opacity: 1;
+    transform: translateY(-20%);
+  }
+
+  &:active {
+    opacity: globals.$active-opacity;
+  }
+
+  &__image {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__classics-cover {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: #0a0a0a;
+  }
+
+  &__classics-backdrop {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: blur(16px) saturate(1.1);
+    opacity: 0.65;
+    pointer-events: none;
+    transform: scale(1.25);
+  }
+
+  &__classics-image {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    width: auto;
+    height: auto;
+    max-width: 80%;
+    max-height: 80%;
+    margin: auto;
+    object-fit: contain;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+    box-shadow:
+      0 11px 7px rgba(0, 0, 0, 0.05),
+      0 5px 5px rgba(0, 0, 0, 0.09),
+      0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  &__placeholder {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    color: rgba(255, 255, 255, 0.3);
+    background: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.08) 0%,
+      rgba(255, 255, 255, 0.04) 50%,
+      rgba(255, 255, 255, 0.08) 100%
+    );
+
+    svg {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+}

--- a/src/renderer/src/components/vertical-cover-card/vertical-cover-card.test.ts
+++ b/src/renderer/src/components/vertical-cover-card/vertical-cover-card.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getVerticalCoverCardImageSources } from "./vertical-cover-card-image-sources.js";
+
+describe("getVerticalCoverCardImageSources", () => {
+  it("preserves fallback order while trimming and deduplicating sources", () => {
+    assert.deepEqual(
+      getVerticalCoverCardImageSources([
+        " https://example.com/cover.jpg ",
+        "https://example.com/library.jpg",
+        "https://example.com/cover.jpg",
+        "",
+        null,
+        "https://example.com/icon.jpg",
+      ]),
+      [
+        "https://example.com/cover.jpg",
+        "https://example.com/library.jpg",
+        "https://example.com/icon.jpg",
+      ]
+    );
+  });
+});

--- a/src/renderer/src/components/vertical-cover-card/vertical-cover-card.tsx
+++ b/src/renderer/src/components/vertical-cover-card/vertical-cover-card.tsx
@@ -1,0 +1,122 @@
+import { ImageIcon } from "@primer/octicons-react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import { isAnimatedCoverCandidate, useCoverPoster } from "@renderer/hooks";
+import { getVerticalCoverCardImageSources } from "./vertical-cover-card-image-sources";
+
+import "./vertical-cover-card.scss";
+
+export interface VerticalCoverCardProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  gameTitle: string;
+  coverImageUrls: readonly (string | null | undefined)[];
+  children?: ReactNode;
+  useClassicsLayout?: boolean;
+  showTitleTooltip?: boolean;
+}
+
+export function VerticalCoverCard({
+  gameTitle,
+  coverImageUrls,
+  children,
+  useClassicsLayout = false,
+  showTitleTooltip = true,
+  className,
+  onMouseEnter,
+  onMouseLeave,
+  ...buttonProps
+}: Readonly<VerticalCoverCardProps>) {
+  const imageSources = getVerticalCoverCardImageSources(coverImageUrls);
+  const imageSourcesKey = imageSources.join("\u0000");
+  const [imageIndex, setImageIndex] = useState(0);
+  const [isHovered, setIsHovered] = useState(false);
+  const failedImageSourcesRef = useRef(new Set<string>());
+  const coverImageUrl = imageSources[imageIndex];
+  const isAnimatedCover = isAnimatedCoverCandidate(coverImageUrl);
+  const coverPoster = useCoverPoster(coverImageUrl, isAnimatedCover);
+  const displayCoverUrl =
+    (isAnimatedCover && !isHovered && coverPoster
+      ? coverPoster
+      : coverImageUrl) ?? undefined;
+
+  useEffect(() => {
+    failedImageSourcesRef.current.clear();
+    setImageIndex(0);
+  }, [imageSourcesKey]);
+
+  const handleImageError = () => {
+    if (!coverImageUrl || failedImageSourcesRef.current.has(coverImageUrl)) {
+      return;
+    }
+
+    failedImageSourcesRef.current.add(coverImageUrl);
+    setImageIndex((currentIndex) => currentIndex + 1);
+  };
+
+  const renderCoverMedia = () => {
+    if (!displayCoverUrl) {
+      return (
+        <div className="vertical-cover-card__placeholder">
+          <ImageIcon size={48} />
+        </div>
+      );
+    }
+
+    if (useClassicsLayout) {
+      return (
+        <div className="vertical-cover-card__classics-cover">
+          <img
+            src={displayCoverUrl}
+            alt=""
+            aria-hidden="true"
+            className="vertical-cover-card__classics-backdrop"
+            loading="lazy"
+            decoding="async"
+            onError={handleImageError}
+          />
+          <img
+            src={displayCoverUrl}
+            alt={gameTitle}
+            className="vertical-cover-card__classics-image"
+            loading="lazy"
+            decoding="async"
+            onError={handleImageError}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <img
+        src={displayCoverUrl}
+        alt={gameTitle}
+        className="vertical-cover-card__image"
+        loading="lazy"
+        decoding="async"
+        onError={handleImageError}
+      />
+    );
+  };
+
+  return (
+    <button
+      {...buttonProps}
+      type="button"
+      className={["vertical-cover-card", className].filter(Boolean).join(" ")}
+      aria-label={buttonProps["aria-label"] ?? gameTitle}
+      title={showTitleTooltip ? (buttonProps.title ?? gameTitle) : undefined}
+      onMouseEnter={(event) => {
+        setIsHovered(true);
+        onMouseEnter?.(event);
+      }}
+      onMouseLeave={(event) => {
+        setIsHovered(false);
+        onMouseLeave?.(event);
+      }}
+    >
+      {children}
+      {renderCoverMedia()}
+    </button>
+  );
+}

--- a/src/renderer/src/hooks/index.ts
+++ b/src/renderer/src/hooks/index.ts
@@ -11,6 +11,7 @@ export * from "./use-download-options-listener";
 export * from "./use-game-card";
 export * from "./use-search-history";
 export * from "./use-search-suggestions";
+export * from "./use-similar-games";
 export * from "./use-game-collections";
 export * from "./use-classics-scan";
 export * from "./use-retroarch-scan";

--- a/src/renderer/src/hooks/similar-games.test.ts
+++ b/src/renderer/src/hooks/similar-games.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  fetchSimilarGames,
+  getSimilarGamesSectionState,
+  normalizeSimilarGamesResponse,
+  type SimilarGame,
+  type SimilarGamesGet,
+} from "./similar-games.js";
+
+describe("getSimilarGamesSectionState", () => {
+  it("uses the same hidden, loading, ready, and empty states on both surfaces", () => {
+    assert.equal(getSimilarGamesSectionState(false, false, 0), "hidden");
+    assert.equal(getSimilarGamesSectionState(true, true, 0), "loading");
+    assert.equal(getSimilarGamesSectionState(true, false, 1), "ready");
+    assert.equal(getSimilarGamesSectionState(true, false, 0), "empty");
+  });
+});
+
+const game = (
+  objectId: string,
+  overrides: Partial<SimilarGame> = {}
+): SimilarGame => ({
+  objectId,
+  shop: "steam",
+  title: `Game ${objectId}`,
+  iconUrl: null,
+  libraryHeroImageUrl: null,
+  libraryImageUrl: `https://example.com/${objectId}.jpg`,
+  coverImageUrl: null,
+  logoImageUrl: null,
+  downloadSources: [],
+  ...overrides,
+});
+
+describe("normalizeSimilarGamesResponse", () => {
+  const query = { objectId: "current", shop: "steam" as const };
+
+  it("preserves server order while excluding invalid identities and duplicates", () => {
+    const results = normalizeSimilarGamesResponse(
+      [
+        game("first"),
+        game("current"),
+        game("other-shop", { shop: "launchbox" }),
+        game("first"),
+        game("second"),
+      ],
+      query
+    );
+
+    assert.deepEqual(
+      results.map(({ objectId }) => objectId),
+      ["first", "second"]
+    );
+  });
+
+  it("rejects blank identities, trims valid identities, and preserves the limit", () => {
+    const results = normalizeSimilarGamesResponse(
+      [
+        game(" \t "),
+        game("blank-title", { title: " \t " }),
+        game(" padded-id ", { title: " Padded title " }),
+        ...Array.from({ length: 8 }, (_, index) => game(`valid-${index}`)),
+      ],
+      query
+    );
+
+    assert.equal(results.length, 9);
+    assert.equal(results[0].objectId, "padded-id");
+    assert.equal(results[0].title, "Padded title");
+  });
+
+  it("drops malformed download sources and limits results to nine", () => {
+    const response = Array.from({ length: 12 }, (_, index) => ({
+      ...game(String(index)),
+      downloadSources: [
+        `Source ${index}`,
+        { id: `source-${index}` },
+        { name: "Legacy" },
+        "",
+      ],
+    }));
+
+    const results = normalizeSimilarGamesResponse(response, query);
+
+    assert.equal(results.length, 9);
+    assert.deepEqual(results[0].downloadSources, ["Source 0"]);
+  });
+
+  it("keeps API-resolved profile cover artwork", () => {
+    const [result] = normalizeSimilarGamesResponse(
+      [
+        game("profile-cover", {
+          coverImageUrl: "https://example.com/profile-cover.jpg",
+        }),
+      ],
+      query
+    );
+
+    assert.equal(result.coverImageUrl, "https://example.com/profile-cover.jpg");
+  });
+
+  it("skips malformed games without rejecting usable results", () => {
+    const results = normalizeSimilarGamesResponse(
+      [
+        null,
+        { objectId: "broken", shop: "steam" },
+        {
+          ...game("missing-sources"),
+          downloadSources: undefined,
+        },
+        game("valid"),
+      ],
+      query
+    );
+
+    assert.deepEqual(
+      results.map(({ objectId }) => objectId),
+      ["missing-sources", "valid"]
+    );
+    assert.deepEqual(results[0].downloadSources, []);
+  });
+
+  it("rejects malformed top-level endpoint responses", () => {
+    assert.throws(() => normalizeSimilarGamesResponse({}, query), TypeError);
+  });
+});
+
+describe("fetchSimilarGames", () => {
+  it("calls the similar endpoint with the shared nine-game limit", async () => {
+    const calls: {
+      path: string;
+      options: Parameters<SimilarGamesGet>[1];
+    }[] = [];
+    const get: SimilarGamesGet = async (path, options) => {
+      calls.push({ path, options });
+      return [game("result")];
+    };
+
+    const results = await fetchSimilarGames(
+      { objectId: "game/id", shop: "steam" },
+      get,
+      ["source-b", "source-a"]
+    );
+
+    assert.equal(results.length, 1);
+    assert.deepEqual(calls, [
+      {
+        path: "/catalogue/steam/game%2Fid/similar",
+        options: {
+          params: {
+            take: 9,
+            downloadSourceIds: ["source-b", "source-a"],
+          },
+          needsAuth: false,
+        },
+      },
+    ]);
+  });
+
+  it("does not request unsupported custom games", async () => {
+    let calls = 0;
+    const get: SimilarGamesGet = async () => {
+      calls += 1;
+      return [];
+    };
+
+    const results = await fetchSimilarGames(
+      { objectId: "custom", shop: "custom" },
+      get
+    );
+
+    assert.deepEqual(results, []);
+    assert.equal(calls, 0);
+  });
+});

--- a/src/renderer/src/hooks/similar-games.ts
+++ b/src/renderer/src/hooks/similar-games.ts
@@ -1,0 +1,144 @@
+import type { GameShop } from "@types";
+
+export const SIMILAR_GAMES_LIMIT = 9;
+
+export type SimilarGamesSectionState = "hidden" | "loading" | "ready" | "empty";
+
+export const getSimilarGamesSectionState = (
+  isEligible: boolean,
+  isLoading: boolean,
+  gameCount: number
+): SimilarGamesSectionState => {
+  if (!isEligible) return "hidden";
+  if (isLoading) return "loading";
+  if (gameCount > 0) return "ready";
+
+  return "empty";
+};
+
+export interface SimilarGamesQuery {
+  objectId: string;
+  shop: GameShop;
+}
+
+export interface SimilarGame {
+  objectId: string;
+  shop: Exclude<GameShop, "custom">;
+  title: string;
+  iconUrl: string | null;
+  libraryHeroImageUrl: string | null;
+  libraryImageUrl: string | null;
+  coverImageUrl: string | null;
+  logoImageUrl: string | null;
+  downloadSources: string[];
+}
+
+interface SimilarGamesRequestOptions {
+  params: {
+    take: number;
+    downloadSourceIds: string[];
+  };
+  needsAuth: false;
+}
+
+export type SimilarGamesGet = (
+  path: string,
+  options: SimilarGamesRequestOptions
+) => Promise<unknown>;
+
+const isSupportedShop = (
+  shop: GameShop
+): shop is Exclude<GameShop, "custom"> => {
+  return shop === "steam" || shop === "launchbox";
+};
+
+const optionalString = (value: unknown) => {
+  return typeof value === "string" ? value : null;
+};
+
+const normalizeDownloadSources = (value: unknown) => {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter(
+    (source): source is string =>
+      typeof source === "string" && source.trim().length > 0
+  );
+};
+
+const normalizeSimilarGame = (value: unknown): SimilarGame | null => {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.objectId !== "string" ||
+    (candidate.shop !== "steam" && candidate.shop !== "launchbox") ||
+    typeof candidate.title !== "string"
+  ) {
+    return null;
+  }
+
+  const objectId = candidate.objectId.trim();
+  const title = candidate.title.trim();
+
+  if (!objectId || !title) return null;
+
+  return {
+    objectId,
+    shop: candidate.shop,
+    title,
+    iconUrl: optionalString(candidate.iconUrl),
+    libraryHeroImageUrl: optionalString(candidate.libraryHeroImageUrl),
+    libraryImageUrl: optionalString(candidate.libraryImageUrl),
+    coverImageUrl: optionalString(candidate.coverImageUrl),
+    logoImageUrl: optionalString(candidate.logoImageUrl),
+    downloadSources: normalizeDownloadSources(candidate.downloadSources),
+  };
+};
+
+export const normalizeSimilarGamesResponse = (
+  response: unknown,
+  query: SimilarGamesQuery
+) => {
+  if (!Array.isArray(response)) {
+    throw new TypeError("Invalid similar games response");
+  }
+
+  const seen = new Set<string>();
+
+  return response
+    .flatMap((candidate) => {
+      const game = normalizeSimilarGame(candidate);
+
+      return game ? [game] : [];
+    })
+    .filter((game) => {
+      const key = `${game.shop}:${game.objectId}`;
+      const isValid =
+        game.shop === query.shop && game.objectId !== query.objectId;
+
+      if (!isValid || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, SIMILAR_GAMES_LIMIT);
+};
+
+export const fetchSimilarGames = async (
+  query: SimilarGamesQuery,
+  get: SimilarGamesGet,
+  downloadSourceIds: string[] = []
+) => {
+  if (!isSupportedShop(query.shop) || !query.objectId) return [];
+
+  const response = await get(
+    `/catalogue/${query.shop}/${encodeURIComponent(query.objectId)}/similar`,
+    {
+      params: { take: SIMILAR_GAMES_LIMIT, downloadSourceIds },
+      needsAuth: false,
+    }
+  );
+
+  return normalizeSimilarGamesResponse(response, query);
+};

--- a/src/renderer/src/hooks/use-similar-games.ts
+++ b/src/renderer/src/hooks/use-similar-games.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from "react";
+import { orderBy } from "lodash-es";
+
+import { logger } from "@renderer/logger";
+import { levelDBService } from "@renderer/services/leveldb.service";
+import type { DownloadSource } from "@types";
+import {
+  fetchSimilarGames,
+  type SimilarGame,
+  type SimilarGamesGet,
+  type SimilarGamesQuery,
+} from "./similar-games";
+
+export const useSimilarGames = (query: SimilarGamesQuery) => {
+  const [games, setGames] = useState<SimilarGame[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [resultQueryKey, setResultQueryKey] = useState("");
+  const requestIdRef = useRef(0);
+  const { objectId, shop } = query;
+  const queryKey = `${shop}:${objectId}`;
+  const isEligible =
+    Boolean(objectId) && (shop === "steam" || shop === "launchbox");
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    const stableQuery: SimilarGamesQuery = { objectId, shop };
+
+    setGames([]);
+    setResultQueryKey(queryKey);
+    if (!isEligible) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+
+    const get: SimilarGamesGet = (path, options) =>
+      globalThis.window.electron.hydraApi.get<unknown>(path, options);
+
+    const loadSimilarGames = async () => {
+      const sources = (await levelDBService.values(
+        "downloadSources"
+      )) as DownloadSource[];
+
+      if (requestId !== requestIdRef.current) return;
+
+      const downloadSourceIds = orderBy(sources, "createdAt", "desc").map(
+        (source) => source.id
+      );
+      const results = await fetchSimilarGames(
+        stableQuery,
+        get,
+        downloadSourceIds
+      );
+
+      if (requestId === requestIdRef.current) setGames(results);
+    };
+
+    void loadSimilarGames()
+      .catch((error) => {
+        if (requestId !== requestIdRef.current) return;
+        logger.error("Failed to fetch similar games", error);
+        setGames([]);
+      })
+      .finally(() => {
+        if (requestId === requestIdRef.current) setIsLoading(false);
+      });
+
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [isEligible, objectId, queryKey, shop]);
+
+  const hasCurrentResults = resultQueryKey === queryKey;
+
+  return {
+    games: hasCurrentResults ? games : [],
+    isLoading: isEligible && (!hasCurrentResults || isLoading),
+    isEligible,
+  };
+};

--- a/src/renderer/src/pages/game-details/game-details-content.tsx
+++ b/src/renderer/src/pages/game-details/game-details-content.tsx
@@ -18,6 +18,7 @@ import { GameReviews } from "./game-reviews";
 import { GameLogo } from "./game-logo";
 import { CloudSaveWidget } from "./cloud-save-v2";
 import { getCloudSaveVisibility } from "./cloud-save-visibility";
+import { SimilarGames } from "./similar-games/similar-games";
 
 import { AuthPage } from "@shared";
 import { cloudSyncContext, gameDetailsContext } from "@renderer/context";
@@ -447,6 +448,10 @@ export function GameDetailsContent() {
               >
                 {isDescriptionExpanded ? t("show_less") : t("show_more")}
               </button>
+            )}
+
+            {shop && objectId && (
+              <SimilarGames objectId={objectId} shop={shop} />
             )}
 
             {shop !== "custom" && shop && objectId && (

--- a/src/renderer/src/pages/game-details/similar-games/similar-games.scss
+++ b/src/renderer/src/pages/game-details/similar-games/similar-games.scss
@@ -1,0 +1,117 @@
+@use "../../../scss/globals.scss";
+
+.similar-games {
+  display: flex;
+  flex-direction: column;
+  gap: calc(globals.$spacing-unit * 1.5);
+  width: 100%;
+  align-self: center;
+  margin-inline: auto;
+
+  @media (min-width: 1280px) {
+    width: 60%;
+  }
+
+  @media (min-width: 1536px) {
+    width: 50%;
+  }
+
+  &__title {
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  &__carousel {
+    position: relative;
+    width: 100%;
+  }
+
+  &__viewport {
+    position: relative;
+    overflow: hidden;
+    border-radius: 6px;
+  }
+
+  &__container {
+    display: flex;
+    margin-inline: calc(globals.$spacing-unit * -1);
+  }
+
+  &__slide {
+    flex: 0 0 calc(100% / 3);
+    min-width: 0;
+    padding: 3px globals.$spacing-unit;
+  }
+
+  &__skeleton {
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    border-radius: 4px;
+  }
+
+  &__empty {
+    display: grid;
+    box-sizing: border-box;
+    width: 100%;
+    aspect-ratio: 2 / 1;
+    place-items: center;
+    padding: calc(globals.$spacing-unit * 2);
+    color: globals.$muted-color;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 6px;
+  }
+
+  &__control {
+    position: absolute;
+    top: 50%;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    color: globals.$muted-color;
+    background-color: rgba(0, 0, 0, 0.4);
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    transform: translateY(-50%);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+    &:hover:not(:disabled) {
+      background-color: rgba(0, 0, 0, 0.6);
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(-50%) scale(0.95);
+    }
+
+    &:disabled {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    &--previous {
+      left: globals.$spacing-unit;
+      opacity: 0;
+      transform: translateY(-50%) translateX(-16px);
+
+      .similar-games__viewport:hover &:not(:disabled) {
+        opacity: 1;
+        transform: translateY(-50%) translateX(0);
+      }
+    }
+
+    &--next {
+      right: globals.$spacing-unit;
+      opacity: 0;
+      transform: translateY(-50%) translateX(16px);
+
+      .similar-games__viewport:hover &:not(:disabled) {
+        opacity: 1;
+        transform: translateY(-50%) translateX(0);
+      }
+    }
+  }
+}

--- a/src/renderer/src/pages/game-details/similar-games/similar-games.tsx
+++ b/src/renderer/src/pages/game-details/similar-games/similar-games.tsx
@@ -1,0 +1,143 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "@primer/octicons-react";
+import useEmblaCarousel from "embla-carousel-react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import Skeleton from "react-loading-skeleton";
+
+import type { GameShop } from "@types";
+import { VerticalCoverCard } from "@renderer/components";
+import { buildGameDetailsPath } from "@renderer/helpers";
+import { useSimilarGames } from "@renderer/hooks";
+import { getSimilarGamesSectionState } from "@renderer/hooks/similar-games";
+
+import "./similar-games.scss";
+
+const GAMES_PER_PAGE = 3;
+
+interface SimilarGamesProps {
+  objectId: string;
+  shop: GameShop;
+}
+
+function SimilarGamesSlide({ children }: Readonly<{ children: ReactNode }>) {
+  return <div className="similar-games__slide">{children}</div>;
+}
+
+function SimilarGamesSkeleton() {
+  return (
+    <div className="similar-games__carousel" aria-busy="true">
+      <div className="similar-games__viewport">
+        <div className="similar-games__container">
+          {Array.from({ length: GAMES_PER_PAGE }, (_, index) => (
+            <SimilarGamesSlide key={`similar-game-skeleton-${index}`}>
+              <Skeleton className="similar-games__skeleton" />
+            </SimilarGamesSlide>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SimilarGames({ objectId, shop }: Readonly<SimilarGamesProps>) {
+  const navigate = useNavigate();
+  const { t } = useTranslation("game_details");
+  const { games, isLoading, isEligible } = useSimilarGames({ objectId, shop });
+  const sectionState = getSimilarGamesSectionState(
+    isEligible,
+    isLoading,
+    games.length
+  );
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    align: "start",
+    containScroll: "trimSnaps",
+    slidesToScroll: GAMES_PER_PAGE,
+    duration: 20,
+  });
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+
+  const syncControls = useCallback(() => {
+    setCanScrollPrev(emblaApi?.canScrollPrev() ?? false);
+    setCanScrollNext(emblaApi?.canScrollNext() ?? false);
+  }, [emblaApi]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    syncControls();
+    emblaApi.on("select", syncControls);
+    emblaApi.on("reInit", syncControls);
+
+    return () => {
+      emblaApi.off("select", syncControls);
+      emblaApi.off("reInit", syncControls);
+    };
+  }, [emblaApi, syncControls]);
+
+  useEffect(() => {
+    emblaApi?.scrollTo(0, true);
+  }, [emblaApi, objectId, shop]);
+
+  if (sectionState === "hidden") return null;
+
+  return (
+    <section className="similar-games">
+      <h2 className="similar-games__title">{t("similar_games")}</h2>
+
+      {sectionState === "loading" ? <SimilarGamesSkeleton /> : null}
+
+      {sectionState === "empty" ? (
+        <div className="similar-games__empty" role="status">
+          {t("no_similar_games")}
+        </div>
+      ) : null}
+
+      {sectionState === "ready" ? (
+        <div className="similar-games__carousel">
+          <div className="similar-games__viewport" ref={emblaRef}>
+            <div className="similar-games__container">
+              {games.map((similarGame) => (
+                <SimilarGamesSlide
+                  key={`${similarGame.shop}:${similarGame.objectId}`}
+                >
+                  <VerticalCoverCard
+                    gameTitle={similarGame.title}
+                    coverImageUrls={[
+                      similarGame.coverImageUrl,
+                      similarGame.libraryImageUrl,
+                      similarGame.iconUrl,
+                    ]}
+                    useClassicsLayout={similarGame.shop === "launchbox"}
+                    onClick={() => navigate(buildGameDetailsPath(similarGame))}
+                  />
+                </SimilarGamesSlide>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              className="similar-games__control similar-games__control--previous"
+              aria-label={t("previous_media")}
+              disabled={!canScrollPrev}
+              onClick={() => emblaApi?.scrollPrev()}
+            >
+              <ChevronLeftIcon size={36} />
+            </button>
+
+            <button
+              type="button"
+              className="similar-games__control similar-games__control--next"
+              aria-label={t("next_media")}
+              disabled={!canScrollNext}
+              onClick={() => emblaApi?.scrollNext()}
+            >
+              <ChevronRightIcon size={36} />
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/renderer/src/pages/profile/profile-content/user-library-game-card.scss
+++ b/src/renderer/src/pages/profile/profile-content/user-library-game-card.scss
@@ -30,40 +30,6 @@
     }
   }
 
-  &__cover {
-    cursor: pointer;
-    transition: all ease 0.2s;
-    box-shadow: 0 8px 10px -2px rgba(0, 0, 0, 0.5);
-    width: 100%;
-    aspect-ratio: 2 / 3;
-    position: relative;
-    overflow: hidden;
-
-    &:before {
-      content: "";
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 172%;
-      position: absolute;
-      background: linear-gradient(
-        35deg,
-        rgba(0, 0, 0, 0.1) 0%,
-        rgba(0, 0, 0, 0.07) 51.5%,
-        rgba(255, 255, 255, 0.15) 54%,
-        rgba(255, 255, 255, 0.15) 100%
-      );
-      transition: all ease 0.3s;
-      transform: translateY(-36%);
-      opacity: 0.5;
-    }
-
-    &:hover::before {
-      opacity: 1;
-      transform: translateY(-20%);
-    }
-  }
-
   &__container {
     transition: all ease 0.2s;
 
@@ -172,76 +138,6 @@
     display: flex;
     align-items: center;
     gap: 8px;
-  }
-
-  &__game-image {
-    object-fit: cover;
-    border-radius: 4px;
-    width: 100%;
-    height: 100%;
-    display: block;
-  }
-
-  &__classics-cover {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    border-radius: 4px;
-    background: #0a0a0a;
-    z-index: 0;
-  }
-
-  &__classics-backdrop {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    filter: blur(16px) saturate(1.1);
-    transform: scale(1.25);
-    opacity: 0.65;
-    pointer-events: none;
-  }
-
-  &__classics-image {
-    position: absolute;
-    inset: 0;
-    margin: auto;
-    z-index: 1;
-    max-width: 80%;
-    max-height: 80%;
-    width: auto;
-    height: auto;
-    object-fit: contain;
-    border-radius: 4px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    box-shadow:
-      0 11px 7px rgba(0, 0, 0, 0.05),
-      0 5px 5px rgba(0, 0, 0, 0.09),
-      0 1px 3px rgba(0, 0, 0, 0.1);
-  }
-
-  &__cover-placeholder {
-    position: relative;
-    width: 100%;
-    padding-bottom: 150%;
-    background: linear-gradient(
-      90deg,
-      rgba(255, 255, 255, 0.08) 0%,
-      rgba(255, 255, 255, 0.04) 50%,
-      rgba(255, 255, 255, 0.08) 100%
-    );
-    border-radius: 4px;
-    color: rgba(255, 255, 255, 0.3);
-
-    svg {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
   }
 
   &__achievements-progress-track {

--- a/src/renderer/src/pages/profile/profile-content/user-library-game-card.tsx
+++ b/src/renderer/src/pages/profile/profile-content/user-library-game-card.tsx
@@ -1,12 +1,8 @@
 import { UserGame } from "@types";
 import HydraIcon from "@renderer/assets/icons/hydra.svg?react";
-import {
-  useFormat,
-  useCoverPoster,
-  isAnimatedCoverCandidate,
-} from "@renderer/hooks";
+import { useFormat } from "@renderer/hooks";
 import { useNavigate } from "react-router-dom";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import {
   buildGameAchievementPath,
   buildGameDetailsPath,
@@ -14,16 +10,11 @@ import {
   isGameCompleted,
 } from "@renderer/helpers";
 import { userProfileContext } from "@renderer/context";
-import {
-  ClockIcon,
-  TrophyIcon,
-  AlertFillIcon,
-  ImageIcon,
-} from "@primer/octicons-react";
+import { ClockIcon, TrophyIcon, AlertFillIcon } from "@primer/octicons-react";
 import { MAX_MINUTES_TO_SHOW_IN_PLAYTIME } from "@renderer/constants";
 import { Tooltip } from "react-tooltip";
 import { useTranslation } from "react-i18next";
-import { ProgressBar } from "@renderer/components";
+import { ProgressBar, VerticalCoverCard } from "@renderer/components";
 import "./user-library-game-card.scss";
 
 interface UserLibraryGameCardProps {
@@ -42,21 +33,8 @@ export function UserLibraryGameCard({
   const { numberFormatter } = useFormat();
   const navigate = useNavigate();
   const [isTooltipHovered, setIsTooltipHovered] = useState(false);
-  const [imageError, setImageError] = useState(false);
 
   const coverImageUrl = game.customLibraryImageUrl ?? game.coverImageUrl;
-
-  const isAnimatedCover = isAnimatedCoverCandidate(coverImageUrl);
-  const coverPoster = useCoverPoster(coverImageUrl, isAnimatedCover);
-  const [isCoverHovered, setIsCoverHovered] = useState(false);
-  const displayCoverUrl =
-    (isAnimatedCover && !isCoverHovered && coverPoster
-      ? coverPoster
-      : coverImageUrl) ?? undefined;
-
-  useEffect(() => {
-    setImageError(false);
-  }, [coverImageUrl]);
 
   const isCompleted = isGameCompleted(
     game.achievementCount,
@@ -131,64 +109,21 @@ export function UserLibraryGameCard({
     onContextMenu(game, { x: event.clientX, y: event.clientY });
   };
 
-  const renderCoverMedia = () => {
-    if (imageError || !coverImageUrl) {
-      return (
-        <div className="user-library-game__cover-placeholder">
-          <ImageIcon size={48} />
-        </div>
-      );
-    }
-
-    if (game.shop === "launchbox" && !game.customLibraryImageUrl) {
-      return (
-        <div className="user-library-game__classics-cover">
-          <img
-            src={displayCoverUrl}
-            alt=""
-            aria-hidden="true"
-            className="user-library-game__classics-backdrop"
-            loading="lazy"
-            decoding="async"
-            onError={() => setImageError(true)}
-          />
-          <img
-            src={displayCoverUrl}
-            alt={game.title}
-            className="user-library-game__classics-image"
-            loading="lazy"
-            decoding="async"
-            onError={() => setImageError(true)}
-          />
-        </div>
-      );
-    }
-
-    return (
-      <img
-        src={displayCoverUrl}
-        alt={game.title}
-        className="user-library-game__game-image"
-        loading="lazy"
-        decoding="async"
-        onError={() => setImageError(true)}
-      />
-    );
-  };
-
   return (
     <>
       <li
         className="user-library-game__wrapper"
         title={isTooltipHovered ? undefined : game.title}
       >
-        <button
-          type="button"
-          className="user-library-game__cover"
+        <VerticalCoverCard
+          gameTitle={game.title}
+          coverImageUrls={[coverImageUrl]}
+          useClassicsLayout={
+            game.shop === "launchbox" && !game.customLibraryImageUrl
+          }
+          showTitleTooltip={false}
           onClick={() => navigate(buildUserGameDetailsPath(game))}
           onContextMenu={handleContextMenu}
-          onMouseEnter={() => setIsCoverHovered(true)}
-          onMouseLeave={() => setIsCoverHovered(false)}
         >
           <div
             className={`user-library-game__overlay${game.shop === "launchbox" && !game.customLibraryImageUrl ? " user-library-game__overlay--classics" : ""}${hasAchievementProgress ? "" : " user-library-game__overlay--no-fade"}`}
@@ -276,9 +211,7 @@ export function UserLibraryGameCard({
               </div>
             )}
           </div>
-
-          {renderCoverMedia()}
-        </button>
+        </VerticalCoverCard>
       </li>
       <Tooltip
         id={game.objectId}


### PR DESCRIPTION
When submitting this pull request, I confirm the following (please check the boxes):

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

Fill in the PR content:

### What

Adds a “More like this” section to Desktop and Big Picture game pages and improves controller navigation in Big Picture menus.

Desktop displays three games at a time, while Big Picture provides a carousel with up to nine recommendations.

### Why

Game pages currently do not offer a way to discover similar games.

Big Picture controller users also need consistent directional navigation and primary-action support in the sidebar and context menus.

### The implementation

- Fetches server-ranked recommendations from `/catalogue/{shop}/{objectId}/similar`.
- Supplies the configured download sources so availability badges remain accurate.
- Excludes the currently opened game and malformed results.
- Keeps regular and classic recommendations separate by shop.
- Lets platform metadata influence LaunchBox ranking without guaranteeing the same console.
- Reuses the existing Big Picture carousel and the profile’s vertical cover presentation.
- Normalizes LaunchBox genre labels by trimming values, accepting name or description fields, and removing case-insensitive duplicates.
- Activates context-menu items, sidebar routes, the exit action, and library filters through the controller’s primary action.
- Connects every Big Picture sidebar item with explicit up and down navigation.

### How to test

1. Open a regular game and confirm “More like this” appears below its description.
2. Navigate through the Desktop carousel and open a recommendation.
3. Open a classic game and confirm relevant LaunchBox recommendations appear.
4. In Big Picture, verify the recommendations carousel behaves like the Home and Profile carousels with mouse, keyboard, and controller.
5. Navigate through every sidebar route with the controller, including profile, exit, and library filters.
6. Activate a sidebar route, library filter, exit action, and context-menu item using the controller’s primary button.
7. Move from a recommendation to reviews, click a carousel arrow, and confirm the carousel does not snap back unexpectedly.

<img width=1850 height=1080 alt=image2 src=https://github.com/user-attachments/assets/11d83732-7096-4695-a17b-5e9158b24ee3 />
<img width=1662 height=928 alt=image src=https://github.com/user-attachments/assets/06563546-6e41-4fde-93bc-1ff69b5ed8fb />