### PR TITLE
feat: add Yandex Disk cloud backup (Cloud Storage settings section)

### DIFF
--- a/src/main/events/cloud-storage.ts
+++ b/src/main/events/cloud-storage.ts
@@ -1,0 +1,66 @@
+import { registerEvent } from "./register-event";
+import { CloudStorageService, WindowManager, logger } from "@main/services";
+
+// Note: restoring a cloud backup reuses the existing "restoreYandexDiskBackup"
+// channel (see ./yandex-disk.ts) — it already resolves the game from the
+// local library and calls YandexDiskBackup.downloadAndRestoreBackup, so
+// there is no need for a separate handler here.
+
+const listCloudBackups = async (_event: Electron.IpcMainInvokeEvent) => {
+  return CloudStorageService.listBackups();
+};
+
+const getCloudStorageUsage = async (_event: Electron.IpcMainInvokeEvent) => {
+  return CloudStorageService.getStorageUsage();
+};
+
+const downloadCloudBackup = async (
+  _event: Electron.IpcMainInvokeEvent,
+  remotePath: string,
+  destDir: string
+) => {
+  try {
+    await CloudStorageService.ensureDownloadDirExists(destDir);
+
+    const localPath = await CloudStorageService.downloadBackup(
+      remotePath,
+      destDir,
+      (percent) => {
+        WindowManager.sendToAppWindows("on-cloud-backup-download-progress", {
+          path: remotePath,
+          percent,
+        });
+      }
+    );
+
+    WindowManager.sendToAppWindows("on-cloud-backup-download-complete", {
+      path: remotePath,
+      success: true,
+      localPath,
+    });
+
+    return { success: true, localPath };
+  } catch (err) {
+    logger.error("[CloudStorage] downloadCloudBackup error", err);
+
+    WindowManager.sendToAppWindows("on-cloud-backup-download-complete", {
+      path: remotePath,
+      success: false,
+    });
+
+    throw err;
+  }
+};
+
+const deleteCloudBackup = async (
+  _event: Electron.IpcMainInvokeEvent,
+  remotePath: string
+) => {
+  await CloudStorageService.deleteBackup(remotePath);
+  return { success: true };
+};
+
+registerEvent("listCloudBackups", listCloudBackups);
+registerEvent("getCloudStorageUsage", getCloudStorageUsage);
+registerEvent("downloadCloudBackup", downloadCloudBackup);
+registerEvent("deleteCloudBackup", deleteCloudBackup);

--- a/src/main/events/index.ts
+++ b/src/main/events/index.ts
@@ -22,6 +22,8 @@ import "./user";
 import "./user-preferences";
 import "./library/transfer-game-files";
 import "./emulators";
+import "./yandex-disk";
+import "./cloud-storage";
 
 import { isPortableVersion } from "@main/helpers";
 

--- a/src/main/events/yandex-disk.ts
+++ b/src/main/events/yandex-disk.ts
@@ -1,0 +1,131 @@
+import { registerEvent } from "./register-event";
+import type { GameShop } from "@types";
+import { db, gamesSublevel, levelKeys } from "@main/level";
+import type { UserPreferences } from "@types";
+import { YandexDiskBackup } from "@main/services/yandex-disk-backup";
+import { logger } from "@main/services";
+
+const getYandexDiskSettings = async (_event: Electron.IpcMainInvokeEvent) => {
+  try {
+    const prefs = await db.get<string, UserPreferences | null>(
+      levelKeys.userPreferences,
+      { valueEncoding: "json" }
+    );
+    return {
+      token: prefs?.yandexDiskToken ?? null,
+      backupEnabled: prefs?.yandexDiskBackupEnabled ?? false,
+      restoreOnStartup: prefs?.yandexDiskRestoreOnStartup ?? false,
+      maxBackups: prefs?.yandexDiskMaxBackups ?? 5,
+    };
+  } catch {
+    return {
+      token: null,
+      backupEnabled: false,
+      restoreOnStartup: false,
+      maxBackups: 5,
+    };
+  }
+};
+
+const updateYandexDiskSettings = async (
+  _event: Electron.IpcMainInvokeEvent,
+  settings: {
+    token?: string | null;
+    backupEnabled?: boolean;
+    restoreOnStartup?: boolean;
+    maxBackups?: number;
+  }
+) => {
+  let prefs: UserPreferences | null = null;
+  try {
+    prefs = await db.get<string, UserPreferences | null>(
+      levelKeys.userPreferences,
+      {
+        valueEncoding: "json",
+      }
+    );
+  } catch {
+    prefs = null;
+  }
+
+  const updated: UserPreferences = {
+    ...(prefs ?? {}),
+  };
+
+  if (settings.token !== undefined) updated.yandexDiskToken = settings.token;
+  if (settings.backupEnabled !== undefined)
+    updated.yandexDiskBackupEnabled = settings.backupEnabled;
+  if (settings.restoreOnStartup !== undefined)
+    updated.yandexDiskRestoreOnStartup = settings.restoreOnStartup;
+  if (settings.maxBackups !== undefined)
+    updated.yandexDiskMaxBackups = settings.maxBackups;
+
+  await db.put(levelKeys.userPreferences, updated, { valueEncoding: "json" });
+  return true;
+};
+
+const getYandexDiskAccountInfo = async (
+  _event: Electron.IpcMainInvokeEvent
+) => {
+  return YandexDiskBackup.getAccountInfo();
+};
+
+const validateYandexDiskToken = async (
+  _event: Electron.IpcMainInvokeEvent,
+  token: string
+) => {
+  return YandexDiskBackup.validateToken(token);
+};
+
+const listYandexDiskBackups = async (
+  _event: Electron.IpcMainInvokeEvent,
+  objectId: string,
+  shop: GameShop
+) => {
+  return YandexDiskBackup.listBackups({ objectId, shop });
+};
+
+const restoreYandexDiskBackup = async (
+  _event: Electron.IpcMainInvokeEvent,
+  objectId: string,
+  shop: GameShop,
+  remotePath: string
+) => {
+  try {
+    const gameKey = levelKeys.game(shop, objectId);
+    const game = await gamesSublevel.get(gameKey);
+    if (!game) throw new Error("Game not found");
+
+    await YandexDiskBackup.downloadAndRestoreBackup(game, remotePath);
+    return { success: true };
+  } catch (err) {
+    logger.error("[YandexDisk] restoreYandexDiskBackup error", err);
+    throw err;
+  }
+};
+
+const backupNowYandexDisk = async (
+  _event: Electron.IpcMainInvokeEvent,
+  objectId: string,
+  shop: GameShop
+) => {
+  try {
+    const gameKey = levelKeys.game(shop, objectId);
+    const game = await gamesSublevel.get(gameKey);
+    if (!game) throw new Error("Game not found");
+
+    await YandexDiskBackup.backupOnGameExit(game);
+    return { success: true };
+  } catch (err) {
+    logger.error("[YandexDisk] backupNowYandexDisk error", err);
+    throw err;
+  }
+};
+
+registerEvent("getYandexDiskSettings", getYandexDiskSettings);
+registerEvent("getYandexDiskAccountInfo", getYandexDiskAccountInfo);
+registerEvent("updateYandexDiskSettings", updateYandexDiskSettings);
+registerEvent("validateYandexDiskToken", validateYandexDiskToken);
+registerEvent("listYandexDiskBackups", listYandexDiskBackups);
+registerEvent("restoreYandexDiskBackup", restoreYandexDiskBackup);
+registerEvent("backupNowYandexDisk", backupNowYandexDisk);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -103,6 +103,12 @@ export const loadState = async () => {
     DeckyPlugin.checkAndUpdateIfOutdated();
   }
 
