### PR TITLE
feat: reduce classic genre font size

### DIFF
--- a/src/renderer/src/pages/catalogue/game-item-classics.scss
+++ b/src/renderer/src/pages/catalogue/game-item-classics.scss
@@ -157,7 +157,7 @@
   }
 
   &__genres {
-    font-size: 14px;
+    font-size: 12px;
     color: rgba(255, 255, 255, 0.5);
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

In the classics catalogue, the game title and the genre line were both rendered at 14px. The only thing separating them was weight and opacity, which made the genre read as a second line of the title rather than as metadata.

Dropped `.game-item-classics__genres` to 12px. The title stays at 14px/700. 12px is what the regular catalogue item (`game-item.scss`) already uses for its genres line, so the two card variants now match.

Closes LBX-981

<img width="2767" height="494" alt="image" src="https://github.com/user-attachments/assets/90aa6ab7-1e1d-4502-a3bf-d1b565a3488e" />

