### PR TITLE
fix: game access to the Steam client on Linux

### DIFF
--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -13,6 +13,7 @@ import {
   Wine,
   NativeAddon,
   launchedGamePids,
+  resolveSteamClientCompatEnv,
 } from "@main/services";
 import { CommonRedistManager } from "@main/services/common-redist-manager";
 import { parseExecutablePath } from "../events/helpers/parse-executable-path";
@@ -259,6 +260,11 @@ const launchWindowsBinaryOnLinux = async (
 
   await cleanupStaleCompatibilityProcesses(objectId, winePrefixPath);
 
+  const extraEnv = await resolveSteamClientCompatEnv({
+    executablePath: parsedPath,
+    winePrefixPath,
+  });
+
   try {
     await Umu.launchExecutable(parsedPath, [], {
       winePrefixPath,
@@ -267,6 +273,7 @@ const launchWindowsBinaryOnLinux = async (
       launchOptions,
       useGamemode,
       useMangohud,
+      extraEnv,
     });
     PowerSaveBlockerManager.markCompatibilityLaunchStarted(gameKey);
     return true;

--- a/src/main/services/index.ts
+++ b/src/main/services/index.ts
@@ -1,6 +1,7 @@
 export * from "./logger";
 export * from "./steam";
 export * from "./steam-250";
+export * from "./steam-client-compat";
 export * from "./window-manager";
 export * from "./download";
 export * from "./download-layout-state";

--- a/src/main/services/steam-client-compat.ts
+++ b/src/main/services/steam-client-compat.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { logger } from "./logger";
+import { getSteamLocation } from "./steam";
+import { SystemPath } from "./system-path";
+
+const ONLINE_FIX_MARKER_FILES = [
+  "onlinefix64.dll",
+  "onlinefix.dll",
+  "onlinefix.ini",
+];
+
+const ONLINE_FIX_PROXY_DLLS = [
+  "winmm.dll",
+  "dinput8.dll",
+  "dsound.dll",
+  "version.dll",
+];
+
+const STEAM_CLIENT_FILES: [string, string][] = [
+  ["steamclient.dll", "steamclient.dll"],
+  ["steamclient64.dll", "steamclient64.dll"],
+  ["GameOverlayRenderer64.dll", "GameOverlayRenderer64.dll"],
+  ["SteamService.exe", "steam.exe"],
+  ["Steam.dll", "Steam.dll"],
+];
+
+const REQUIRED_STEAM_CLIENT_FILE = "steamclient64.dll";
+
+const LEGACY_COMPAT_DIRECTORY = "legacycompat";
+
+const PREFIX_STEAM_DIRECTORY = path.join(
+  "drive_c",
+  "Program Files (x86)",
+  "Steam"
+);
+
+export interface OnlineFixDetection {
+  detected: boolean;
+  dllOverrides: string;
+}
+
+export interface SteamClientCompatOptions {
+  executablePath: string;
+  winePrefixPath: string | null;
+}
+
+const readDirectoryEntries = (directoryPath: string) => {
+  try {
+    return fs.readdirSync(directoryPath).map((entry) => entry.toLowerCase());
+  } catch {
+    return [];
+  }
+};
+
+export const detectOnlineFix = (executablePath: string): OnlineFixDetection => {
+  const entries = new Set(readDirectoryEntries(path.dirname(executablePath)));
+
+  const detected = ONLINE_FIX_MARKER_FILES.some((markerFile) =>
+    entries.has(markerFile)
+  );
+
+  if (!detected) {
+    return { detected: false, dllOverrides: "" };
+  }
+
+  const dllOverrides = ONLINE_FIX_PROXY_DLLS.filter((proxyDll) =>
+    entries.has(proxyDll)
+  )
+    .map((proxyDll) => `${path.basename(proxyDll, ".dll")}=n,b`)
+    .join(";");
+
+  return { detected: true, dllOverrides };
+};
+
+export const isSteamClientRunning = () => {
+  const pidFilePath = path.join(
+    SystemPath.getPath("home"),
+    ".steam",
+    "steam.pid"
+  );
+
+  try {
+    const pid = Number.parseInt(
+      fs.readFileSync(pidFilePath, "utf-8").trim(),
+      10
+    );
+
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+
+    return fs.existsSync(path.join("/proc", String(pid)));
+  } catch {
+    return false;
+  }
+};
+
+const isCopyUpToDate = (sourceFilePath: string, targetFilePath: string) => {
+  try {
+    const source = fs.statSync(sourceFilePath);
+    const target = fs.statSync(targetFilePath);
+
+    return source.size === target.size && target.mtimeMs >= source.mtimeMs;
+  } catch {
+    return false;
+  }
+};
+
+const copySteamClientFiles = (
+  steamInstallPath: string,
+  winePrefixPath: string
+) => {
+  const legacyCompatPath = path.join(steamInstallPath, LEGACY_COMPAT_DIRECTORY);
+  const targetDirectory = path.join(winePrefixPath, PREFIX_STEAM_DIRECTORY);
+
+  fs.mkdirSync(targetDirectory, { recursive: true });
+
+  for (const [sourceName, targetName] of STEAM_CLIENT_FILES) {
+    const sourceFilePath = path.join(legacyCompatPath, sourceName);
+
+    if (!fs.existsSync(sourceFilePath)) continue;
+
+    const targetFilePath = path.join(targetDirectory, targetName);
+
+    if (isCopyUpToDate(sourceFilePath, targetFilePath)) continue;
+
+    fs.copyFileSync(sourceFilePath, targetFilePath);
+  }
+};
+
+export const resolveSteamClientCompatEnv = async ({
+  executablePath,
+  winePrefixPath,
+}: SteamClientCompatOptions): Promise<Record<string, string> | null> => {
+  if (process.platform !== "linux") return null;
+
+  const { detected, dllOverrides } = detectOnlineFix(executablePath);
+
+  if (!detected) return null;
+
+  if (!winePrefixPath) {
+    logger.warn(
+      "Online-Fix game detected but no wine prefix is configured, skipping Steam client setup",
+      { executablePath }
+    );
+    return null;
+  }
+
+  const steamInstallPath = await getSteamLocation().catch(() => null);
+
+  const requiredFilePath = steamInstallPath
+    ? path.join(
+        steamInstallPath,
+        LEGACY_COMPAT_DIRECTORY,
+        REQUIRED_STEAM_CLIENT_FILE
+      )
+    : null;
+
+  if (
+    !steamInstallPath ||
+    !requiredFilePath ||
+    !fs.existsSync(requiredFilePath)
+  ) {
+    logger.warn(
+      "Online-Fix game detected but the Steam client files were not found, skipping Steam client setup",
+      { executablePath, steamInstallPath }
+    );
+    return null;
+  }
+
+  try {
+    copySteamClientFiles(steamInstallPath, winePrefixPath);
+  } catch (error) {
+    logger.error("Failed to copy the Steam client files into the wine prefix", {
+      winePrefixPath,
+      error,
+    });
+    return null;
+  }
+
+  if (!isSteamClientRunning()) {
+    logger.warn(
+      "Online-Fix game detected but the Steam client is not running, the game will likely fail to initialize Steam",
+      { executablePath }
+    );
+  }
+
+  logger.info("Enabling Steam client compatibility for an Online-Fix game", {
+    executablePath,
+    steamInstallPath,
+    winePrefixPath,
+    dllOverrides,
+  });
+
+  return {
+    STEAM_COMPAT_CLIENT_INSTALL_PATH: steamInstallPath,
+    UMU_USE_STEAM: "1",
+    ...(dllOverrides ? { WINEDLLOVERRIDES: dllOverrides } : {}),
+  };
+};

--- a/src/main/services/umu.ts
+++ b/src/main/services/umu.ts
@@ -212,6 +212,7 @@ export class Umu {
       launchOptions?: string | null;
       useMangohud?: boolean;
       useGamemode?: boolean;
+      extraEnv?: Record<string, string> | null;
     }
   ): Promise<void> {
     const QUICK_EXIT_THRESHOLD_MS = 3000;
@@ -233,7 +234,16 @@ export class Umu {
     fs.mkdirSync(path.dirname(umuLogPath), { recursive: true });
     ensureExecutablePermission(umuBinaryPath);
 
-    const launchEnv = {
+    const extraEnv = options?.extraEnv ?? {};
+
+    const dllOverrides = [
+      extraEnv.WINEDLLOVERRIDES,
+      resolvedLaunchCommand.env.WINEDLLOVERRIDES,
+    ]
+      .filter(Boolean)
+      .join(";");
+
+    const launchEnv: Record<string, string> = {
       PROTON_LOG: "1",
       ...(options?.gameId ? { GAMEID: `umu-${options.gameId}` } : {}),
       ...(options?.winePrefixPath
@@ -241,7 +251,9 @@ export class Umu {
         : {}),
       ...(options?.protonPath ? { PROTONPATH: options.protonPath } : {}),
       ...(options?.useMangohud ? { MANGOHUD: "1" } : {}),
+      ...extraEnv,
       ...resolvedLaunchCommand.env,
+      ...(dllOverrides ? { WINEDLLOVERRIDES: dllOverrides } : {}),
     };
 
     const envCommandPart = Object.entries(launchEnv)


### PR DESCRIPTION
Closes LBX-706.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Games that ship the Online-Fix emulator don't start when launched from Hydra on Linux. They fail with `Could not Initialize Steam` or `Steam is not installed, please install it first`, sometimes with no output at all. The exact same executable works when it's added directly to Steam, and no combination of `WINEDLLOVERRIDES` in the launch options fixes it, which is what made this one confusing to debug.

### What's actually going on

Two separate things, both on the umu side.

The bundled umu-launcher declares `STEAM_COMPAT_CLIENT_INSTALL_PATH` in its env dict hardcoded to an empty string, never fills it in, and then does `os.environ[key] = val` over the whole dict before handing off to Proton. So the variable gets blanked no matter what we pass in.

Proton needs that path. It reads it in `setup_prefix()` and uses it to copy `steamclient.dll`, `steamclient64.dll`, `Steam.dll`, `GameOverlayRenderer64.dll` and `SteamService.exe` out of `<steam>/legacycompat` into `C:\Program Files (x86)\Steam` inside the prefix. With an empty path every copy silently no-ops, and the prefix is left with `SteamClientDll64` in the registry pointing at a `steamclient64.dll` that isn't there. Proton's own dist doesn't carry that file either, only `lsteamclient.dll`, so nothing fills the gap.

Second, GE-Proton and UMU-Proton both skip their `steam.exe` entry point whenever `UMU_ID` is set, which it always is for us since we set `GAMEID`. They go through `umu.exe` instead unless `UMU_USE_STEAM=1` is set:

```python
elif "UMU_ID" in os.environ or os.environ.get("SteamGameId", 0) in ["3347400"]:
    if os.environ.get("UMU_USE_STEAM", "0") == "1":
        append_to_env_str(self.env, "WINEDLLOVERRIDES", "lsteamclient=d", ";")
        argv = [g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"]
```

That's also why the DLL overrides from the issue never helped. The overrides were never the problem.

### The fix

New `steam-client-compat` service. When an Online-Fix marker (`OnlineFix64.dll`, `OnlineFix.dll` or `OnlineFix.ini`) sits next to the executable, it does the copy Proton would have done if the variable had survived, then sets `UMU_USE_STEAM=1` so Proton actually goes through `steam.exe`. `STEAM_COMPAT_CLIENT_INSTALL_PATH` is passed too, so this starts working on its own if umu ever stops blanking it.

It also adds `=n,b` overrides for the proxy loaders the repack actually ships (`winmm`, `dinput8`, `dsound`, `version`), only for the ones present in the game folder. `Umu.launchExecutable` gained an `extraEnv` option, and `WINEDLLOVERRIDES` is merged rather than overwritten so anything in a user's launch options still wins.

Copies are skipped when size and mtime already match, so we're not moving 21 MB on every launch. Non-Online-Fix games resolve to `null` and take the exact same path they do today.

### Verification

Ran the bundled `umu-run` with GE-Proton against a throwaway prefix, before and after:

| | `C:\Program Files (x86)\Steam` | `ActiveProcess\PID` |
| --- | --- | --- |
| before, with `STEAM_COMPAT_CLIENT_INSTALL_PATH` passed anyway | empty | absent |
| after | 5 files, survive relaunch | `0x20`, plus `steamapps/libraryfolders.vdf` |

The registry key showing up is the real steamclient coming up inside the prefix, which is the part that was failing.

### Worth knowing

- I don't have an Online-Fix title to test against, so this is verified at the Proton/umu layer rather than on a real game. The `Could not Initialize Steam` cause is demonstrably gone, but someone with one of the games from the issue should confirm before this ships.
- Online-Fix needs the native Steam client running, which is outside what we can do here. If it isn't running we log a warning and carry on.
- Flatpak Steam isn't covered. `getSteamLocation()` didn't handle it before either, and its `legacycompat` lives inside a sandbox Proton can't read anyway.
- No toggle for this. It's fully automatic based on the marker files, which keeps the change in the main process and avoids adding strings across the locales. Happy to add a per-game switch in the compatibility section if you'd rather have the escape hatch.