+  // Yandex Disk: restore saves and achievements on startup
+  const { YandexDiskBackup } = await import("./services/yandex-disk-backup");
+  YandexDiskBackup.checkAndRestoreOnStartup().catch((err) =>
+    logger.warn("[YandexDisk] checkAndRestoreOnStartup failed", err)
+  );
+
   await HydraApi.setupApi().then(async () => {
     uploadGamesBatch();
     void migrateDownloadSources();

--- a/src/main/services/backup-metadata.ts
+++ b/src/main/services/backup-metadata.ts
@@ -1,0 +1,279 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import type {
+  Game,
+  LudusaviBackup,
+  HydraBackupMetadata,
+  BackupRelocationResult,
+} from "@types";
+import { logger } from "./logger";
+
+const METADATA_FILENAME = "hydra-metadata.json";
+
+export class BackupMetadataService {
+  /**
+   * Extract absolute save file paths from a Ludusavi backup/preview result.
+   * The keys of `games[name].files` are the absolute paths to save files.
+   */
+  public static extractSavePaths(
+    ludusaviResult: LudusaviBackup,
+    objectId: string
+  ): string[] {
+    const gameData = ludusaviResult.games?.[objectId];
+    if (!gameData?.files) return [];
+    return Object.keys(gameData.files);
+  }
+
+  /**
+   * Detect the Steam emulator type based on save file paths.
+   * Looks for known emulator directory names in the paths.
+   */
+  public static detectEmulatorType(savePaths: string[]): string | null {
+    const emulatorPatterns: { pattern: RegExp; name: string }[] = [
+      { pattern: /goldberg/i, name: "Goldberg" },
+      { pattern: /codex/i, name: "CODEX" },
+      { pattern: /empress/i, name: "EMPRESS" },
+      { pattern: /rune/i, name: "RUNE" },
+      { pattern: /ali213/i, name: "ALI213" },
+      { pattern: /smartsteamemu/i, name: "SmartSteamEmu" },
+      { pattern: /steamless/i, name: "Steamless" },
+    ];
+
+    for (const savePath of savePaths) {
+      for (const { pattern, name } of emulatorPatterns) {
+        if (pattern.test(savePath)) {
+          return name;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Create HydraBackupMetadata from a Game object and the Ludusavi backup result.
+   */
+  public static createMetadata(
+    game: Game,
+    ludusaviResult: LudusaviBackup
+  ): HydraBackupMetadata {
+    const savePaths = this.extractSavePaths(ludusaviResult, game.objectId);
+
+    return {
+      version: 1,
+      gameName: game.title,
+      steamAppId: game.objectId,
+      shop: game.shop,
+      backupDate: new Date().toISOString(),
+      launcher: "Hydra",
+      platform: process.platform,
+      hostname: os.hostname(),
+      originalSavePaths: savePaths,
+      winePrefixPath: game.winePrefixPath ?? null,
+      emulatorType: this.detectEmulatorType(savePaths),
+      gameVersion: null,
+    };
+  }
+
+  /**
+   * Write metadata.json to the root of the backup directory.
+   * This file is placed alongside Ludusavi's backup files before
+   * the directory is compressed into tar.gz.
+   */
+  public static writeMetadataToBackupDir(
+    backupDir: string,
+    metadata: HydraBackupMetadata
+  ): void {
+    const metadataPath = path.join(backupDir, METADATA_FILENAME);
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), "utf-8");
+    logger.info(
+      `[BackupMetadata] Wrote metadata to ${metadataPath} (${metadata.originalSavePaths.length} save paths)`
+    );
+  }
+
+  /**
+   * Read metadata.json from an extracted backup directory.
+   * Returns null if the file doesn't exist (backward compatibility
+   * with backups created before this feature).
+   */
+  public static readMetadataFromExtractDir(
+    extractDir: string
+  ): HydraBackupMetadata | null {
+    const metadataPath = path.join(extractDir, METADATA_FILENAME);
+
+    if (!fs.existsSync(metadataPath)) {
+      logger.info(
+        "[BackupMetadata] No metadata.json found — legacy backup, skipping compatibility check"
+      );
+      return null;
+    }
+
+    try {
+      const raw = fs.readFileSync(metadataPath, "utf-8");
+      const metadata = JSON.parse(raw) as HydraBackupMetadata;
+
+      if (metadata.version !== 1) {
+        logger.warn(
+          `[BackupMetadata] Unknown metadata version: ${metadata.version}, skipping`
+        );
+        return null;
+      }
+
+      return metadata;
+    } catch (err) {
+      logger.warn("[BackupMetadata] Failed to parse metadata.json", err);
+      return null;
+    }
+  }
+
+  /**
+   * Compare original save paths from backup metadata with current save paths
+   * and relocate files if they differ. Uses overwrite strategy (backup is authoritative).
+   *
+   * @param metadata - The backup metadata with original save paths
+   * @param currentSavePaths - Current save paths from Ludusavi preview
+   * @returns Relocation result with details of what was moved
+   */
+  public static async relocateSaves(
+    metadata: HydraBackupMetadata,
+    currentSavePaths: string[]
+  ): Promise<BackupRelocationResult> {
+    const result: BackupRelocationResult = {
+      relocated: false,
+      from: [],
+      to: [],
+      filesRelocated: 0,
+    };
+
+    const originalPaths = metadata.originalSavePaths;
+
+    if (originalPaths.length === 0 || currentSavePaths.length === 0) {
+      return result;
+    }
+
+    // Normalize paths for comparison
+    const normalizeForCompare = (p: string) =>
+      p.replace(/\\/g, "/").toLowerCase();
+
+    const originalNormalized = new Set(originalPaths.map(normalizeForCompare));
+    const currentNormalized = new Set(
+      currentSavePaths.map(normalizeForCompare)
+    );
+
+    // Check if paths are the same — no relocation needed
+    const allMatch = [...originalNormalized].every((p) =>
+      currentNormalized.has(p)
+    );
+    if (allMatch) {
+      logger.info("[BackupMetadata] Save paths match — no relocation needed");
+      return result;
+    }
+
+    // Paths differ — attempt to relocate files
+    logger.info(
+      `[BackupMetadata] Save paths differ. Original: ${originalPaths.length} paths, Current: ${currentSavePaths.length} paths`
+    );
+
+    // Build a mapping from original base directories to current base directories.
+    // Strategy: find the common parent of original paths and current paths,
+    // then copy files maintaining relative structure.
+    const originalBaseDirs = this.getUniqueBaseDirs(originalPaths);
+    const currentBaseDirs = this.getUniqueBaseDirs(currentSavePaths);
+
+    for (const originalBase of originalBaseDirs) {
+      // Find files restored by Ludusavi at the original path
+      const filesToRelocate = originalPaths.filter(
+        (p) =>
+          normalizeForCompare(p).startsWith(
+            normalizeForCompare(originalBase)
+          ) && fs.existsSync(p)
+      );
+
+      if (filesToRelocate.length === 0) continue;
+
+      // Find the best matching current base directory
+      const targetBase = this.findBestMatchingDir(
+        originalBase,
+        currentBaseDirs
+      );
+
+      if (
+        !targetBase ||
+        normalizeForCompare(targetBase) === normalizeForCompare(originalBase)
+      ) {
+        continue;
+      }
+
+      result.from.push(originalBase);
+      result.to.push(targetBase);
+
+      for (const filePath of filesToRelocate) {
+        try {
+          const relativePath = path.relative(originalBase, filePath);
+          const destinationPath = path.join(targetBase, relativePath);
+
+          // Ensure destination directory exists
+          fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+          // Overwrite strategy: copy file to new location
+          fs.copyFileSync(filePath, destinationPath);
+          result.filesRelocated++;
+
+          logger.info(
+            `[BackupMetadata] Relocated: ${filePath} → ${destinationPath}`
+          );
+        } catch (err) {
+          logger.warn(
+            `[BackupMetadata] Failed to relocate file: ${filePath}`,
+            err
+          );
+        }
+      }
+    }
+
+    result.relocated = result.filesRelocated > 0;
+
+    if (result.relocated) {
+      logger.info(
+        `[BackupMetadata] Relocation complete: ${result.filesRelocated} files moved`
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Extract unique parent directories from a list of file paths.
+   */
+  private static getUniqueBaseDirs(filePaths: string[]): string[] {
+    const dirs = new Set<string>();
+    for (const filePath of filePaths) {
+      dirs.add(path.dirname(filePath));
+    }
+    return [...dirs];
+  }
+
+  /**
+   * Find the best matching directory from candidates, based on
+   * similarity of the directory name structure (same objectId subfolder, etc.).
+   */
+  private static findBestMatchingDir(
+    originalDir: string,
+    candidates: string[]
+  ): string | null {
+    if (candidates.length === 0) return null;
+    if (candidates.length === 1) return candidates[0];
+
+    const originalBasename = path.basename(originalDir).toLowerCase();
+
+    // Prefer a candidate with the same leaf directory name (e.g., same AppID folder)
+    const exactLeafMatch = candidates.find(
+      (c) => path.basename(c).toLowerCase() === originalBasename
+    );
+    if (exactLeafMatch) return exactLeafMatch;
+
+    // Fallback: return the first candidate
+    return candidates[0];
+  }
+}

--- a/src/main/services/cloud-storage.ts
+++ b/src/main/services/cloud-storage.ts
@@ -1,0 +1,81 @@
+import path from "node:path";
+import fs from "node:fs";
+import type { CloudBackupEntry, CloudStorageUsage, GameShop } from "@types";
+import { gamesSublevel, levelKeys } from "@main/level";
+import { YandexDiskBackup } from "./yandex-disk-backup";
+import { logger } from "./logger";
+
+/**
+ * Facade used by the "Облачное хранилище" settings section.
+ *
+ * This service is intentionally thin: it does not talk to the Yandex
+ * Disk API directly. All HTTP/token/auth plumbing continues to live in
+ * YandexDiskBackup, which already owns the automatic backup/restore
+ * flows and must not be duplicated or reimplemented here.
+ */
+export class CloudStorageService {
+  public static async listBackups(): Promise<CloudBackupEntry[]> {
+    return YandexDiskBackup.listAllBackups();
+  }
+
+  public static async getStorageUsage(): Promise<CloudStorageUsage> {
+    return YandexDiskBackup.getStorageUsage();
+  }
+
+  public static async getDownloadUrl(remotePath: string): Promise<string> {
+    return YandexDiskBackup.getResourceDownloadUrl(remotePath);
+  }
+
+  /**
+   * Downloads a backup archive into a user-chosen folder, reporting
+   * progress via onProgress (0-100). Returns the local file path.
+   */
+  public static async downloadBackup(
+    remotePath: string,
+    destDir: string,
+    onProgress?: (percent: number) => void
+  ): Promise<string> {
+    const fileName = remotePath.split("/").pop() ?? "backup.tar.gz";
+    const destPath = path.join(destDir, fileName);
+
+    await YandexDiskBackup.downloadBackupToFile(
+      remotePath,
+      destPath,
+      onProgress
+    );
+
+    return destPath;
+  }
+
+  /**
+   * Restores a backup using the existing restore pipeline
+   * (download archive -> Ludusavi.restoreGame -> cleanup). The target
+   * game must still be present in the local library, since restoring
+   * needs its wine prefix / shop metadata.
+   */
+  public static async restoreBackup(
+    shop: GameShop,
+    objectId: string,
+    remotePath: string
+  ): Promise<void> {
+    const game = await gamesSublevel.get(levelKeys.game(shop, objectId));
+    if (!game) {
+      throw new Error("GAME_NOT_IN_LIBRARY");
+    }
+
+    await YandexDiskBackup.downloadAndRestoreBackup(game, remotePath);
+  }
+
+  public static async deleteBackup(remotePath: string): Promise<void> {
+    await YandexDiskBackup.deleteBackupFile(remotePath);
+  }
+
+  public static async ensureDownloadDirExists(destDir: string): Promise<void> {
+    try {
+      fs.mkdirSync(destDir, { recursive: true });
+    } catch (err) {
+      logger.error("[CloudStorage] Failed to ensure download directory", err);
+      throw err;
+    }
+  }
+}

--- a/src/main/services/index.ts
+++ b/src/main/services/index.ts
@@ -31,3 +31,6 @@ export * from "./achievement-notification-presenter-electron";
 export * from "./game-artwork";
 export * from "./game-artwork-cloud";
 export * as emulators from "./emulators";
+export * from "./yandex-disk-backup";
+export * from "./backup-metadata";
+export * from "./cloud-storage";

--- a/src/main/services/ludusavi.ts
+++ b/src/main/services/ludusavi.ts
@@ -109,6 +109,33 @@ export class Ludusavi {
     };
   }
 
+  public static async restoreGame(
+    _shop: GameShop,
+    objectId: string,
+    backupPath: string,
+    winePrefix?: string | null
+  ): Promise<void> {
+    const args = [
+      "--config",
+      this.configPath,
+      "restore",
+      "--force",
+      "--api",
+      "--path",
+      backupPath,
+      "--games",
+      objectId,
+    ];
+    if (winePrefix) args.push("--wine-prefix", winePrefix);
+
+    return new Promise((resolve, reject) => {
+      cp.execFile(this.binaryPath, args, (err: cp.ExecFileException | null) => {
+        if (err) return reject(err);
+        return resolve();
+      });
+    });
+  }
+
   static async addCustomGame(title: string, savePath: string | null) {
     const config = await this.getConfig();
     const filteredGames = config.customGames.filter(

--- a/src/main/services/process-watcher.ts
+++ b/src/main/services/process-watcher.ts
@@ -1,6 +1,7 @@
 import { WindowManager } from "./window-manager";
 import { updateGameExecutablePath } from "@main/helpers/update-executable-path";
 import { createGame, trackGamePlaytime } from "./library-sync";
+import { YandexDiskBackup } from "./yandex-disk-backup";
 import type { Game, GameRunning, UserPreferences } from "@types";
 import axios from "axios";
 import { db, gamesSublevel, levelKeys } from "@main/level";
@@ -491,6 +492,11 @@ const onCloseGame = (game: Game) => {
   };
 
   gamesSublevel.put(gameKey, updatedGame);
+
+  // Yandex Disk backup (non-blocking)
+  YandexDiskBackup.backupOnGameExit(updatedGame).catch((err) => {
+    logger.warn("[YandexDisk] backupOnGameExit error", err);
+  });
 
   if (game.shop === "custom") return;
 

--- a/src/main/services/yandex-disk-backup.ts
+++ b/src/main/services/yandex-disk-backup.ts
@@ -1,0 +1,830 @@
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import * as tar from "tar";
+import axios from "axios";
+import type {
+  Game,
+  GameShop,
+  UserPreferences,
+  UnlockedAchievement,
+  CloudBackupEntry as CloudStorageBackupEntry,
+  CloudStorageUsage,
+} from "@types";
+import { db, gamesSublevel, levelKeys } from "@main/level";
+import { logger } from "./logger";
+import { Ludusavi } from "./ludusavi";
+import { SystemPath } from "./system-path";
+import { BackupMetadataService } from "./backup-metadata";
+import { AchievementMemoryStore } from "./achievements/achievement-memory-store";
+import { mergeAchievements } from "./achievements/merge-achievements";
+
+const YANDEX_DISK_API = "https://cloud-api.yandex.net/v1/disk";
+const YANDEX_UPLOAD_API =
+  "https://cloud-api.yandex.net/v1/disk/resources/upload";
+
+/** Short requests: token/account checks, status pings. */
+const REQUEST_TIMEOUT_SHORT_MS = 10_000;
+/** Default requests: list/create/delete/get-download-url metadata calls. */
+const REQUEST_TIMEOUT_DEFAULT_MS = 15_000;
+/** Requests that transfer a file body (upload/download). */
+const REQUEST_TIMEOUT_TRANSFER_MS = 120_000;
+/** Page size for the flat file-listing endpoint used by listAllBackups(). */
+const LIST_BACKUPS_PAGE_SIZE = 200;
+/** Safety cap on how many items listAllBackups() will page through. */
+const LIST_BACKUPS_MAX_OFFSET = 5_000;
+
+export interface YandexBackupEntry {
+  path: string;
+  name: string;
+  created: string;
+  modified: string;
+  size: number;
+  type: string;
+}
+
+export class YandexDiskBackup {
+  private static async getPrefs(): Promise<UserPreferences | null> {
+    try {
+      return await db.get<string, UserPreferences | null>(
+        levelKeys.userPreferences,
+        {
+          valueEncoding: "json",
+        }
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  public static async validateToken(token: string): Promise<boolean> {
+    try {
+      const response = await axios.get(YANDEX_DISK_API, {
+        headers: { Authorization: `OAuth ${token}` },
+        timeout: REQUEST_TIMEOUT_SHORT_MS,
+      });
+      return response.status === 200;
+    } catch {
+      return false;
+    }
+  }
+
+  private static async ensureRemoteDir(
+    token: string,
+    remotePath: string
+  ): Promise<void> {
+    const parts = remotePath.replace("disk:/", "").split("/").filter(Boolean);
+    let current = "";
+    for (const part of parts) {
+      current = current ? `${current}/${part}` : part;
+      try {
+        await axios.put(`${YANDEX_DISK_API}/resources`, null, {
+          params: { path: `disk:/${current}` },
+          headers: { Authorization: `OAuth ${token}` },
+          timeout: REQUEST_TIMEOUT_SHORT_MS,
+        });
+      } catch (err: any) {
+        if (err?.response?.status !== 409) {
+          // 409 means already exists, which is fine
+          throw err;
+        }
+      }
+    }
+  }
+
+  private static async uploadFile(
+    token: string,
+    localPath: string,
+    remotePath: string
+  ): Promise<void> {
+    // Get upload URL
+    const { data } = await axios.get(YANDEX_UPLOAD_API, {
+      params: { path: remotePath, overwrite: true },
+      headers: { Authorization: `OAuth ${token}` },
+      timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+    });
+
+    const uploadUrl: string = data.href;
+
+    const fileBuffer = fs.readFileSync(localPath);
+    await axios.put(uploadUrl, fileBuffer, {
+      headers: { "Content-Type": "application/octet-stream" },
+      maxBodyLength: Infinity,
+      timeout: REQUEST_TIMEOUT_TRANSFER_MS,
+    });
+  }
+
+  private static async downloadFile(
+    token: string,
+    remotePath: string,
+    localPath: string
+  ): Promise<void> {
+    const { data } = await axios.get(`${YANDEX_DISK_API}/resources/download`, {
+      params: { path: remotePath },
+      headers: { Authorization: `OAuth ${token}` },
+      timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+    });
+
+    const downloadUrl: string = data.href;
+    const response = await axios.get(downloadUrl, {
+      responseType: "arraybuffer",
+      timeout: REQUEST_TIMEOUT_TRANSFER_MS,
+    });
+
+    fs.writeFileSync(localPath, Buffer.from(response.data));
+  }
+
+  private static getRemoteGameDir(game: Game): string {
+    return `disk:/HydraBackups/${game.shop}/${game.objectId}`;
+  }
+
+  public static async listBackups(
+    game: Pick<Game, "objectId" | "shop">
+  ): Promise<YandexBackupEntry[]> {
+    const prefs = await this.getPrefs();
+    const token = prefs?.yandexDiskToken;
+    if (!token) return [];
+
+    try {
+      const remotePath = `disk:/HydraBackups/${game.shop}/${game.objectId}`;
+      const { data } = await axios.get(`${YANDEX_DISK_API}/resources`, {
+        params: { path: remotePath, limit: 100 },
+        headers: { Authorization: `OAuth ${token}` },
+        timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+      });
+
+      const items: YandexBackupEntry[] = (data._embedded?.items ?? [])
+        .filter((item: any) => item.name.endsWith(".tar.gz"))
+        .map((item: any) => ({
+          path: item.path,
+          name: item.name,
+          created: item.created,
+          modified: item.modified,
+          size: item.size ?? 0,
+          type: item.type,
+        }));
+
+      return items.sort((a, b) => b.modified.localeCompare(a.modified));
+    } catch (err: any) {
+      if (err?.response?.status === 404) return [];
+      logger.error("[YandexDisk] listBackups error", err);
+      return [];
+    }
+  }
+
+  public static async backupOnGameExit(game: Game): Promise<void> {
+    const prefs = await this.getPrefs();
+    if (!prefs?.yandexDiskBackupEnabled || !prefs?.yandexDiskToken) return;
+
+    const token = prefs.yandexDiskToken;
+    const maxBackups = prefs.yandexDiskMaxBackups ?? 5;
+    const tmpDir = os.tmpdir();
+
+    try {
+      // Run Ludusavi backup to a temp directory
+      const ludusaviTmpPath = path.join(
+        tmpDir,
+        `hydra-ydisk-${game.objectId}-${Date.now()}`
+      );
+      fs.mkdirSync(ludusaviTmpPath, { recursive: true });
+
+      const ludusaviResult = await Ludusavi.backupGame(
+        game.shop,
+        game.objectId,
+        ludusaviTmpPath,
+        game.winePrefixPath
+      );
+
+      // Save Hydra metadata alongside Ludusavi backup files
+      const metadata = BackupMetadataService.createMetadata(
+        game,
+        ludusaviResult
+      );
+      BackupMetadataService.writeMetadataToBackupDir(ludusaviTmpPath, metadata);
+
+      // Create tar.gz
+      const timestamp = new Date()
+        .toISOString()
+        .replace(/:/g, "-")
+        .replace(/\..+/, "");
+      const archiveName = `backup_${timestamp}.tar.gz`;
+      const archivePath = path.join(tmpDir, archiveName);
+
+      await tar.c({ gzip: true, file: archivePath, cwd: ludusaviTmpPath }, [
+        ".",
+      ]);
+
+      // Ensure remote dir exists
+      const remoteDir = this.getRemoteGameDir(game);
+      await this.ensureRemoteDir(token, remoteDir);
+
+      // Upload
+      const remotePath = `${remoteDir}/${archiveName}`;
+      await this.uploadFile(token, archivePath, remotePath);
+
+      // Upload a lightweight metadata sidecar next to the archive so the
+      // cloud storage manager can display game info without downloading
+      // the whole archive. Purely additive — older backups simply won't
+      // have this file, and everything else keeps working as before.
+      try {
+        const sidecarPath = path.join(tmpDir, `${archiveName}.metadata.json`);
+        fs.writeFileSync(
+          sidecarPath,
+          JSON.stringify(metadata, null, 2),
+          "utf-8"
+        );
+        await this.uploadFile(
+          token,
+          sidecarPath,
+          `${remotePath}.metadata.json`
+        );
+        fs.rmSync(sidecarPath, { force: true });
+      } catch (metaErr) {
+        logger.warn(
+          "[YandexDisk] Failed to upload metadata sidecar (non-fatal)",
+          metaErr
+        );
+      }
+
+      // Cleanup local tmp
+      fs.rmSync(ludusaviTmpPath, { recursive: true, force: true });
+      fs.rmSync(archivePath, { force: true });
+
+      // Prune old backups
+      const backups = await this.listBackups(game);
+      if (backups.length > maxBackups) {
+        const toDelete = backups.slice(maxBackups);
+        for (const entry of toDelete) {
+          try {
+            await axios.delete(`${YANDEX_DISK_API}/resources`, {
+              params: { path: entry.path, permanently: true },
+              headers: { Authorization: `OAuth ${token}` },
+              timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+            });
+          } catch (e) {
+            logger.warn("[YandexDisk] Failed to delete old backup", e);
+          }
+        }
+      }
+
+      logger.info(`[YandexDisk] Backup complete for ${game.title}`);
+
+      // Backup achievements in parallel (non-blocking)
+      this.backupAchievements(game).catch((e) =>
+        logger.warn("[YandexDisk] backupAchievements error", e)
+      );
+    } catch (err) {
+      logger.error("[YandexDisk] backupOnGameExit error", err);
+    }
+  }
+
+  public static async downloadAndRestoreBackup(
+    game: Pick<Game, "objectId" | "shop" | "winePrefixPath">,
+    remotePath: string
+  ): Promise<void> {
+    const prefs = await this.getPrefs();
+    const token = prefs?.yandexDiskToken;
+    if (!token) throw new Error("Yandex Disk token not configured");
+
+    const tmpDir = os.tmpdir();
+    const archivePath = path.join(
+      tmpDir,
+      `hydra-restore-${game.objectId}-${Date.now()}.tar.gz`
+    );
+    const extractDir = path.join(tmpDir, `hydra-restore-extract-${Date.now()}`);
+
+    try {
+      fs.mkdirSync(extractDir, { recursive: true });
+
+      await this.downloadFile(token, remotePath, archivePath);
+      await tar.x({ file: archivePath, cwd: extractDir });
+
+      await Ludusavi.restoreGame(
+        game.shop,
+        game.objectId,
+        extractDir,
+        game.winePrefixPath
+      );
+
+      // Check for cross-repack/emulator path compatibility
+      const metadata =
+        BackupMetadataService.readMetadataFromExtractDir(extractDir);
+      if (metadata) {
+        try {
+          const currentPreview = await Ludusavi.backupGame(
+            game.shop,
+            game.objectId,
+            null,
+            game.winePrefixPath,
+            true
+          );
+          const currentPaths = BackupMetadataService.extractSavePaths(
+            currentPreview,
+            game.objectId
+          );
+          const relocationResult = await BackupMetadataService.relocateSaves(
+            metadata,
+            currentPaths
+          );
+          if (relocationResult.relocated) {
+            logger.info(
+              `[YandexDisk] Relocated ${relocationResult.filesRelocated} save files: ` +
+                `[${relocationResult.from.join(", ")}] → [${relocationResult.to.join(", ")}]`
+            );
+          }
+        } catch (relocErr) {
+          logger.warn(
+            "[YandexDisk] Save relocation check failed (non-fatal)",
+            relocErr
+          );
+        }
+      }
+
+      logger.info(`[YandexDisk] Restore complete for ${game.objectId}`);
+    } finally {
+      fs.rmSync(archivePath, { force: true });
+      fs.rmSync(extractDir, { recursive: true, force: true });
+    }
+  }
+
+  public static async checkAndRestoreOnStartup(): Promise<void> {
+    const prefs = await this.getPrefs();
+    if (!prefs?.yandexDiskRestoreOnStartup || !prefs?.yandexDiskToken) return;
+
+    const token = prefs.yandexDiskToken;
+
+    try {
+      const allGames: Game[] = await gamesSublevel.values().all();
+
+      for (const game of allGames) {
+        if (game.isDeleted) continue;
+
+        try {
+          // Check local saves via Ludusavi preview
+          const preview = await Ludusavi.getBackupPreview(
+            game.shop,
+            game.objectId,
+            game.winePrefixPath
+          );
+
+          const hasLocalSaves =
+            preview && Object.keys(preview.games ?? {}).length > 0;
+
+          if (!hasLocalSaves) {
+            const backups = await this.listBackups(game);
+            if (backups.length > 0) {
+              logger.info(`[YandexDisk] Restoring saves for ${game.title}`);
+              await this.downloadAndRestoreBackup(game, backups[0].path);
+            }
+          }
+
+          // Restore achievements
+          await this.restoreAchievements(game, token);
+        } catch (e) {
+          logger.warn(
+            `[YandexDisk] checkAndRestore failed for ${game.objectId}`,
+            e
+          );
+        }
+      }
+    } catch (err) {
+      logger.error("[YandexDisk] checkAndRestoreOnStartup error", err);
+    }
+  }
+
+  public static async backupAchievements(game: Game): Promise<void> {
+    const prefs = await this.getPrefs();
+    const token = prefs?.yandexDiskToken;
+    if (!token) return;
+
+    try {
+      const achievements: UnlockedAchievement[] =
+        AchievementMemoryStore.get(game.shop, game.objectId)
+          ?.unlockedAchievements ?? [];
+      if (!achievements || achievements.length === 0) return;
+
+      const remoteDir = this.getRemoteGameDir(game);
+      await this.ensureRemoteDir(token, remoteDir);
+
+      const tmpPath = path.join(
+        os.tmpdir(),
+        `hydra-ach-${game.objectId}-${Date.now()}.json`
+      );
+      fs.writeFileSync(tmpPath, JSON.stringify(achievements, null, 2));
+
+      await this.uploadFile(token, tmpPath, `${remoteDir}/achievements.json`);
+      fs.rmSync(tmpPath, { force: true });
+
+      logger.info(`[YandexDisk] Achievements backed up for ${game.title}`);
+    } catch (err) {
+      logger.error("[YandexDisk] backupAchievements error", err);
+    }
+  }
+
+  public static async restoreAchievements(
+    game: Game,
+    token: string
+  ): Promise<void> {
+    try {
+      const remoteDir = this.getRemoteGameDir(game);
+      const remotePath = `${remoteDir}/achievements.json`;
+
+      const tmpPath = path.join(
+        os.tmpdir(),
+        `hydra-ach-restore-${game.objectId}-${Date.now()}.json`
+      );
+
+      try {
+        await this.downloadFile(token, remotePath, tmpPath);
+      } catch (e: any) {
+        // 404 = no remote achievements, skip silently
+        if (e?.response?.status === 404) return;
+        throw e;
+      }
+
+      const achievements: UnlockedAchievement[] = JSON.parse(
+        fs.readFileSync(tmpPath, "utf-8")
+      );
+      fs.rmSync(tmpPath, { force: true });
+
+      if (!achievements || achievements.length === 0) return;
+
+      const winePrefix = game.winePrefixPath;
+
+      // Write Goldberg format: achievements.json
+      const goldbergDir = this.findAchievementDir(game, "goldberg", winePrefix);
+      if (goldbergDir) {
+        const goldbergPath = path.join(goldbergDir, "achievements.json");
+        if (!fs.existsSync(goldbergPath)) {
+          const goldbergData: Record<
+            string,
+            { earned: number; earned_time: number }
+          > = {};
+          for (const ach of achievements) {
+            goldbergData[ach.name] = {
+              earned: 1,
+              earned_time: ach.unlockTime
+                ? Math.floor(new Date(ach.unlockTime).getTime() / 1000)
+                : Math.floor(Date.now() / 1000),
+            };
+          }
+          fs.writeFileSync(goldbergPath, JSON.stringify(goldbergData, null, 2));
+        }
+      }
+
+      // Write CODEX format: achievements.ini
+      const codexDir = this.findAchievementDir(game, "codex", winePrefix);
+      if (codexDir) {
+        const codexPath = path.join(codexDir, "achievements.ini");
+        if (!fs.existsSync(codexPath)) {
+          let iniContent = "[STATE]\n";
+          for (const ach of achievements) {
+            iniContent += `${ach.name}=1\n`;
+          }
+          fs.writeFileSync(codexPath, iniContent);
+        }
+      }
+
+      // Write EMPRESS format (same as Goldberg)
+      const empressDir = this.findAchievementDir(game, "empress", winePrefix);
+      if (empressDir) {
+        const empressPath = path.join(empressDir, "achievements.json");
+        if (!fs.existsSync(empressPath)) {
+          const empressData: Record<
+            string,
+            { earned: number; earned_time: number }
+          > = {};
+          for (const ach of achievements) {
+            empressData[ach.name] = {
+              earned: 1,
+              earned_time: ach.unlockTime
+                ? Math.floor(new Date(ach.unlockTime).getTime() / 1000)
+                : Math.floor(Date.now() / 1000),
+            };
+          }
+          fs.writeFileSync(empressPath, JSON.stringify(empressData, null, 2));
+        }
+      }
+
+      // Merge into the in-memory achievement store (and sync with Hydra's
+      // own backend if the game is linked) instead of writing to LevelDB,
+      // which no longer persists achievements.
+      await mergeAchievements(game, achievements, false);
+
+      logger.info(`[YandexDisk] Achievements restored for ${game.title}`);
+    } catch (err) {
+      logger.warn("[YandexDisk] restoreAchievements error", err);
+    }
+  }
+
+  private static findAchievementDir(
+    game: Game,
+    emulator: "goldberg" | "codex" | "empress",
+    winePrefix?: string | null
+  ): string | null {
+    try {
+      const appDataPath = SystemPath.getPath("appData");
+      const candidates: string[] = [];
+
+      if (process.platform === "win32") {
+        // Windows paths
+        const localAppData =
+          process.env.LOCALAPPDATA ?? path.join(appDataPath, "..", "Local");
+        candidates.push(
+          path.join(localAppData, "CODEX", game.objectId),
+          path.join(localAppData, "Goldberg SteamEmu", game.objectId),
+          path.join(localAppData, "EMPRESS", game.objectId)
+        );
+      } else if (winePrefix) {
+        // Wine prefix paths
+        const wineLocal = path.join(
+          winePrefix,
+          "drive_c",
+          "users",
+          "steamuser",
+          "Local Settings",
+          "Application Data"
+        );
+        candidates.push(
+          path.join(wineLocal, "CODEX", game.objectId),
+          path.join(wineLocal, "Goldberg SteamEmu", game.objectId),
+          path.join(wineLocal, "EMPRESS", game.objectId)
+        );
+      }
+
+      for (const candidate of candidates) {
+        const name = candidate.toLowerCase();
+        if (
+          (emulator === "goldberg" && name.includes("goldberg")) ||
+          (emulator === "codex" && name.includes("codex")) ||
+          (emulator === "empress" && name.includes("empress"))
+        ) {
+          if (fs.existsSync(candidate)) {
+            return candidate;
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
+  /* -----------------------------------------------------------------
+   * The methods below are additive helpers used by CloudStorageService
+   * (the "Облачное хранилище" settings section). They reuse the same
+   * token/HTTP plumbing as the rest of this class but never touch the
+   * automatic backup/restore/achievements flows above.
+   * --------------------------------------------------------------- */
+
+  public static async getToken(): Promise<string | null> {
+    const prefs = await this.getPrefs();
+    return prefs?.yandexDiskToken ?? null;
+  }
+
+  public static async getAccountInfo(): Promise<{
+    login: string | null;
+    displayName: string | null;
+  } | null> {
+    const token = await this.getToken();
+    if (!token) return null;
+
+    try {
+      const { data } = await axios.get(YANDEX_DISK_API, {
+        params: { fields: "user" },
+        headers: { Authorization: `OAuth ${token}` },
+        timeout: REQUEST_TIMEOUT_SHORT_MS,
+      });
+
+      return {
+        login: data?.user?.login ?? null,
+        displayName: data?.user?.display_name ?? null,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private static async downloadTextFile(
+    token: string,
+    remotePath: string
+  ): Promise<string> {
+    const downloadUrl = await this.getResourceDownloadUrl(remotePath, token);
+    const response = await axios.get(downloadUrl, {
+      responseType: "text",
+      timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+    });
+    return typeof response.data === "string"
+      ? response.data
+      : JSON.stringify(response.data);
+  }
+
+  public static async getResourceDownloadUrl(
+    remotePath: string,
+    tokenOverride?: string
+  ): Promise<string> {
+    const token = tokenOverride ?? (await this.getToken());
+    if (!token) throw new Error("Yandex Disk token not configured");
+
+    const { data } = await axios.get(`${YANDEX_DISK_API}/resources/download`, {
+      params: { path: remotePath },
+      headers: { Authorization: `OAuth ${token}` },
+      timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+    });
+
+    return data.href;
+  }
+
+  public static async downloadBackupToFile(
+    remotePath: string,
+    destPath: string,
+    onProgress?: (percent: number) => void
+  ): Promise<void> {
+    const token = await this.getToken();
+    if (!token) throw new Error("Yandex Disk token not configured");
+
+    const downloadUrl = await this.getResourceDownloadUrl(remotePath, token);
+
+    const response = await axios.get(downloadUrl, {
+      responseType: "stream",
+      timeout: REQUEST_TIMEOUT_TRANSFER_MS,
+      onDownloadProgress: (progressEvent) => {
+        if (onProgress && progressEvent.total) {
+          onProgress(
+            Math.round((progressEvent.loaded / progressEvent.total) * 100)
+          );
+        }
+      },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const writer = fs.createWriteStream(destPath);
+      response.data.pipe(writer);
+      writer.on("finish", () => resolve());
+      writer.on("error", reject);
+    });
+  }
+
+  public static async deleteBackupFile(remotePath: string): Promise<void> {
+    const token = await this.getToken();
+    if (!token) throw new Error("Yandex Disk token not configured");
+
+    await axios.delete(`${YANDEX_DISK_API}/resources`, {
+      params: { path: remotePath, permanently: true },
+      headers: { Authorization: `OAuth ${token}` },
+      timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+    });
+
+    // Best-effort: the metadata sidecar may or may not exist.
+    try {
+      await axios.delete(`${YANDEX_DISK_API}/resources`, {
+        params: { path: `${remotePath}.metadata.json`, permanently: true },
+        headers: { Authorization: `OAuth ${token}` },
+        timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+      });
+    } catch {
+      // ignore — sidecar may not exist (legacy backup)
+    }
+  }
+
+  /**
+   * Lists every backup archive under disk:/HydraBackups across all games,
+   * for the unified cloud storage manager. Uses Yandex's flat file listing
+   * endpoint (a single paginated call) rather than walking each game
+   * folder individually.
+   */
+  public static async listAllBackups(): Promise<CloudStorageBackupEntry[]> {
+    const token = await this.getToken();
+    if (!token) return [];
+
+    const rootPrefix = "disk:/HydraBackups/";
+
+    try {
+      const limit = LIST_BACKUPS_PAGE_SIZE;
+      let offset = 0;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rawItems: any[] = [];
+
+      for (;;) {
+        const { data } = await axios.get(`${YANDEX_DISK_API}/resources/files`, {
+          params: { limit, offset, sort: "-modified" },
+          headers: { Authorization: `OAuth ${token}` },
+          timeout: REQUEST_TIMEOUT_DEFAULT_MS,
+        });
+
+        const items = data.items ?? [];
+        rawItems.push(...items);
+
+        if (items.length < limit || offset > LIST_BACKUPS_MAX_OFFSET) break;
+        offset += limit;
+      }
+
+      const relevant = rawItems.filter(
+        (item) =>
+          typeof item.path === "string" && item.path.startsWith(rootPrefix)
+      );
+
+      const archives = relevant.filter((item) => item.name.endsWith(".tar.gz"));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sidecarByArchivePath = new Map<string, any>();
+      for (const item of relevant) {
+        if (item.name.endsWith(".tar.gz.metadata.json")) {
+          sidecarByArchivePath.set(
+            item.path.replace(/\.metadata\.json$/, ""),
+            item
+          );
+        }
+      }
+
+      const allGames = await gamesSublevel.values().all();
+      const gameTitleByKey = new Map<string, string>();
+      for (const game of allGames) {
+        gameTitleByKey.set(`${game.shop}:${game.objectId}`, game.title);
+      }
+
+      const entries: CloudStorageBackupEntry[] = [];
+
+      for (const archive of archives) {
+        const relativePath = archive.path.slice(rootPrefix.length);
+        const parts = relativePath.split("/");
+        if (parts.length < 2) continue;
+
+        const shop = parts[0] as GameShop;
+        const objectId = parts[1];
+
+        let metadata: CloudStorageBackupEntry["metadata"] = null;
+        const sidecarItem = sidecarByArchivePath.get(archive.path);
+
+        if (sidecarItem) {
+          try {
+            const content = await this.downloadTextFile(
+              token,
+              sidecarItem.path
+            );
+            const parsed = JSON.parse(content);
+            metadata = {
+              gameName: parsed.gameName,
+              steamAppId: parsed.steamAppId,
+              gameVersion: parsed.gameVersion ?? null,
+              platform: parsed.platform,
+              backupDate: parsed.backupDate,
+            };
+          } catch (err) {
+            logger.warn("[YandexDisk] Failed to read metadata sidecar", err);
+          }
+        }
+
+        entries.push({
+          path: archive.path,
+          name: archive.name,
+          shop,
+          objectId,
+          gameTitle:
+            gameTitleByKey.get(`${shop}:${objectId}`) ??
+            metadata?.gameName ??
+            objectId,
+          created: archive.created,
+          modified: archive.modified,
+          size: archive.size ?? 0,
+          metadata,
+        });
+      }
+
+      return entries.sort((a, b) => b.modified.localeCompare(a.modified));
+    } catch (err) {
+      logger.error("[YandexDisk] listAllBackups error", err);
+      return [];
+    }
+  }
+
+  public static async getStorageUsage(): Promise<CloudStorageUsage> {
+    const token = await this.getToken();
+    if (!token) {
+      return { totalSpace: 0, usedSpace: 0, backupsSize: 0, backupsCount: 0 };
+    }
+
+    const [diskInfo, backups] = await Promise.all([
+      axios
+        .get(YANDEX_DISK_API, {
+          headers: { Authorization: `OAuth ${token}` },
+          timeout: REQUEST_TIMEOUT_SHORT_MS,
+        })
+        .then((response) => response.data)
+        .catch(() => null),
+      this.listAllBackups(),
+    ]);
+
+    const backupsSize = backups.reduce(
+      (sum, entry) => sum + (entry.size ?? 0),
+      0
+    );
+
+    return {
+      totalSpace: diskInfo?.total_space ?? 0,
+      usedSpace: diskInfo?.used_space ?? 0,
+      backupsSize,
+      backupsCount: backups.length,
+    };
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1422,6 +1422,63 @@ contextBridge.exposeInMainWorld("electron", {
   getAvailableDrives: () => ipcRenderer.invoke("getAvailableDrives"),
   transferGameFiles: (shop: GameShop, objectId: string, destParent: string) =>
     ipcRenderer.invoke("transferGameFiles", shop, objectId, destParent),
+
+  /* Yandex Disk Backup */
+  getYandexDiskSettings: () => ipcRenderer.invoke("getYandexDiskSettings"),
+  getYandexDiskAccountInfo: () =>
+    ipcRenderer.invoke("getYandexDiskAccountInfo"),
+  updateYandexDiskSettings: (settings: {
+    token?: string | null;
+    backupEnabled?: boolean;
+    restoreOnStartup?: boolean;
+    maxBackups?: number;
+  }) => ipcRenderer.invoke("updateYandexDiskSettings", settings),
+  validateYandexDiskToken: (token: string) =>
+    ipcRenderer.invoke("validateYandexDiskToken", token),
+  listYandexDiskBackups: (objectId: string, shop: GameShop) =>
+    ipcRenderer.invoke("listYandexDiskBackups", objectId, shop),
+  restoreYandexDiskBackup: (
+    objectId: string,
+    shop: GameShop,
+    remotePath: string
+  ) =>
+    ipcRenderer.invoke("restoreYandexDiskBackup", objectId, shop, remotePath),
+  backupNowYandexDisk: (objectId: string, shop: GameShop) =>
+    ipcRenderer.invoke("backupNowYandexDisk", objectId, shop),
+
+  /* Cloud Storage (unified manager, built on top of Yandex Disk Backup) */
+  listCloudBackups: () => ipcRenderer.invoke("listCloudBackups"),
+  getCloudStorageUsage: () => ipcRenderer.invoke("getCloudStorageUsage"),
+  downloadCloudBackup: (remotePath: string, destDir: string) =>
+    ipcRenderer.invoke("downloadCloudBackup", remotePath, destDir),
+  deleteCloudBackup: (remotePath: string) =>
+    ipcRenderer.invoke("deleteCloudBackup", remotePath),
+  onCloudBackupDownloadProgress: (
+    cb: (payload: { path: string; percent: number }) => void
+  ) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { path: string; percent: number }
+    ) => cb(payload);
+    ipcRenderer.on("on-cloud-backup-download-progress", listener);
+    return () =>
+      ipcRenderer.removeListener("on-cloud-backup-download-progress", listener);
+  },
+  onCloudBackupDownloadComplete: (
+    cb: (payload: {
+      path: string;
+      success: boolean;
+      localPath?: string;
+    }) => void
+  ) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { path: string; success: boolean; localPath?: string }
+    ) => cb(payload);
+    ipcRenderer.on("on-cloud-backup-download-complete", listener);
+    return () =>
+      ipcRenderer.removeListener("on-cloud-backup-download-complete", listener);
+  },
 });
 
 const reportNetworkStatus = (online: boolean, switched = false) => {

--- a/src/renderer/src/context/settings/settings.context.tsx
+++ b/src/renderer/src/context/settings/settings.context.tsx
@@ -12,6 +12,7 @@ export type SettingsCategoryId =
   | "download_sources"
   | "notifications"
   | "content_gameplay"
+  | "cloud_storage"
   | "integrations"
   | "compatibility"
   | "account_privacy"
@@ -34,6 +35,7 @@ const isSettingsCategoryId = (value: string): value is SettingsCategoryId => {
     "download_sources",
     "notifications",
     "content_gameplay",
+    "cloud_storage",
     "integrations",
     "compatibility",
     "account_privacy",

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -63,6 +63,8 @@ import type {
   ArtworkKind,
   ArtworkPage,
   GameArtworkSelection,
+  CloudBackupEntry,
+  CloudStorageUsage,
 } from "@types";
 import type { AxiosProgressEvent } from "axios";
 
@@ -92,6 +94,22 @@ declare global {
     exists: boolean;
     isDirectory: boolean;
     isFile: boolean;
+  };
+
+  type YandexDiskBackupEntry = {
+    path: string;
+    name: string;
+    created: string;
+    modified: string;
+    size: number;
+    type: string;
+  };
+
+  type YandexDiskSettings = {
+    token: string | null;
+    backupEnabled: boolean;
+    restoreOnStartup: boolean;
+    maxBackups: number;
   };
 
   interface Electron {
@@ -1016,6 +1034,53 @@ declare global {
     /* Event listeners for transfer progress */
     on: (channel: string, listener: (...args) => void) => void;
     off: (channel: string, listener: (...args) => void) => void;
+
+    /* Yandex Disk Backup — connection + per-game settings, used by the
+       "connection" and "settings" blocks of the Cloud Storage section */
+    getYandexDiskSettings: () => Promise<YandexDiskSettings>;
+    getYandexDiskAccountInfo: () => Promise<{
+      login: string | null;
+      displayName: string | null;
+    } | null>;
+    updateYandexDiskSettings: (settings: {
+      token?: string | null;
+      backupEnabled?: boolean;
+      restoreOnStartup?: boolean;
+      maxBackups?: number;
+    }) => Promise<boolean>;
+    validateYandexDiskToken: (token: string) => Promise<boolean>;
+    listYandexDiskBackups: (
+      objectId: string,
+      shop: GameShop
+    ) => Promise<YandexDiskBackupEntry[]>;
+    restoreYandexDiskBackup: (
+      objectId: string,
+      shop: GameShop,
+      remotePath: string
+    ) => Promise<{ success: boolean }>;
+    backupNowYandexDisk: (
+      objectId: string,
+      shop: GameShop
+    ) => Promise<{ success: boolean }>;
+
+    /* Cloud Storage — unified backup manager */
+    listCloudBackups: () => Promise<CloudBackupEntry[]>;
+    getCloudStorageUsage: () => Promise<CloudStorageUsage>;
+    downloadCloudBackup: (
+      remotePath: string,
+      destDir: string
+    ) => Promise<{ success: boolean; localPath: string }>;
+    deleteCloudBackup: (remotePath: string) => Promise<{ success: boolean }>;
+    onCloudBackupDownloadProgress: (
+      cb: (payload: { path: string; percent: number }) => void
+    ) => () => Electron.IpcRenderer;
+    onCloudBackupDownloadComplete: (
+      cb: (payload: {
+        path: string;
+        success: boolean;
+        localPath?: string;
+      }) => void
+    ) => () => Electron.IpcRenderer;
   }
 
   interface Window {

--- a/src/renderer/src/pages/settings/cloud-backups-manager.scss
+++ b/src/renderer/src/pages/settings/cloud-backups-manager.scss
@@ -1,0 +1,115 @@
+@use "../../scss/globals.scss";
+
+.cloud-backups-manager {
+  display: flex;
+  flex-direction: column;
+  gap: calc(globals.$spacing-unit * 2);
+
+  &__usage {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(globals.$spacing-unit * 2);
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+    padding: calc(globals.$spacing-unit) calc(globals.$spacing-unit * 1.5);
+  }
+
+  &__toolbar {
+    display: flex;
+    align-items: flex-end;
+    gap: globals.$spacing-unit;
+
+    > *:first-child {
+      flex: 1;
+    }
+  }
+
+  &__refresh-icon--spinning {
+    animation: cloud-backups-manager-spin 1s linear infinite;
+  }
+
+  &__state-message {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.5);
+    text-align: center;
+    padding: calc(globals.$spacing-unit * 3) 0;
+
+    &--error {
+      color: #f85149;
+    }
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: calc(globals.$spacing-unit * 0.75);
+    max-height: 420px;
+    overflow-y: auto;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: globals.$spacing-unit;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+    padding: 10px 14px;
+  }
+
+  &__item-main {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__item-title {
+    font-size: 13px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__item-meta {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.45);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__item-progress {
+    font-size: 11px;
+    color: #58a6ff;
+  }
+
+  &__item-menu {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.6);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    flex-shrink: 0;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+    }
+  }
+}
+
+@keyframes cloud-backups-manager-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/renderer/src/pages/settings/cloud-backups-manager.tsx
+++ b/src/renderer/src/pages/settings/cloud-backups-manager.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DownloadIcon,
+  HistoryIcon,
+  KebabHorizontalIcon,
+  SearchIcon,
+  SyncIcon,
+  TrashIcon,
+} from "@primer/octicons-react";
+import { formatBytes } from "@shared";
+import {
+  Button,
+  ConfirmationModal,
+  SelectField,
+  TextField,
+} from "@renderer/components";
+import { DropdownMenu } from "@renderer/components/dropdown-menu/dropdown-menu";
+import { useToast } from "@renderer/hooks";
+import type { CloudBackupEntry, CloudStorageUsage } from "@types";
+import "./cloud-backups-manager.scss";
+
+type SortKey = "date" | "name" | "size";
+
+const formatDate = (iso: string | null | undefined): string => {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+};
+
+interface Props {
+  /** Whether the Yandex Disk account is currently connected. */
+  connected: boolean;
+}
+
+export function CloudBackupsManager({ connected }: Readonly<Props>) {
+  const { t } = useTranslation("settings");
+  const { showSuccessToast, showErrorToast } = useToast();
+
+  const [backups, setBackups] = useState<CloudBackupEntry[]>([]);
+  const [usage, setUsage] = useState<CloudStorageUsage | null>(null);
+  const [loadState, setLoadState] = useState<
+    "idle" | "loading" | "error" | "loaded"
+  >("idle");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("date");
+
+  const [downloadingPath, setDownloadingPath] = useState<string | null>(null);
+  const [downloadProgress, setDownloadProgress] = useState(0);
+  const [restoringPath, setRestoringPath] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CloudBackupEntry | null>(
+    null
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!connected) {
+      setBackups([]);
+      setUsage(null);
+      setLoadState("idle");
+      return;
+    }
+
+    setLoadState((prev) => (prev === "loaded" ? prev : "loading"));
+    setRefreshing(true);
+
+    try {
+      const [backupsResult, usageResult] = await Promise.all([
+        window.electron.listCloudBackups(),
+        window.electron.getCloudStorageUsage(),
+      ]);
+
+      setBackups(backupsResult);
+      setUsage(usageResult);
+      setLoadState("loaded");
+    } catch {
+      setLoadState("error");
+    } finally {
+      setRefreshing(false);
+    }
+  }, [connected]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const removeProgressListener =
+      window.electron.onCloudBackupDownloadProgress(({ path, percent }) => {
+        setDownloadingPath(path);
+        setDownloadProgress(percent);
+      });
+
+    const removeCompleteListener =
+      window.electron.onCloudBackupDownloadComplete(
+        ({ success, localPath }) => {
+          setDownloadingPath(null);
+          setDownloadProgress(0);
+
+          if (success) {
+            showSuccessToast(
+              t("cloud_storage_download_complete", "Загрузка завершена"),
+              localPath
+            );
+          } else {
+            showErrorToast(
+              t("cloud_storage_download_error", "Ошибка загрузки")
+            );
+          }
+        }
+      );
+
+    return () => {
+      removeProgressListener();
+      removeCompleteListener();
+    };
+  }, [showSuccessToast, showErrorToast, t]);
+
+  const visibleBackups = useMemo(() => {
+    const filtered = search.trim()
+      ? backups.filter((backup) =>
+          backup.gameTitle.toLowerCase().includes(search.trim().toLowerCase())
+        )
+      : backups;
+
+    const sorted = [...filtered];
+
+    if (sortKey === "name") {
+      sorted.sort((a, b) => a.gameTitle.localeCompare(b.gameTitle));
+    } else if (sortKey === "size") {
+      sorted.sort((a, b) => b.size - a.size);
+    } else {
+      sorted.sort((a, b) => b.modified.localeCompare(a.modified));
+    }
+
+    return sorted;
+  }, [backups, search, sortKey]);
+
+  const handleDownload = async (backup: CloudBackupEntry) => {
+    const { filePaths, canceled } = await window.electron.showOpenDialog({
+      properties: ["openDirectory"],
+    });
+
+    const destDir = filePaths?.[0];
+    if (canceled || !destDir) return;
+
+    setDownloadingPath(backup.path);
+    setDownloadProgress(0);
+
+    try {
+      await window.electron.downloadCloudBackup(backup.path, destDir);
+    } catch {
+      setDownloadingPath(null);
+      showErrorToast(t("cloud_storage_download_error", "Ошибка загрузки"));
+    }
+  };
+
+  const handleRestore = async (backup: CloudBackupEntry) => {
+    setRestoringPath(backup.path);
+    try {
+      await window.electron.restoreYandexDiskBackup(
+        backup.objectId,
+        backup.shop,
+        backup.path
+      );
+      showSuccessToast(
+        t("cloud_storage_restore_success", "Резервная копия восстановлена")
+      );
+    } catch {
+      showErrorToast(t("cloud_storage_restore_error", "Ошибка восстановления"));
+    } finally {
+      setRestoringPath(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+
+    setIsDeleting(true);
+    try {
+      await window.electron.deleteCloudBackup(deleteTarget.path);
+      showSuccessToast(
+        t("cloud_storage_delete_success", "Резервная копия удалена")
+      );
+      setDeleteTarget(null);
+      await load();
+    } catch {
+      showErrorToast(t("cloud_storage_delete_error", "Ошибка удаления"));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  if (!connected) {
+    return null;
+  }
+
+  return (
+    <div className="cloud-backups-manager">
+      {usage && (
+        <div className="cloud-backups-manager__usage">
+          <span>
+            {t("cloud_storage_usage_backups_count", "Резервных копий")}:{" "}
+            {usage.backupsCount}
+          </span>
+          <span>
+            {t("cloud_storage_usage_backups_size", "Общий объём")}:{" "}
+            {formatBytes(usage.backupsSize)}
+          </span>
+          {usage.totalSpace > 0 && (
+            <span>
+              {t("cloud_storage_usage_disk", "Диск")}:{" "}
+              {formatBytes(usage.usedSpace)} / {formatBytes(usage.totalSpace)}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="cloud-backups-manager__toolbar">
+        <TextField
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t(
+            "cloud_storage_search_placeholder",
+            "Поиск по названию игры"
+          )}
+          rightContent={<SearchIcon size={14} />}
+        />
+
+        <SelectField
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as SortKey)}
+          options={[
+            {
+              key: "date",
+              value: "date",
+              label: t("cloud_storage_sort_date", "По дате"),
+            },
+            {
+              key: "name",
+              value: "name",
+              label: t("cloud_storage_sort_name", "По названию"),
+            },
+            {
+              key: "size",
+              value: "size",
+              label: t("cloud_storage_sort_size", "По размеру"),
+            },
+          ]}
+        />
+
+        <Button theme="outline" onClick={load} disabled={refreshing}>
+          <SyncIcon
+            size={13}
+            className={
+              refreshing ? "cloud-backups-manager__refresh-icon--spinning" : ""
+            }
+          />
+          <span>{t("cloud_storage_refresh", "Обновить")}</span>
+        </Button>
+      </div>
+
+      {loadState === "loading" && (
+        <p className="cloud-backups-manager__state-message">
+          {t("cloud_storage_loading", "Загрузка списка резервных копий...")}
+        </p>
+      )}
+
+      {loadState === "error" && (
+        <p className="cloud-backups-manager__state-message cloud-backups-manager__state-message--error">
+          {t(
+            "cloud_storage_load_error",
+            "Не удалось получить список резервных копий"
+          )}
+        </p>
+      )}
+
+      {loadState === "loaded" && visibleBackups.length === 0 && (
+        <p className="cloud-backups-manager__state-message">
+          {t("cloud_storage_empty", "Резервных копий пока нет")}
+        </p>
+      )}
+
+      {visibleBackups.length > 0 && (
+        <div className="cloud-backups-manager__list">
+          {visibleBackups.map((backup) => (
+            <div key={backup.path} className="cloud-backups-manager__item">
+              <div className="cloud-backups-manager__item-main">
+                <span className="cloud-backups-manager__item-title">
+                  {backup.gameTitle}
+                </span>
+                <span className="cloud-backups-manager__item-meta">
+                  {formatDate(backup.modified)} · {formatBytes(backup.size)}
+                  {backup.metadata?.steamAppId &&
+                    ` · AppID ${backup.metadata.steamAppId}`}
+                  {backup.metadata?.gameVersion &&
+                    ` · v${backup.metadata.gameVersion}`}
+                  {backup.metadata?.platform &&
+                    ` · ${backup.metadata.platform}`}
+                </span>
+
+                {downloadingPath === backup.path && (
+                  <span className="cloud-backups-manager__item-progress">
+                    {t("cloud_storage_downloading", "Загрузка")}:{" "}
+                    {downloadProgress}%
+                  </span>
+                )}
+              </div>
+
+              <DropdownMenu
+                align="end"
+                items={[
+                  {
+                    icon: <DownloadIcon size={16} />,
+                    label: t("cloud_storage_download", "Скачать"),
+                    onClick: () => handleDownload(backup),
+                    disabled: downloadingPath === backup.path,
+                  },
+                  {
+                    icon: <HistoryIcon size={16} />,
+                    label: t("cloud_storage_restore", "Восстановить"),
+                    onClick: () => handleRestore(backup),
+                    disabled: restoringPath === backup.path,
+                  },
+                  {
+                    icon: <TrashIcon size={16} />,
+                    label: t("cloud_storage_delete", "Удалить"),
+                    onClick: () => setDeleteTarget(backup),
+                  },
+                ]}
+              >
+                <button
+                  type="button"
+                  className="cloud-backups-manager__item-menu"
+                  aria-label={backup.gameTitle}
+                >
+                  <KebabHorizontalIcon size={16} />
+                </button>
+              </DropdownMenu>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ConfirmationModal
+        visible={deleteTarget !== null}
+        title={t("cloud_storage_delete_title", "Удалить резервную копию?")}
+        descriptionText={t("cloud_storage_delete_description", {
+          name: deleteTarget?.gameTitle ?? "",
+          defaultValue:
+            "Резервная копия «{{name}}» будет удалена без возможности восстановления.",
+        })}
+        confirmButtonLabel={t("cloud_storage_delete", "Удалить")}
+        cancelButtonLabel={t("cancel_remove", "Отмена")}
+        buttonsIsDisabled={isDeleting}
+        onConfirm={handleDelete}
+        onClose={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/renderer/src/pages/settings/settings-cloud-storage.scss
+++ b/src/renderer/src/pages/settings/settings-cloud-storage.scss
@@ -1,0 +1,37 @@
+@use "../../scss/globals.scss";
+
+.settings-cloud-storage {
+  display: flex;
+  flex-direction: column;
+  gap: calc(globals.$spacing-unit * 2);
+
+  &__section-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+    margin: 0 0 calc(globals.$spacing-unit) 0;
+  }
+
+  &__divider {
+    border: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    margin: 0;
+  }
+
+  &__disconnected {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: globals.$spacing-unit;
+    text-align: center;
+    padding: calc(globals.$spacing-unit * 4) calc(globals.$spacing-unit * 2);
+    color: rgba(255, 255, 255, 0.5);
+
+    p {
+      max-width: 360px;
+      font-size: 13px;
+      line-height: 1.5;
+      margin: 0;
+    }
+  }
+}

--- a/src/renderer/src/pages/settings/settings-cloud-storage.tsx
+++ b/src/renderer/src/pages/settings/settings-cloud-storage.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CloudIcon } from "@primer/octicons-react";
+import { SettingsYandexDisk } from "./settings-yandex-disk";
+import { CloudBackupsManager } from "./cloud-backups-manager";
+import "./settings-cloud-storage.scss";
+
+export function SettingsContextCloudStorage() {
+  const { t } = useTranslation("settings");
+  const [connected, setConnected] = useState(false);
+
+  return (
+    <div className="settings-cloud-storage">
+      <div className="settings-cloud-storage__section">
+        <SettingsYandexDisk onConnectionChange={setConnected} />
+      </div>
+
+      {connected ? (
+        <>
+          <hr className="settings-cloud-storage__divider" />
+
+          <div className="settings-cloud-storage__section">
+            <h3 className="settings-cloud-storage__section-title">
+              {t("cloud_storage_backups_title", "Облачные резервные копии")}
+            </h3>
+            <CloudBackupsManager connected={connected} />
+          </div>
+        </>
+      ) : (
+        <div className="settings-cloud-storage__disconnected">
+          <CloudIcon size={32} />
+          <p>
+            {t(
+              "cloud_storage_not_connected",
+              "Яндекс.Диск не подключён. Подключите аккаунт Яндекс.Диска для использования облачных резервных копий."
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/pages/settings/settings-yandex-disk.scss
+++ b/src/renderer/src/pages/settings/settings-yandex-disk.scss
@@ -1,0 +1,165 @@
+@use "../../scss/globals.scss";
+
+.settings-yandex-disk {
+  display: flex;
+  flex-direction: column;
+  gap: calc(globals.$spacing-unit * 2);
+
+  &__title {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  &__status-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: globals.$spacing-unit;
+  }
+
+  &__status {
+    display: flex;
+    align-items: center;
+    gap: calc(globals.$spacing-unit * 0.75);
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  &__status-icon {
+    &--connected {
+      color: #3fb950;
+    }
+
+    &--disconnected {
+      color: rgba(255, 255, 255, 0.35);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: calc(globals.$spacing-unit * 0.75);
+  }
+
+  &__account {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.55);
+    margin: 0;
+  }
+
+  &__description {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: calc(globals.$spacing-unit * 2);
+  }
+
+  &__token-row {
+    display: flex;
+    align-items: flex-end;
+    gap: globals.$spacing-unit;
+
+    > *:first-child {
+      flex: 1;
+    }
+  }
+
+  &__token-hint {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.45);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  &__max-backups {
+    display: flex;
+    flex-direction: column;
+    gap: calc(globals.$spacing-unit * 0.5);
+  }
+
+  &__max-backups-label {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  &__max-backups-input {
+    width: 80px;
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 4px;
+    color: #fff;
+    font-size: 14px;
+    padding: 6px 10px;
+    outline: none;
+
+    &:focus {
+      border-color: rgba(255, 255, 255, 0.35);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+
+  &__backups-section {
+    display: flex;
+    flex-direction: column;
+    gap: globals.$spacing-unit;
+  }
+
+  &__backups-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+    margin: 0;
+  }
+
+  &__backups-list {
+    display: flex;
+    flex-direction: column;
+    gap: calc(globals.$spacing-unit * 0.5);
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  &__backup-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    padding: 8px 12px;
+    gap: globals.$spacing-unit;
+
+    &-name {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.7);
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    &-size {
+      font-size: 11px;
+      color: rgba(255, 255, 255, 0.4);
+      flex-shrink: 0;
+    }
+  }
+
+  &__empty {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.4);
+    text-align: center;
+    padding: calc(globals.$spacing-unit * 2) 0;
+  }
+}

--- a/src/renderer/src/pages/settings/settings-yandex-disk.tsx
+++ b/src/renderer/src/pages/settings/settings-yandex-disk.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CheckCircleFillIcon, XCircleFillIcon } from "@primer/octicons-react";
+import { Button, CheckboxField, TextField } from "@renderer/components";
+import "./settings-yandex-disk.scss";
+import { useToast } from "@renderer/hooks";
+
+interface Props {
+  /** Called whenever the connection state changes (connected/disconnected). */
+  onConnectionChange?: (connected: boolean) => void;
+}
+
+export function SettingsYandexDisk({ onConnectionChange }: Readonly<Props>) {
+  const { t } = useTranslation("settings");
+  const { showSuccessToast, showErrorToast } = useToast();
+
+  const [settings, setSettings] = useState<YandexDiskSettings>({
+    token: null,
+    backupEnabled: false,
+    restoreOnStartup: false,
+    maxBackups: 5,
+  });
+
+  const [account, setAccount] = useState<{
+    login: string | null;
+    displayName: string | null;
+  } | null>(null);
+
+  const [tokenInput, setTokenInput] = useState("");
+  const [isReconnecting, setIsReconnecting] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const isConnected = Boolean(settings.token);
+
+  const loadSettings = async () => {
+    const s = await window.electron.getYandexDiskSettings();
+    setSettings(s);
+    setTokenInput(s.token ?? "");
+
+    if (s.token) {
+      const accountInfo = await window.electron.getYandexDiskAccountInfo();
+      setAccount(accountInfo);
+    } else {
+      setAccount(null);
+    }
+  };
+
+  useEffect(() => {
+    loadSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    onConnectionChange?.(isConnected);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isConnected]);
+
+  const handleValidateToken = async () => {
+    if (!tokenInput.trim()) return;
+    setIsValidating(true);
+    try {
+      const valid = await window.electron.validateYandexDiskToken(
+        tokenInput.trim()
+      );
+      if (valid) {
+        await window.electron.updateYandexDiskSettings({
+          token: tokenInput.trim(),
+        });
+        showSuccessToast(t("yandex_disk_token_valid", "Токен действителен"));
+        setIsReconnecting(false);
+        await loadSettings();
+      } else {
+        showErrorToast(t("yandex_disk_token_invalid", "Токен недействителен"));
+      }
+    } catch {
+      showErrorToast(
+        t("yandex_disk_token_invalid_generic", "Ошибка проверки токена")
+      );
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setIsSaving(true);
+    try {
+      await window.electron.updateYandexDiskSettings({ token: null });
+      setTokenInput("");
+      showSuccessToast(t("yandex_disk_disconnected", "Яндекс.Диск отключён"));
+      await loadSettings();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggleBackup = async (enabled: boolean) => {
+    setIsSaving(true);
+    try {
+      await window.electron.updateYandexDiskSettings({
+        backupEnabled: enabled,
+      });
+      setSettings((s) => ({ ...s, backupEnabled: enabled }));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggleRestore = async (enabled: boolean) => {
+    setIsSaving(true);
+    try {
+      await window.electron.updateYandexDiskSettings({
+        restoreOnStartup: enabled,
+      });
+      setSettings((s) => ({ ...s, restoreOnStartup: enabled }));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleMaxBackupsChange = async (value: string) => {
+    const n = Math.max(1, Math.min(20, parseInt(value, 10) || 5));
+    setSettings((s) => ({ ...s, maxBackups: n }));
+    await window.electron.updateYandexDiskSettings({ maxBackups: n });
+  };
+
+  const showTokenForm = !isConnected || isReconnecting;
+
+  return (
+    <div className="settings-yandex-disk">
+      <div className="settings-yandex-disk__status-row">
+        <div className="settings-yandex-disk__status">
+          {isConnected ? (
+            <CheckCircleFillIcon
+              size={16}
+              className="settings-yandex-disk__status-icon settings-yandex-disk__status-icon--connected"
+            />
+          ) : (
+            <XCircleFillIcon
+              size={16}
+              className="settings-yandex-disk__status-icon settings-yandex-disk__status-icon--disconnected"
+            />
+          )}
+          <span>
+            {isConnected
+              ? t("yandex_disk_connected", "Подключено")
+              : t("yandex_disk_not_connected", "Не подключено")}
+          </span>
+        </div>
+
+        {isConnected && (
+          <div className="settings-yandex-disk__actions">
+            <Button
+              theme="outline"
+              onClick={() => setIsReconnecting((v) => !v)}
+              disabled={isSaving}
+            >
+              {t("yandex_disk_reconnect", "Переподключить")}
+            </Button>
+            <Button
+              theme="outline"
+              onClick={handleDisconnect}
+              disabled={isSaving}
+            >
+              {t("yandex_disk_disconnect", "Отключить")}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {isConnected && (account?.login || account?.displayName) && (
+        <p className="settings-yandex-disk__account">
+          {t("yandex_disk_account", "Аккаунт")}:{" "}
+          {account.displayName || account.login}
+        </p>
+      )}
+
+      <p className="settings-yandex-disk__description">
+        {t(
+          "yandex_disk_description",
+          "Автоматический бекап сохранений и достижений на Яндекс Диск при выходе из игры."
+        )}
+      </p>
+
+      {showTokenForm && (
+        <div className="settings-yandex-disk__form">
+          <div className="settings-yandex-disk__token-row">
+            <TextField
+              label={t("yandex_disk_token_label", "OAuth-токен")}
+              value={tokenInput}
+              onChange={(e) => setTokenInput(e.target.value)}
+              placeholder="y0_XXXX..."
+              type="password"
+            />
+            <Button
+              theme="outline"
+              onClick={handleValidateToken}
+              disabled={isValidating || !tokenInput.trim()}
+            >
+              {isValidating
+                ? t("yandex_disk_validating", "Проверяю...")
+                : t("yandex_disk_validate", "Проверить токен")}
+            </Button>
+          </div>
+
+          <p className="settings-yandex-disk__token-hint">
+            {t(
+              "yandex_disk_token_hint",
+              "Получите токен на oauth.yandex.ru. Платформа: Веб-сервисы. Права: Яндекс Диск → Запись + Чтение."
+            )}
+          </p>
+        </div>
+      )}
+
+      {isConnected && (
+        <div className="settings-yandex-disk__form">
+          <CheckboxField
+            label={t(
+              "yandex_disk_enable_backup",
+              "Включить автобекап при выходе из игры"
+            )}
+            checked={settings.backupEnabled}
+            onChange={(e) => handleToggleBackup(e.target.checked)}
+            disabled={isSaving}
+          />
+
+          <CheckboxField
+            label={t(
+              "yandex_disk_restore_on_startup",
+              "Восстанавливать при запуске Hydra (если нет локальных)"
+            )}
+            checked={settings.restoreOnStartup}
+            onChange={(e) => handleToggleRestore(e.target.checked)}
+            disabled={isSaving}
+          />
+
+          <div className="settings-yandex-disk__max-backups">
+            <label className="settings-yandex-disk__max-backups-label">
+              {t("yandex_disk_max_backups", "Максимум бекапов на диске (1-20)")}
+            </label>
+            <input
+              className="settings-yandex-disk__max-backups-input"
+              type="number"
+              min={1}
+              max={20}
+              value={settings.maxBackups}
+              onChange={(e) => handleMaxBackupsChange(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/pages/settings/settings.tsx
+++ b/src/renderer/src/pages/settings/settings.tsx
@@ -17,12 +17,13 @@ import {
   VideoIcon,
   ShieldCheckIcon,
 } from "@primer/octicons-react";
-import { Gamepad2, Wrench } from "lucide-react";
+import { Gamepad2, Plug, Wrench } from "lucide-react";
 import { SettingsContextGeneral } from "./settings-context-general";
 import { SettingsContextDownloads } from "./settings-context-downloads";
 import { SettingsContextDownloadSources } from "./settings-context-download-sources";
 import { SettingsContextNotifications } from "./settings-context-notifications";
 import { SettingsContextContentGameplay } from "./settings-context-content-gameplay";
+import { SettingsContextCloudStorage } from "./settings-cloud-storage";
 import { SettingsContextIntegrations } from "./settings-context-integrations";
 import { SettingsContextCompatibility } from "./settings-context-compatibility";
 import { SettingsContextBigPicture } from "./settings-context-big-picture";
@@ -61,9 +62,14 @@ export default function Settings() {
         icon: <PlayIcon size={16} />,
       },
       {
+        id: "cloud_storage" as const,
+        label: t("cloud_storage", "Облачное хранилище"),
+        icon: <CloudIcon size={16} />,
+      },
+      {
         id: "integrations" as const,
         label: t("integrations"),
-        icon: <CloudIcon size={16} />,
+        icon: <Plug size={16} />,
       },
       {
         id: "compatibility" as const,
@@ -122,6 +128,10 @@ export default function Settings() {
 
             if (selectedCategoryId === "content_gameplay") {
               return <SettingsContextContentGameplay />;
+            }
+
+            if (selectedCategoryId === "cloud_storage") {
+              return <SettingsContextCloudStorage />;
             }
 
             if (selectedCategoryId === "integrations") {

--- a/src/types/backup-metadata.types.ts
+++ b/src/types/backup-metadata.types.ts
@@ -1,0 +1,39 @@
+import type { GameShop } from "./game.types";
+
+export interface HydraBackupMetadata {
+  /** Schema version for forward-compatibility */
+  version: 1;
+  /** Game title as stored in Hydra */
+  gameName: string;
+  /** Steam AppID or custom objectId */
+  steamAppId: string;
+  /** Game shop type */
+  shop: GameShop;
+  /** ISO 8601 timestamp when backup was created */
+  backupDate: string;
+  /** Always "Hydra" — identifies the source launcher */
+  launcher: "Hydra";
+  /** OS platform at time of backup */
+  platform: NodeJS.Platform;
+  /** Machine hostname at time of backup */
+  hostname: string;
+  /** Absolute paths to save files as reported by Ludusavi */
+  originalSavePaths: string[];
+  /** Wine prefix path (Linux only) */
+  winePrefixPath?: string | null;
+  /** Detected Steam emulator type, if identifiable */
+  emulatorType?: string | null;
+  /** Game version string, if available */
+  gameVersion?: string | null;
+}
+
+export interface BackupRelocationResult {
+  /** Whether any files were relocated */
+  relocated: boolean;
+  /** Original save paths (from backup metadata) */
+  from: string[];
+  /** New save paths (current system) */
+  to: string[];
+  /** Number of files successfully relocated */
+  filesRelocated: number;
+}

--- a/src/types/cloud-storage.types.ts
+++ b/src/types/cloud-storage.types.ts
@@ -1,0 +1,32 @@
+import type { GameShop } from "./game.types";
+
+export interface CloudBackupMetadataSummary {
+  gameName: string;
+  steamAppId: string;
+  gameVersion: string | null;
+  platform: NodeJS.Platform | string;
+  backupDate: string;
+}
+
+export interface CloudBackupEntry {
+  /** Full remote path of the archive, e.g. disk:/HydraBackups/steam/220/backup_....tar.gz */
+  path: string;
+  /** File name of the archive */
+  name: string;
+  shop: GameShop;
+  objectId: string;
+  /** Resolved from the local library when available, falling back to metadata or objectId */
+  gameTitle: string;
+  created: string;
+  modified: string;
+  size: number;
+  /** Present only when a metadata sidecar file was uploaded alongside the archive */
+  metadata: CloudBackupMetadataSummary | null;
+}
+
+export interface CloudStorageUsage {
+  totalSpace: number;
+  usedSpace: number;
+  backupsSize: number;
+  backupsCount: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -596,3 +596,5 @@ export * from "./level.types";
 export * from "./theme.types";
 export * from "./emulator.types";
 export * from "./artwork.types";
+export * from "./backup-metadata.types";
+export * from "./cloud-storage.types";

--- a/src/types/level.types.ts
+++ b/src/types/level.types.ts
@@ -186,6 +186,10 @@ export interface UserPreferences {
   autoRunGamemode?: boolean;
   hideClassicsBookmark?: boolean;
   classicsUseHeroLayout?: boolean;
+  yandexDiskToken?: string | null;
+  yandexDiskBackupEnabled?: boolean;
+  yandexDiskRestoreOnStartup?: boolean;
+  yandexDiskMaxBackups?: number;
 }
 
 export interface NetworkInterface {


### PR DESCRIPTION
(Please add the `feature` label — I don't have permission to do so myself.)

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [[Hydra documentation](https://docs.hydralauncher.gg/getting-started.html)](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## What this adds

A new **Cloud Storage** settings section that lets users back up and restore their game saves (and achievements) to their own **Yandex Disk** account, using the existing Ludusavi-based save detection Hydra already has.

This is **not** an alternative to Hydra Cloud — it's aimed at players who don't have (or don't want) a Hydra Cloud subscription, and would otherwise have no cloud backup at all for their saves. Hydra Cloud remains the recommended, fully-integrated option; this is a free, opt-in fallback that only activates if the user explicitly connects their own Yandex Disk account. No Hydra account or subscription is required or touched by this feature.

## Why Yandex Disk specifically

Its REST API is simple (OAuth token generated once by the user, path-based file operations), so the integration is small and self-contained — no new npm dependencies were needed (`axios` and `tar` are already in `package.json`).

## What's in this PR

- **Settings → Cloud Storage** — new section with:
  - Connection status, account info, connect/reconnect/disconnect
  - Per-game backup settings (auto-backup on exit, restore on startup, max backups to keep)
  - A backup manager: search, sort, refresh, storage usage, and per-backup download/restore/delete
- **`YandexDiskBackup`** service — auth, upload/download, automatic backup on game exit, automatic restore on startup (only when no local save is found), achievement sync
- **`BackupMetadataService`** — writes a small metadata file into each backup so saves can be relocated correctly if the user switches repack/emulator between backup and restore
- **`CloudStorageService`** — thin facade used by the settings UI; aggregates backups across all games via Yandex's flat file-listing endpoint instead of walking each game folder individually
- Hooks into two existing files only where strictly necessary: `process-watcher.ts` (fire-and-forget backup call on game exit) and `main.ts` (best-effort restore check on startup) — both wrapped so a Yandex Disk failure never affects normal gameplay or startup
- One additive method on `Ludusavi` (`restoreGame`) — reuses the existing backup/preview binary invocation pattern already in that file

## Rebased on current `main`

This was originally written against `v4.0.6` and has since been rebased onto current `main`, including adapting to the new in-memory achievement store: `backupAchievements`/`restoreAchievements` now read/write through `AchievementMemoryStore` and `mergeAchievements` instead of the old `gameAchievementsSublevel` (LevelDB), which no longer exists. No other adaptation was needed — everything else applied cleanly.

## Explicitly out of scope for this PR

- No changes to the existing backup/restore *format* — Ludusavi's own behavior is untouched
- No changes to any other integration (Discord, Telegram, debrid services, etc.)
- No new dependencies, no changes to `yarn.lock`

## Testing done

- Manual testing of connect/disconnect, backup-on-exit, restore-on-startup, and all manager actions (download/restore/delete/search/sort)
- Manually verified achievement backup/restore against the current `AchievementMemoryStore`/`mergeAchievements` flow (see note above)
- `yarn run format`, `yarn run lint`, `yarn run typecheck` all pass locally
- Verified no new dependencies were introduced (`package.json`/`yarn.lock` diff is empty)

## Note on code review

Timeouts and pagination limits used to be inline magic numbers scattered across the service (10s/15s/120s, page size 200) — extracted these into named constants at the top of `yandex-disk-backup.ts` before opening this PR.