### PR TITLE
fix: open download sources tab from install-source deep link

### DIFF
--- a/src/renderer/src/context/settings/settings.context.tsx
+++ b/src/renderer/src/context/settings/settings.context.tsx
@@ -109,7 +109,7 @@ export function SettingsContextProvider({
   const defaultAppearanceAuthorName = searchParams.get("authorName");
 
   useEffect(() => {
-    if (sourceUrl) setCurrentCategoryId("downloads");
+    if (sourceUrl) setCurrentCategoryId("download_sources");
   }, [sourceUrl]);
 
   useEffect(() => {


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

The `hydralauncher://install-source?urls=...` deep link stopped working when download sources were moved out of the downloads tab into their own `download_sources` category.

`settings.context.tsx` was still switching to `downloads` when a source URL came in from the deep link. Since `SettingsContextDownloadSources` is only mounted for the `download_sources` category, the effect that opens `AddDownloadSourceModal` never ran, so the link just dropped you on the downloads tab with nothing happening.

Now points at `download_sources`, so the modal opens prefilled with the URL again.

**How to test**

With the app running, open `hydralauncher://install-source?urls=https%3A%2F%2Fexample.com%2Fsource.json`. Settings should open on Download Sources with the add source modal already up and the URL filled in.
