### PR TITLE
feat: support archive.org direct downloads

### DIFF
--- a/src/big-picture/src/constants.ts
+++ b/src/big-picture/src/constants.ts
@@ -23,4 +23,5 @@ export const DOWNLOADER_NAME: Record<Downloader, string> = {
   [Downloader.Rootz]: "Rootz",
   [Downloader.Premiumize]: "Premiumize",
   [Downloader.AllDebrid]: "AllDebrid",
+  [Downloader.ArchiveOrg]: "Archive.org",
 };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -590,6 +590,7 @@
     "download_error_torrent_too_many_files": "This torrent has too many files to display safely.",
     "download_error_torrent_files_unavailable": "Could not fetch torrent files. Please try again.",
     "download_error_torrent_invalid_trackers": "The tracker list contains invalid trackers. Please check the list and try again.",
+    "download_error_archive_org_invalid_file_url": "This archive.org link does not point to a file. Add a direct file link instead.",
     "update_playtime_title": "Update playtime",
     "update_playtime_description": "Manually update the playtime for {{game}}",
     "update_playtime": "Update playtime",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -679,7 +679,8 @@
     "pkg_unreadable_toast": "No se pudo leer este PKG. Instálalo e inícialo directamente desde RPCS3.",
     "rpcs3_already_running_title": "RPCS3 ya se está ejecutando",
     "rpcs3_already_running_description": "RPCS3 solo permite una instancia. ¿Cerrar la sesión en ejecución para iniciar este juego?",
-    "rpcs3_already_running_confirm": "Cerrar e iniciar"
+    "rpcs3_already_running_confirm": "Cerrar e iniciar",
+    "download_error_archive_org_invalid_file_url": "Este enlace de archive.org no apunta a un archivo. Usá un enlace directo al archivo."
   },
   "activation": {
     "title": "Activar Hydra",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -657,6 +657,7 @@
     "download_error_torrent_too_many_files": "Este torrent tem arquivos demais para exibir com segurança.",
     "download_error_torrent_files_unavailable": "Não foi possível buscar os arquivos do torrent. Por favor, tente novamente.",
     "download_error_torrent_invalid_trackers": "A lista de trackers contém trackers inválidos. Verifique a lista e tente novamente.",
+    "download_error_archive_org_invalid_file_url": "Este link do archive.org não aponta para um arquivo. Use um link direto para o arquivo.",
     "transferring": "Transferindo...",
     "view_progress": "Ver progresso",
     "game_size": "Tamanho do jogo",

--- a/src/locales/pt-PT/translation.json
+++ b/src/locales/pt-PT/translation.json
@@ -547,7 +547,8 @@
     "launch_options_description_linux": "Add game launch arguments, or use <code>%command%</code> to wrap the launch command.",
     "create_steam_shortcut_modal_vr_flag": "VR Game (In Steam: update the VR flag or delete/recreate the shortcut)",
     "create_steam_shortcut_modal_create_button": "Create",
-    "create_steam_shortcut_modal_cancel_button": "Cancel"
+    "create_steam_shortcut_modal_cancel_button": "Cancel",
+    "download_error_archive_org_invalid_file_url": "Este link do archive.org não aponta para um ficheiro. Use um link direto para o ficheiro."
   },
   "activation": {
     "title": "Ativação",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -712,7 +712,8 @@
     "create_steam_shortcut_modal_cancel_button": "Отмена",
     "delete_shortcut_success": "Ярлык Steam успешно удалён",
     "delete_shortcut_error": "Не удалось удалить ярлык Steam",
-    "delete_steam_shortcut": "Удалить ярлык Steam"
+    "delete_steam_shortcut": "Удалить ярлык Steam",
+    "download_error_archive_org_invalid_file_url": "Эта ссылка archive.org не указывает на файл. Используйте прямую ссылку на файл."
   },
   "activation": {
     "title": "Активировать Hydra",

--- a/src/main/services/download/download-manager.ts
+++ b/src/main/services/download/download-manager.ts
@@ -1,4 +1,9 @@
-import { Downloader, DownloadError, FILE_EXTENSIONS_TO_EXTRACT } from "@shared";
+import {
+  Downloader,
+  DownloadError,
+  FILE_EXTENSIONS_TO_EXTRACT,
+  resolveArchiveOrgFile,
+} from "@shared";
 import { WindowManager } from "../window-manager";
 import { publishDownloadCompleteNotification } from "../notifications";
 import type { Download, DownloadProgress, Game, UserPreferences } from "@types";
@@ -153,6 +158,7 @@ export class DownloadManager {
   private static sanitizeRelativePath(pathValue: string): string {
     return pathValue
       .split(/[\\/]+/)
+      .filter((segment) => segment !== "." && segment !== "..")
       .map((segment) => this.sanitizeFilename(segment))
       .filter(Boolean)
       .join("/");
@@ -1115,6 +1121,8 @@ export class DownloadManager {
         return this.getVikingFileDownloadOptions(download, resumingFilename);
       case Downloader.Rootz:
         return this.getRootzDownloadOptions(download, resumingFilename);
+      case Downloader.ArchiveOrg:
+        return this.getArchiveOrgDownloadOptions(download, resumingFilename);
       default:
         return null;
     }
@@ -1435,6 +1443,20 @@ export class DownloadManager {
       downloadUrl,
       download.downloadPath,
       filename
+    );
+  }
+
+  private static async getArchiveOrgDownloadOptions(
+    download: Download,
+    resumingFilename?: string
+  ) {
+    const resolvedFile = resolveArchiveOrgFile(download.uri);
+    if (!resolvedFile) throw new Error(DownloadError.ArchiveOrgInvalidFileUrl);
+
+    return this.buildDownloadOptions(
+      resolvedFile.url,
+      download.downloadPath,
+      resumingFilename ?? this.sanitizeFilename(resolvedFile.filename)
     );
   }
 

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -14,6 +14,7 @@ export const DOWNLOADER_NAME = {
   [Downloader.Rootz]: "Rootz",
   [Downloader.Premiumize]: "Premiumize",
   [Downloader.AllDebrid]: "AllDebrid",
+  [Downloader.ArchiveOrg]: "Archive.org",
 };
 
 export const MAX_MINUTES_TO_SHOW_IN_PLAYTIME = 120;

--- a/src/shared/archive-org.ts
+++ b/src/shared/archive-org.ts
@@ -1,0 +1,92 @@
+export interface ArchiveOrgFileUri {
+  identifier: string;
+  path: string;
+}
+
+const ARCHIVE_ORG_BASE_URL = "https://archive.org";
+const CANONICAL_HOSTS = new Set(["archive.org", "www.archive.org"]);
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{1,99}$/;
+const FILE_EXTENSION_PATTERN = /\.[A-Za-z0-9]{1,10}$/;
+
+const decodeSegment = (segment: string) => {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+};
+
+const buildFilePath = (segments: string[]) => {
+  const filePath = segments
+    .map(decodeSegment)
+    .filter((segment) => segment !== "." && segment !== "..")
+    .join("/");
+
+  return FILE_EXTENSION_PATTERN.test(filePath) ? filePath : null;
+};
+
+const parseFileUri = (
+  segments: string[],
+  identifierIndex: number,
+  pathname: string
+): ArchiveOrgFileUri | null => {
+  if (pathname.endsWith("/")) return null;
+
+  const identifier = segments[identifierIndex];
+  if (!identifier || !IDENTIFIER_PATTERN.test(identifier)) return null;
+
+  const path = buildFilePath(segments.slice(identifierIndex + 1));
+  if (!path) return null;
+
+  return { identifier, path };
+};
+
+export const parseArchiveOrgFileUri = (
+  uri: string
+): ArchiveOrgFileUri | null => {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(uri.trim());
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    return null;
+  }
+
+  const host = parsedUrl.hostname.toLowerCase();
+  const segments = parsedUrl.pathname.split("/").filter(Boolean);
+
+  if (CANONICAL_HOSTS.has(host)) {
+    if (segments[0] !== "download") return null;
+    return parseFileUri(segments, 1, parsedUrl.pathname);
+  }
+
+  if (!host.endsWith(".archive.org")) return null;
+
+  const itemsIndex = segments.indexOf("items");
+  if (itemsIndex === -1) return null;
+
+  return parseFileUri(segments, itemsIndex + 1, parsedUrl.pathname);
+};
+
+export const isArchiveOrgFileUri = (uri: string) =>
+  parseArchiveOrgFileUri(uri) !== null;
+
+export const resolveArchiveOrgFile = (uri: string) => {
+  const parsedUri = parseArchiveOrgFileUri(uri);
+  if (!parsedUri) return null;
+
+  const { identifier, path } = parsedUri;
+  const encodedPath = path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return {
+    url: `${ARCHIVE_ORG_BASE_URL}/download/${encodeURIComponent(identifier)}/${encodedPath}`,
+    filename: path.split("/").at(-1) ?? path,
+  };
+};

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -12,6 +12,7 @@ export enum Downloader {
   Rootz = 11,
   Premiumize = 12,
   AllDebrid = 13,
+  ArchiveOrg = 14,
 }
 
 export enum DownloadSourceStatus {
@@ -83,6 +84,7 @@ export enum DownloadError {
   TorrentTooManyFiles = "download_error_torrent_too_many_files",
   TorrentFilesUnavailable = "download_error_torrent_files_unavailable",
   TorrentInvalidTrackers = "download_error_torrent_invalid_trackers",
+  ArchiveOrgInvalidFileUrl = "download_error_archive_org_invalid_file_url",
 }
 
 export const FILE_EXTENSIONS_TO_EXTRACT = [".rar", ".zip", ".7z"];

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -13,11 +13,13 @@ import {
   da,
 } from "date-fns/locale";
 
+import { isArchiveOrgFileUri } from "./archive-org";
 import { charMap } from "./char-map";
 import { Downloader } from "./constants";
 import { format } from "date-fns";
 import { AchievementNotificationInfo } from "@types";
 
+export * from "./archive-org";
 export * from "./constants";
 export * from "./controller-support";
 export * from "./artwork-resolver";
@@ -149,6 +151,9 @@ export const getDownloadersForUri = (uri: string) => {
   }
   if (uri.startsWith("https://www.rootz.so")) {
     return [Downloader.Rootz];
+  }
+  if (isArchiveOrgFileUri(uri)) {
+    return [Downloader.ArchiveOrg];
   }
 
   if (realDebridHosts.some((host) => uri.startsWith(host)))


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Adds `archive.org` as a downloader, so download sources can point at Internet Archive file links. Closes LBX-991.

```
https://archive.org/download/megabonk.zip
```

A link like this behaves exactly like any other direct download link. The URL is resolved locally into a canonical archive.org URL and handed to the HTTP downloader, which already follows the redirect to the node server and resumes through range requests, so there is no metadata lookup and no extra request. The file is saved in the download folder under its own name and extracted like any other archive. Node server links (`ia800101.us.archive.org/25/items/<item>/<file>`) are normalized to the same canonical form, and nested paths keep only the file name.

Links that do not point at a file (`/download/<item>`, `/download/<item>/subfolder/`, `/details/<item>`) are deliberately not accepted, so `getDownloadersForUri` does not offer archive.org for them and the option stays unavailable instead of failing at start. No API key or account is involved.

The whole resolver lives in `src/shared/archive-org.ts`, so the renderer and the main process apply the same rule.

`sanitizeRelativePath` now drops `.` and `..` segments as well. Unrelated to archive.org strictly speaking, but it is the function that turns a remote listing into an on-disk path, and it should not be able to write outside the download folder.

### Tested

Against live archive.org files:

- `Megabonk.zip` (217,483,656 bytes) and `Alleyway (USA).gb` (32,768 bytes) resolve and download with the expected byte counts, valid content, and a `206` on resume.
- Nested and node-host links resolve to the right canonical URL and file name.
- Item, folder, details, metadata, traversal (`/download/../etc/passwd`) and non-archive links are all rejected by the resolver.
- `yarn typecheck` (node + web), lint and the existing test suite pass.