### PR TITLE
feat(cloud-save): add native save discovery

### DIFF
--- a/native/hydra-native/Cargo.lock
+++ b/native/hydra-native/Cargo.lock
@@ -9,10 +9,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -21,10 +48,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -45,16 +134,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -66,12 +215,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -91,6 +294,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dtor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +330,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -119,6 +374,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -131,10 +392,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -192,7 +474,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -225,16 +507,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -248,6 +556,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "globetter"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b656e6c51ccf5966543712f56bf6235494a7cf341206b3ccb336d1586f0e01fd"
+
+[[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -269,17 +615,213 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hydra-native"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "blake3",
+ "globetter",
+ "globset",
  "image",
+ "indexmap",
+ "known-folders",
  "mime_guess",
  "napi",
  "napi-build",
  "napi-derive",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "sha2",
  "sysinfo",
+ "tempfile",
  "tokio",
+ "unicode-normalization",
  "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -287,6 +829,27 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -318,21 +881,86 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -342,6 +970,15 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "known-folders"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d9a1740cc8b46e259a0eb787d79d855e79ff10b9855a5eba58868d5da7927c"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -367,10 +1004,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -402,6 +1057,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -447,7 +1113,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -460,7 +1126,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -522,10 +1188,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -541,13 +1225,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -572,6 +1265,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,16 +1337,258 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -611,6 +1603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -630,14 +1623,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -647,16 +1640,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -667,6 +1734,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -684,13 +1782,209 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
+name = "system-configuration"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-core",
 ]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -705,6 +1999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,15 +2020,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -759,6 +2123,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,7 +2155,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -813,6 +2191,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +2213,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -845,6 +2265,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -883,8 +2312,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -906,7 +2335,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -917,7 +2346,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -943,12 +2372,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -961,6 +2410,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
 name = "windows-threading"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +2469,54 @@ checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -999,7 +2548,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1015,7 +2564,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1055,6 +2604,95 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/native/hydra-native/Cargo.toml
+++ b/native/hydra-native/Cargo.toml
@@ -7,13 +7,31 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = "1.0"
+blake3 = "=1.8.5"
+globetter = "=0.2.0"
+globset = "=0.4.15"
 image = { version = "0.25.8", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
+indexmap = { version = "2.14", features = ["serde"] }
 mime_guess = "2.0.5"
 napi = { version = "3.5.2", default-features = false, features = ["napi8", "tokio_rt"] }
 napi-derive = "3.3.2"
+reqwest = { version = "0.13", features = ["stream"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+serde_yaml_ng = "0.10"
+sha2 = "0.10"
 sysinfo = "0.37.2"
-tokio = { version = "1.50.0", features = ["rt"] }
+tokio = { version = "1.52", features = ["fs", "rt", "sync", "macros"] }
+unicode-normalization = "0.1.25"
 uuid = { version = "1.11.0", features = ["v4"] }
+walkdir = "=2.5.0"
+
+[target.'cfg(windows)'.dependencies]
+known-folders = "=1.2.0"
+
+[dev-dependencies]
+tempfile = "3.27"
 
 [build-dependencies]
 napi-build = "2.3.1"

--- a/native/hydra-native/src/cloud_save/identity/mod.rs
+++ b/native/hydra-native/src/cloud_save/identity/mod.rs
@@ -1,0 +1,155 @@
+use napi_derive::napi;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use unicode_normalization::UnicodeNormalization;
+
+use crate::cloud_save::manifest::types::{CloudSaveRule, CloudSaveRuleCondition};
+
+pub const RULE_ID_VERSION: u32 = 1;
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct UserLocationCoverage {
+    pub candidate_id: String,
+    pub rule_id: String,
+    pub variant_id: Option<String>,
+    pub raw_path: Option<String>,
+    pub relative_path: Option<String>,
+    pub selected_root: bool,
+    pub authority: String,
+    pub outcome: String,
+    pub enumerated_completely: bool,
+    pub warning_codes: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalRuleCondition<'a> {
+    os: Option<&'a str>,
+    store: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalRule<'a> {
+    rule_id_version: u32,
+    source_namespace: &'a str,
+    raw_rule: &'a str,
+    target_semantics: &'a str,
+    constraints: Vec<CanonicalRuleCondition<'a>>,
+}
+
+fn hash_json<T: Serialize>(value: &T) -> String {
+    let serialized = serde_json::to_vec(value).expect("canonical cloud save identity serializes");
+    format!("{:x}", Sha256::digest(serialized))
+}
+
+pub fn normalize_text(value: &str) -> String {
+    value.nfc().collect::<String>()
+}
+
+pub fn normalize_rule_path(value: &str) -> String {
+    normalize_text(&value.replace('\\', "/"))
+}
+
+pub fn target_semantics(rule: &CloudSaveRule) -> &'static str {
+    if rule.kind == "dir" {
+        "directory-tree"
+    } else if rule
+        .raw_path
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '[' | '{'))
+    {
+        "glob-set"
+    } else {
+        "single-file"
+    }
+}
+
+pub fn build_rule_id(rule: &CloudSaveRule) -> String {
+    let raw_rule = normalize_rule_path(&rule.raw_path);
+    let semantics = target_semantics(rule);
+    let mut constraints = rule.when.iter().collect::<Vec<_>>();
+    constraints.sort_by(|left, right| {
+        left.os
+            .cmp(&right.os)
+            .then_with(|| left.store.cmp(&right.store))
+    });
+    constraints.dedup_by(|left, right| left.os == right.os && left.store == right.store);
+    hash_json(&CanonicalRule {
+        rule_id_version: RULE_ID_VERSION,
+        source_namespace: &rule.source,
+        raw_rule: &raw_rule,
+        target_semantics: semantics,
+        constraints: constraints
+            .into_iter()
+            .map(
+                |condition: &CloudSaveRuleCondition| CanonicalRuleCondition {
+                    os: condition.os.as_deref(),
+                    store: condition.store.as_deref(),
+                },
+            )
+            .collect(),
+    })
+}
+
+pub fn local_id(parts: &[&str]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for part in parts {
+        hasher.update(&(part.len() as u64).to_le_bytes());
+        hasher.update(part.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+pub fn is_safe_capture(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 255
+        && !value.contains(['/', '\\', '\0'])
+        && value != "."
+        && value != ".."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(raw_path: &str) -> CloudSaveRule {
+        let mut rule = CloudSaveRule {
+            rule_id: String::new(),
+            kind: "dir".into(),
+            raw_path: raw_path.into(),
+            source: "ludusavi".into(),
+            tags: vec!["save".into()],
+            when: vec![],
+            preferred_path: None,
+        };
+        rule.rule_id = build_rule_id(&rule);
+        rule
+    }
+
+    #[test]
+    fn stable_rule_id_ignores_tags_and_changes_with_semantics() {
+        let first = rule("<winAppData>/Game/<storeUserId>");
+        let mut reordered_metadata = first.clone();
+        reordered_metadata.tags = vec!["config".into()];
+        assert_eq!(build_rule_id(&first), build_rule_id(&reordered_metadata));
+
+        reordered_metadata.raw_path.push_str("/saves");
+        assert_ne!(build_rule_id(&first), build_rule_id(&reordered_metadata));
+    }
+
+    #[test]
+    fn local_ids_are_length_delimited() {
+        assert_ne!(local_id(&["ab", "c"]), local_id(&["a", "bc"]));
+        assert_eq!(local_id(&["same"]), local_id(&["same"]));
+    }
+
+    #[test]
+    fn capture_validation_rejects_path_segments() {
+        assert!(is_safe_capture("76561198012345678"));
+        for value in ["", ".", "..", "a/b", "a\\b", "a\0b"] {
+            assert!(!is_safe_capture(value));
+        }
+    }
+}

--- a/native/hydra-native/src/cloud_save/manifest/cache.rs
+++ b/native/hydra-native/src/cloud_save/manifest/cache.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use tokio::fs;
+use tokio::sync::Mutex;
+
+use super::indexer::build_manifest_index;
+use super::types::ManifestIndex;
+use crate::constants::MANIFEST_INDEX_VERSION;
+
+const MANIFEST_CACHE_TTL_MS: i64 = 24 * 60 * 60 * 1000;
+const MANIFEST_HTTP_TIMEOUT_SECS: u64 = 30;
+const RAW_MANIFEST_FILE_NAME: &str = "cloud-save-manifest.yaml";
+const INDEX_FILE_NAME: &str = "cloud-save-manifest-index.json";
+
+type ManifestCache = Arc<Mutex<Option<ManifestIndex>>>;
+type ManifestCaches = Mutex<HashMap<PathBuf, ManifestCache>>;
+
+static CACHE_LOCKS: OnceLock<ManifestCaches> = OnceLock::new();
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+fn http_client() -> &'static reqwest::Client {
+    HTTP_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(MANIFEST_HTTP_TIMEOUT_SECS))
+            .build()
+            .expect("Failed to build cloud save manifest HTTP client")
+    })
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn is_index_expired(index: &ManifestIndex, current_time: i64) -> bool {
+    index.fetched_at + MANIFEST_CACHE_TTL_MS <= current_time
+}
+
+async fn cache_for(key: PathBuf) -> ManifestCache {
+    let caches = CACHE_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut caches = caches.lock().await;
+    caches
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(None)))
+        .clone()
+}
+
+fn raw_manifest_path(user_data_path: &Path) -> PathBuf {
+    user_data_path.join(RAW_MANIFEST_FILE_NAME)
+}
+
+fn index_path(user_data_path: &Path) -> PathBuf {
+    user_data_path.join(INDEX_FILE_NAME)
+}
+
+async fn read_index(path: &Path) -> Option<ManifestIndex> {
+    let content = fs::read_to_string(path).await.ok()?;
+    let index: ManifestIndex = serde_json::from_str(&content).ok()?;
+    (index.version == MANIFEST_INDEX_VERSION).then_some(index)
+}
+
+async fn raw_manifest_fetched_at(path: &Path) -> Option<i64> {
+    let modified = fs::metadata(path).await.ok()?.modified().ok()?;
+    Some(
+        modified
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64,
+    )
+}
+
+async fn remove_cache_file(path: &Path) -> Result<()> {
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("Failed to remove stale cache file {}", path.display())),
+    }
+}
+
+async fn write_atomically(path: &Path, content: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .with_context(|| format!("Invalid manifest cache path: {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .await
+        .with_context(|| format!("Failed to create cache directory {}", parent.display()))?;
+    let temp_path = path.with_extension(format!("{}.{}.tmp", std::process::id(), now_ms()));
+    if let Err(error) = fs::write(&temp_path, content).await {
+        return Err(error).with_context(|| {
+            format!(
+                "Failed to write temporary cache file {}",
+                temp_path.display()
+            )
+        });
+    }
+    if let Err(error) = fs::rename(&temp_path, path).await {
+        let _ = fs::remove_file(&temp_path).await;
+        return Err(error).with_context(|| {
+            format!(
+                "Failed to replace cache file {} with {}",
+                path.display(),
+                temp_path.display()
+            )
+        });
+    }
+    Ok(())
+}
+
+async fn write_index(path: &Path, index: &ManifestIndex) -> Result<()> {
+    let content = serde_json::to_vec_pretty(index)
+        .with_context(|| format!("Failed to serialize manifest index for {}", path.display()))?;
+    write_atomically(path, &content).await
+}
+
+async fn download_manifest(source_url: &str) -> Result<String> {
+    let response = http_client()
+        .get(source_url)
+        .send()
+        .await
+        .with_context(|| format!("Failed to download cloud save manifest from {source_url}"))?
+        .error_for_status()
+        .with_context(|| format!("Cloud save manifest request failed for {source_url}"))?;
+
+    response
+        .text()
+        .await
+        .with_context(|| format!("Failed to read cloud save manifest body from {source_url}"))
+}
+
+async fn load_index(user_data_path: &Path, source_url: &str) -> Result<ManifestIndex> {
+    let current_time = now_ms();
+    let index_file = index_path(user_data_path);
+    let raw_file = raw_manifest_path(user_data_path);
+    let disk_index = read_index(&index_file).await;
+    let has_matching_disk_index = disk_index
+        .as_ref()
+        .is_some_and(|index| index.source_url == source_url);
+    let disk_index = disk_index.filter(|index| index.source_url == source_url);
+    let mut fallback = disk_index.clone();
+
+    if let Some(index) = &disk_index {
+        if !is_index_expired(index, current_time) {
+            return Ok(index.clone());
+        }
+    }
+
+    let raw_yaml = if disk_index.is_some() {
+        fs::read_to_string(&raw_file).await.ok()
+    } else {
+        None
+    };
+
+    if let Some(raw_yaml) = raw_yaml {
+        let fetched_at = raw_manifest_fetched_at(&raw_file)
+            .await
+            .unwrap_or(current_time);
+        if let Ok(rebuilt) = build_manifest_index(&raw_yaml, source_url, fetched_at) {
+            // A valid rebuilt index remains usable in memory if refreshing disk fails.
+            let _ = write_index(&index_file, &rebuilt).await;
+            if !is_index_expired(&rebuilt, current_time) {
+                return Ok(rebuilt);
+            }
+            fallback = Some(rebuilt);
+        }
+    }
+
+    let fresh_result = async {
+        let raw_yaml = download_manifest(source_url).await?;
+        let fresh = build_manifest_index(&raw_yaml, source_url, now_ms())?;
+        if !has_matching_disk_index {
+            remove_cache_file(&raw_file).await?;
+            remove_cache_file(&index_file).await?;
+        }
+        write_atomically(&raw_file, raw_yaml.as_bytes()).await?;
+        write_index(&index_file, &fresh).await?;
+        Ok::<ManifestIndex, anyhow::Error>(fresh)
+    }
+    .await;
+
+    fresh_result.or_else(|error| fallback.ok_or(error))
+}
+
+pub async fn get_manifest_index(user_data_path: &Path, source_url: &str) -> Result<ManifestIndex> {
+    let cache = cache_for(user_data_path.to_path_buf()).await;
+    let mut cached = cache.lock().await;
+
+    if let Some(index) = cached.as_ref() {
+        if index.source_url == source_url && !is_index_expired(index, now_ms()) {
+            return Ok(index.clone());
+        }
+    }
+
+    let fallback = cached
+        .as_ref()
+        .filter(|index| index.source_url == source_url)
+        .cloned();
+    let index = load_index(user_data_path, source_url)
+        .await
+        .or_else(|error| fallback.ok_or(error))?;
+    *cached = Some(index.clone());
+    Ok(index)
+}

--- a/native/hydra-native/src/cloud_save/manifest/cache.rs
+++ b/native/hydra-native/src/cloud_save/manifest/cache.rs
@@ -8,6 +8,7 @@ use tokio::fs;
 use tokio::sync::Mutex;
 
 use super::indexer::build_manifest_index;
+use super::lookup::ManifestLookupIndex;
 use super::types::ManifestIndex;
 use crate::constants::MANIFEST_INDEX_VERSION;
 
@@ -16,7 +17,7 @@ const MANIFEST_HTTP_TIMEOUT_SECS: u64 = 30;
 const RAW_MANIFEST_FILE_NAME: &str = "cloud-save-manifest.yaml";
 const INDEX_FILE_NAME: &str = "cloud-save-manifest-index.json";
 
-type ManifestCache = Arc<Mutex<Option<ManifestIndex>>>;
+type ManifestCache = Arc<Mutex<Option<Arc<ManifestLookupIndex>>>>;
 type ManifestCaches = Mutex<HashMap<PathBuf, ManifestCache>>;
 
 static CACHE_LOCKS: OnceLock<ManifestCaches> = OnceLock::new();
@@ -187,23 +188,28 @@ async fn load_index(user_data_path: &Path, source_url: &str) -> Result<ManifestI
     fresh_result.or_else(|error| fallback.ok_or(error))
 }
 
-pub async fn get_manifest_index(user_data_path: &Path, source_url: &str) -> Result<ManifestIndex> {
+pub async fn get_manifest_index(
+    user_data_path: &Path,
+    source_url: &str,
+) -> Result<Arc<ManifestLookupIndex>> {
     let cache = cache_for(user_data_path.to_path_buf()).await;
     let mut cached = cache.lock().await;
 
     if let Some(index) = cached.as_ref() {
-        if index.source_url == source_url && !is_index_expired(index, now_ms()) {
-            return Ok(index.clone());
+        if index.manifest.source_url == source_url && !is_index_expired(&index.manifest, now_ms()) {
+            return Ok(Arc::clone(index));
         }
     }
 
     let fallback = cached
         .as_ref()
-        .filter(|index| index.source_url == source_url)
-        .cloned();
+        .filter(|index| index.manifest.source_url == source_url)
+        .map(Arc::clone);
     let index = load_index(user_data_path, source_url)
         .await
+        .map(ManifestLookupIndex::new)
+        .map(Arc::new)
         .or_else(|error| fallback.ok_or(error))?;
-    *cached = Some(index.clone());
+    *cached = Some(Arc::clone(&index));
     Ok(index)
 }

--- a/native/hydra-native/src/cloud_save/manifest/indexer.rs
+++ b/native/hydra-native/src/cloud_save/manifest/indexer.rs
@@ -1,0 +1,135 @@
+use anyhow::{bail, Context, Result};
+use indexmap::IndexMap;
+use serde_yaml_ng::{Mapping, Value};
+
+use super::types::{ManifestFileRule, ManifestGameEntry, ManifestIndex, ManifestRuleCondition};
+use crate::constants::MANIFEST_INDEX_VERSION;
+
+fn string_value(value: &Value) -> Option<String> {
+    value.as_str().map(ToString::to_string)
+}
+
+fn mapping_value<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Value> {
+    mapping.get(Value::String(key.to_string()))
+}
+
+fn read_tags(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_sequence)
+        .map(|items| items.iter().filter_map(string_value).collect())
+        .unwrap_or_default()
+}
+
+fn read_conditions(value: Option<&Value>) -> Vec<ManifestRuleCondition> {
+    value
+        .and_then(Value::as_sequence)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let mapping = item.as_mapping()?;
+                    let os = mapping_value(mapping, "os").and_then(string_value);
+                    let store = mapping_value(mapping, "store").and_then(string_value);
+                    (os.is_some() || store.is_some()).then_some(ManifestRuleCondition { os, store })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn map_game_entry(manifest_key: &str, value: &Value) -> Option<ManifestGameEntry> {
+    let game = value.as_mapping()?;
+    let files = mapping_value(game, "files")?.as_mapping()?;
+    let files = files
+        .iter()
+        .filter_map(|(raw_path, metadata)| {
+            let raw_path = string_value(raw_path)?;
+            let metadata = metadata.as_mapping();
+            Some(ManifestFileRule {
+                raw_path,
+                tags: metadata
+                    .map(|m| read_tags(mapping_value(m, "tags")))
+                    .unwrap_or_default(),
+                when: metadata
+                    .map(|m| read_conditions(mapping_value(m, "when")))
+                    .unwrap_or_default(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    (!files.is_empty()).then_some(ManifestGameEntry {
+        manifest_key: manifest_key.to_string(),
+        files,
+    })
+}
+
+pub fn build_manifest_index(
+    raw_yaml: &str,
+    source_url: &str,
+    fetched_at: i64,
+) -> Result<ManifestIndex> {
+    let root: Value = serde_yaml_ng::from_str(raw_yaml)
+        .with_context(|| format!("Failed to parse cloud save manifest from {source_url}"))?;
+    let Some(root) = root.as_mapping() else {
+        bail!("Cloud save manifest root from {source_url} must be a YAML map");
+    };
+    let mut games = IndexMap::new();
+
+    for (key, value) in root {
+        let Some(manifest_key) = string_value(key) else {
+            continue;
+        };
+        if let Some(entry) = map_game_entry(&manifest_key, value) {
+            games.insert(manifest_key, entry);
+        }
+    }
+
+    Ok(ManifestIndex {
+        version: MANIFEST_INDEX_VERSION,
+        fetched_at,
+        source_url: source_url.to_string(),
+        games,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_save::manifest::source::resolve_source_url;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[tokio::test]
+    async fn builds_index_from_real_manifest() {
+        let source_url = resolve_source_url(None);
+
+        let raw_yaml = reqwest::get(&source_url)
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        let fetched_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let index = build_manifest_index(&raw_yaml, &source_url, fetched_at).unwrap();
+
+        let example = index
+            .games
+            .values()
+            .flat_map(|game| game.files.iter().map(move |file| (game, file)))
+            .find(|(_, file)| !file.tags.is_empty() || !file.when.is_empty())
+            .expect("no file with tags or conditions found");
+
+        println!("{}", serde_json::to_string_pretty(&example).unwrap());
+
+        assert_eq!(index.version, 1);
+        assert_eq!(index.source_url, source_url);
+        assert_eq!(index.fetched_at, fetched_at);
+        assert!(!index.games.is_empty());
+    }
+}

--- a/native/hydra-native/src/cloud_save/manifest/lookup.rs
+++ b/native/hydra-native/src/cloud_save/manifest/lookup.rs
@@ -1,0 +1,67 @@
+use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
+
+use super::types::{ManifestGameEntry, ManifestIndex};
+
+fn normalize_manifest_key(value: &str) -> String {
+    value
+        .nfkd()
+        .filter(|character| !is_combining_mark(*character) && character.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+pub fn find_manifest_entry<'a>(
+    index: &'a ManifestIndex,
+    object_id: &str,
+    remote_id: Option<&str>,
+    title: Option<&str>,
+) -> Option<&'a ManifestGameEntry> {
+    let candidates = [Some(object_id), remote_id, title]
+        .into_iter()
+        .flatten()
+        .filter(|candidate| !candidate.is_empty())
+        .collect::<Vec<_>>();
+
+    for candidate in &candidates {
+        if let Some(entry) = index.games.get(*candidate) {
+            return Some(entry);
+        }
+    }
+
+    for candidate in candidates {
+        let normalized_candidate = normalize_manifest_key(candidate);
+        if let Some(entry) = index.games.iter().find_map(|(key, entry)| {
+            (normalize_manifest_key(key) == normalized_candidate).then_some(entry)
+        }) {
+            return Some(entry);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_save::manifest::cache::get_manifest_index;
+    use crate::cloud_save::manifest::source::resolve_source_url;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn finds_balatro_from_real_manifest() {
+        let source_url = resolve_source_url(None);
+        let cache_directory = tempdir().unwrap();
+
+        let index = get_manifest_index(cache_directory.path(), &source_url)
+            .await
+            .unwrap();
+
+        let result = find_manifest_entry(&index, "2379780", None, Some("Balatro"))
+            .expect("Balatro should be found in the real manifest");
+
+        println!("{}", serde_json::to_string_pretty(result).unwrap());
+
+        assert_eq!(result.manifest_key, "2379780");
+        assert!(!result.files.is_empty());
+    }
+}

--- a/native/hydra-native/src/cloud_save/manifest/lookup.rs
+++ b/native/hydra-native/src/cloud_save/manifest/lookup.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 
 use super::types::{ManifestGameEntry, ManifestIndex};
@@ -10,8 +12,29 @@ fn normalize_manifest_key(value: &str) -> String {
         .collect()
 }
 
+pub struct ManifestLookupIndex {
+    pub manifest: ManifestIndex,
+    normalized_games: HashMap<String, String>,
+}
+
+impl ManifestLookupIndex {
+    pub fn new(manifest: ManifestIndex) -> Self {
+        let mut normalized_games = HashMap::new();
+        for key in manifest.games.keys() {
+            normalized_games
+                .entry(normalize_manifest_key(key))
+                .or_insert_with(|| key.clone());
+        }
+
+        Self {
+            manifest,
+            normalized_games,
+        }
+    }
+}
+
 pub fn find_manifest_entry<'a>(
-    index: &'a ManifestIndex,
+    index: &'a ManifestLookupIndex,
     object_id: &str,
     remote_id: Option<&str>,
     title: Option<&str>,
@@ -23,16 +46,18 @@ pub fn find_manifest_entry<'a>(
         .collect::<Vec<_>>();
 
     for candidate in &candidates {
-        if let Some(entry) = index.games.get(*candidate) {
+        if let Some(entry) = index.manifest.games.get(*candidate) {
             return Some(entry);
         }
     }
 
     for candidate in candidates {
         let normalized_candidate = normalize_manifest_key(candidate);
-        if let Some(entry) = index.games.iter().find_map(|(key, entry)| {
-            (normalize_manifest_key(key) == normalized_candidate).then_some(entry)
-        }) {
+        if let Some(entry) = index
+            .normalized_games
+            .get(&normalized_candidate)
+            .and_then(|key| index.manifest.games.get(key))
+        {
             return Some(entry);
         }
     }
@@ -45,7 +70,39 @@ mod tests {
     use super::*;
     use crate::cloud_save::manifest::cache::get_manifest_index;
     use crate::cloud_save::manifest::source::resolve_source_url;
+    use crate::cloud_save::manifest::types::ManifestGameEntry;
+    use indexmap::IndexMap;
     use tempfile::tempdir;
+
+    #[test]
+    fn normalized_lookup_preserves_exact_matches_and_manifest_order() {
+        let entry = |manifest_key: &str| ManifestGameEntry {
+            manifest_key: manifest_key.to_string(),
+            files: vec![],
+        };
+        let mut games = IndexMap::new();
+        games.insert("Pokémon".to_string(), entry("Pokémon"));
+        games.insert("Pokemon".to_string(), entry("Pokemon"));
+        let index = ManifestLookupIndex::new(ManifestIndex {
+            version: 1,
+            fetched_at: 0,
+            source_url: "test".to_string(),
+            games,
+        });
+
+        assert_eq!(
+            find_manifest_entry(&index, "missing", None, Some("Pokemon"))
+                .unwrap()
+                .manifest_key,
+            "Pokemon"
+        );
+        assert_eq!(
+            find_manifest_entry(&index, "missing", None, Some("POKEMON"))
+                .unwrap()
+                .manifest_key,
+            "Pokémon"
+        );
+    }
 
     #[tokio::test]
     async fn finds_balatro_from_real_manifest() {

--- a/native/hydra-native/src/cloud_save/manifest/mod.rs
+++ b/native/hydra-native/src/cloud_save/manifest/mod.rs
@@ -1,0 +1,35 @@
+mod cache;
+mod indexer;
+mod lookup;
+mod rules;
+mod source;
+pub(crate) mod types;
+
+use std::path::Path;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+pub use types::{GameSaveRules, GetSaveRulesForGameInput};
+
+#[napi]
+pub async fn get_save_rules_for_game(
+    input: GetSaveRulesForGameInput,
+) -> napi::Result<GameSaveRules> {
+    let source_url = source::resolve_source_url(input.source_url);
+    let index = cache::get_manifest_index(Path::new(&input.user_data_path), &source_url)
+        .await
+        .map_err(|error| Error::from_reason(format!("{error:#}")))?;
+    let entry = lookup::find_manifest_entry(
+        &index,
+        &input.object_id,
+        input.remote_id.as_deref(),
+        input.title.as_deref(),
+    );
+
+    Ok(rules::build_game_save_rules(
+        input.shop,
+        input.object_id,
+        entry,
+    ))
+}

--- a/native/hydra-native/src/cloud_save/manifest/rules.rs
+++ b/native/hydra-native/src/cloud_save/manifest/rules.rs
@@ -1,0 +1,121 @@
+use super::types::{
+    CloudSaveGameId, CloudSaveRule, CloudSaveRuleCondition, GameSaveRules, ManifestFileRule,
+    ManifestGameEntry,
+};
+use crate::cloud_save::identity::build_rule_id;
+
+const FILE_RULE_KIND: &str = "file";
+const DIRECTORY_RULE_KIND: &str = "dir";
+const LUDUSAVI_RULE_SOURCE: &str = "ludusavi";
+
+pub(crate) fn infer_rule_kind(raw_path: &str) -> &'static str {
+    if raw_path
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '[' | '{' | ']'))
+    {
+        return FILE_RULE_KIND;
+    }
+    if raw_path.ends_with('/') {
+        return DIRECTORY_RULE_KIND;
+    }
+    let base_name = raw_path.rsplit('/').next().unwrap_or(raw_path);
+    if base_name.contains('.') {
+        FILE_RULE_KIND
+    } else {
+        DIRECTORY_RULE_KIND
+    }
+}
+
+fn build_rule(file: &ManifestFileRule) -> CloudSaveRule {
+    let mut rule = CloudSaveRule {
+        rule_id: String::new(),
+        kind: infer_rule_kind(&file.raw_path).to_string(),
+        raw_path: file.raw_path.clone(),
+        source: LUDUSAVI_RULE_SOURCE.to_string(),
+        tags: file.tags.clone(),
+        preferred_path: None,
+        when: file
+            .when
+            .iter()
+            .map(|condition| CloudSaveRuleCondition {
+                os: condition.os.clone(),
+                store: condition.store.clone(),
+            })
+            .collect(),
+    };
+    rule.rule_id = build_rule_id(&rule);
+    rule
+}
+
+pub fn build_game_save_rules(
+    shop: String,
+    object_id: String,
+    entry: Option<&ManifestGameEntry>,
+) -> GameSaveRules {
+    let manifest_key = entry.map(|entry| entry.manifest_key.clone());
+
+    let rules = entry.map_or_else(Vec::new, |entry| {
+        entry.files.iter().map(build_rule).collect()
+    });
+
+    let mut revision_ids = rules
+        .iter()
+        .map(|rule| rule.rule_id.as_str())
+        .collect::<Vec<_>>();
+    revision_ids.sort();
+    let rule_source_revision = blake3::hash(revision_ids.join("\n").as_bytes())
+        .to_hex()
+        .to_string();
+
+    GameSaveRules {
+        game_id: CloudSaveGameId { shop, object_id },
+        manifest_key,
+        rule_source_revision,
+        rules,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_save::manifest::cache::get_manifest_index;
+    use crate::cloud_save::manifest::lookup::find_manifest_entry;
+    use crate::cloud_save::manifest::source::resolve_source_url;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn builds_balatro_save_rules_from_real_manifest() {
+        let shop = "steam";
+        let object_id = "2379780";
+        let title = "Balatro";
+
+        let source_url = resolve_source_url(None);
+        let cache_directory = tempdir().unwrap();
+
+        let index = get_manifest_index(cache_directory.path(), &source_url)
+            .await
+            .unwrap();
+
+        let entry = find_manifest_entry(&index, object_id, None, Some(title));
+
+        let result = build_game_save_rules(shop.to_string(), object_id.to_string(), entry);
+
+        println!("{result:#?}");
+
+        assert_eq!(result.game_id.shop, shop);
+        assert_eq!(result.game_id.object_id, object_id);
+        assert_eq!(result.manifest_key.as_deref(), Some(object_id));
+        assert!(!result.rules.is_empty());
+
+        assert!(result.rules.iter().all(|rule| rule.source == "ludusavi"));
+
+        assert!(result
+            .rules
+            .iter()
+            .any(|rule| rule.tags.iter().any(|tag| tag == "save")));
+
+        assert!(result.rules.iter().any(|rule| rule.kind == "file"));
+
+        assert!(result.rules.iter().any(|rule| rule.kind == "dir"));
+    }
+}

--- a/native/hydra-native/src/cloud_save/manifest/source.rs
+++ b/native/hydra-native/src/cloud_save/manifest/source.rs
@@ -1,0 +1,33 @@
+pub const DEFAULT_CLOUD_SAVE_MANIFEST_URL: &str = "https://cdn.losbroxas.org/manifest.yaml";
+
+pub fn resolve_source_url(configured_url: Option<String>) -> String {
+    configured_url
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty())
+        .unwrap_or_else(|| DEFAULT_CLOUD_SAVE_MANIFEST_URL.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_configured_url() {
+        let configured_url = Some("https://example.com/manifest.yaml".to_string());
+
+        let result = resolve_source_url(configured_url);
+
+        println!("resolved url: {result}");
+
+        assert_eq!(result, "https://example.com/manifest.yaml");
+    }
+
+    #[test]
+    fn uses_default_when_url_is_none() {
+        let result = resolve_source_url(None);
+
+        println!("resolved default url: {result}");
+
+        assert_eq!(result, DEFAULT_CLOUD_SAVE_MANIFEST_URL);
+    }
+}

--- a/native/hydra-native/src/cloud_save/manifest/types.rs
+++ b/native/hydra-native/src/cloud_save/manifest/types.rs
@@ -1,0 +1,81 @@
+use indexmap::IndexMap;
+use napi_derive::napi;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestRuleCondition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub os: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestFileRule {
+    pub raw_path: String,
+    pub tags: Vec<String>,
+    pub when: Vec<ManifestRuleCondition>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestGameEntry {
+    pub manifest_key: String,
+    pub files: Vec<ManifestFileRule>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestIndex {
+    pub version: u8,
+    pub fetched_at: i64,
+    pub source_url: String,
+    pub games: IndexMap<String, ManifestGameEntry>,
+}
+
+#[napi(object)]
+pub struct GetSaveRulesForGameInput {
+    pub shop: String,
+    pub object_id: String,
+    pub title: Option<String>,
+    pub remote_id: Option<String>,
+    pub user_data_path: String,
+    pub source_url: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Debug)]
+pub struct CloudSaveGameId {
+    pub shop: String,
+    pub object_id: String,
+}
+
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct CloudSaveRuleCondition {
+    pub os: Option<String>,
+    pub store: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct CloudSaveRule {
+    pub rule_id: String,
+    pub kind: String,
+    pub raw_path: String,
+    pub source: String,
+    pub tags: Vec<String>,
+    pub when: Vec<CloudSaveRuleCondition>,
+    pub preferred_path: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Debug)]
+pub struct GameSaveRules {
+    pub game_id: CloudSaveGameId,
+    pub manifest_key: Option<String>,
+    pub rule_source_revision: String,
+    pub rules: Vec<CloudSaveRule>,
+}

--- a/native/hydra-native/src/cloud_save/mod.rs
+++ b/native/hydra-native/src/cloud_save/mod.rs
@@ -1,0 +1,4 @@
+pub mod identity;
+pub mod manifest;
+pub mod path_resolution;
+pub mod save_scanner;

--- a/native/hydra-native/src/cloud_save/path_resolution/candidates.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/candidates.rs
@@ -1,0 +1,165 @@
+use super::context::normalize_separators;
+use super::tokens::{apply, literal, missing, optional_literal, TokenValues};
+use super::types::PathResolutionContext;
+
+#[derive(Clone, Copy)]
+enum WindowsLayout {
+    Modern,
+    Legacy,
+}
+
+fn native_values(context: &PathResolutionContext, root: Option<&str>) -> TokenValues {
+    let windows = context.platform == "windows";
+    let windows_path = |path| {
+        if windows {
+            optional_literal(path)
+        } else {
+            missing()
+        }
+    };
+    let unix_path = |path| {
+        if windows {
+            missing()
+        } else {
+            optional_literal(path)
+        }
+    };
+
+    TokenValues {
+        root: optional_literal(root),
+        base: optional_literal(context.install_dir.as_deref()),
+        home: literal(&context.home_dir),
+        os_username: literal(&context.os_username),
+        app_data: windows_path(context.app_data_dir.as_deref()),
+        local_app_data: windows_path(context.local_app_data_dir.as_deref()),
+        documents: windows_path(context.documents_dir.as_deref()),
+        public: windows_path(context.public_dir.as_deref()),
+        program_data: windows_path(context.program_data_dir.as_deref()),
+        windows_dir: windows_path(context.windows_dir.as_deref()),
+        xdg_data: unix_path(context.xdg_data_dir.as_deref()),
+        xdg_config: unix_path(context.xdg_config_dir.as_deref()),
+    }
+}
+
+fn windows_values(
+    context: &PathResolutionContext,
+    root: &str,
+    drive: &str,
+    home: &str,
+    layout: WindowsLayout,
+) -> TokenValues {
+    let (documents, app_data, local_app_data) = match layout {
+        WindowsLayout::Modern => (
+            format!("{home}/Documents"),
+            format!("{home}/AppData/Roaming"),
+            format!("{home}/AppData/Local"),
+        ),
+        WindowsLayout::Legacy => (
+            format!("{home}/My Documents"),
+            format!("{home}/Application Data"),
+            format!("{home}/Local Settings/Application Data"),
+        ),
+    };
+
+    TokenValues {
+        root: root.to_string(),
+        base: optional_literal(context.install_dir.as_deref()),
+        home: home.to_string(),
+        os_username: home.rsplit('/').next().unwrap_or("*").to_string(),
+        app_data,
+        local_app_data,
+        documents,
+        public: format!("{drive}/users/Public"),
+        program_data: format!("{drive}/ProgramData"),
+        windows_dir: format!("{drive}/windows"),
+        xdg_data: optional_literal(context.xdg_data_dir.as_deref()),
+        xdg_config: optional_literal(context.xdg_config_dir.as_deref()),
+    }
+}
+
+fn windows_environment_paths(
+    path: &str,
+    context: &PathResolutionContext,
+    root: String,
+    drive: String,
+    home: String,
+) -> Vec<String> {
+    [WindowsLayout::Modern, WindowsLayout::Legacy]
+        .into_iter()
+        .map(|layout| apply(path, &windows_values(context, &root, &drive, &home, layout)))
+        .collect()
+}
+
+fn windows_environment_path(
+    path: &str,
+    context: &PathResolutionContext,
+    root: &str,
+    drive: &str,
+    home: &str,
+    layout: WindowsLayout,
+) -> String {
+    apply(path, &windows_values(context, root, drive, home, layout))
+}
+
+pub fn native_paths(
+    path: &str,
+    context: &PathResolutionContext,
+    root: Option<&str>,
+) -> Vec<String> {
+    let mut paths = vec![apply(path, &native_values(context, root))];
+
+    if root.is_none() && context.platform == "windows" && path.contains("<home>/Saved Games/") {
+        if let Some(saved_games) = &context.saved_games_dir {
+            let replaced =
+                path.replace("<home>/Saved Games/", &format!("{}/", literal(saved_games)));
+            paths.push(apply(&replaced, &native_values(context, None)));
+        }
+    }
+
+    paths
+}
+
+pub fn wine_paths(path: &str, context: &PathResolutionContext, prefix: &str) -> Vec<String> {
+    let root = literal(prefix);
+    let preferred_users = [
+        "steamuser".to_string(),
+        globset::escape(&context.os_username),
+    ];
+    let mut paths = Vec::new();
+
+    for layout in [WindowsLayout::Modern, WindowsLayout::Legacy] {
+        for user in &preferred_users {
+            let drive = format!("{root}/drive_c");
+            let home = format!("{drive}/users/{user}");
+            paths.push(windows_environment_path(
+                path, context, &root, &drive, &home, layout,
+            ));
+        }
+
+        let drive = format!("{root}/drive_*");
+        let home = format!("{drive}/users/*");
+        paths.push(windows_environment_path(
+            path, context, &root, &drive, &home, layout,
+        ));
+    }
+
+    paths
+}
+
+pub fn steam_proton_paths(
+    path: &str,
+    context: &PathResolutionContext,
+    steam_root: &str,
+) -> Vec<String> {
+    let root = literal(steam_root);
+    let drive = format!(
+        "{root}/steamapps/compatdata/{}/pfx/drive_c",
+        globset::escape(&context.object_id)
+    );
+    let home = format!("{drive}/users/steamuser");
+    windows_environment_paths(path, context, root, drive, home)
+}
+
+pub fn normalize_candidate(path: &str) -> String {
+    normalize_separators(path)
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/capture.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/capture.rs
@@ -1,0 +1,218 @@
+use super::context::normalize_separators;
+use crate::cloud_save::identity::is_safe_capture;
+
+pub const STORE_USER_CAPTURE_MARKER: &str = "__HYDRA_STORE_USER_CAPTURE__";
+
+fn raw_segments(raw_rule: &str) -> Vec<String> {
+    normalize_separators(raw_rule)
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn path_segments(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect()
+}
+
+pub fn capture_template(raw_rule: &str, resolved_path: &str) -> Option<String> {
+    if !raw_rule.contains("<storeUserId>") {
+        return None;
+    }
+
+    let raw = normalize_separators(raw_rule);
+    let raw_segments = raw_segments(&raw);
+    let mut resolved_segments = path_segments(resolved_path)
+        .into_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+
+    for (raw_index, raw_segment) in raw_segments.iter().enumerate() {
+        if !raw_segment.contains("<storeUserId>") {
+            continue;
+        }
+        let offset_from_end = raw_segments.len() - raw_index - 1;
+        let resolved_index = resolved_segments.len().checked_sub(offset_from_end + 1)?;
+        resolved_segments[resolved_index] = raw_segment
+            .replace("*<storeUserId>", "<storeUserId>")
+            .replace("<storeUserId>*", "<storeUserId>")
+            .replace("<storeUserId>", STORE_USER_CAPTURE_MARKER);
+    }
+
+    let prefix = if resolved_path.starts_with('/') {
+        "/"
+    } else {
+        ""
+    };
+    Some(format!("{prefix}{}", resolved_segments.join("/")))
+}
+
+fn segment_matches(pattern: &str, value: &str, case_sensitive: bool) -> bool {
+    globset::GlobBuilder::new(pattern)
+        .case_insensitive(!case_sensitive)
+        .literal_separator(true)
+        .build()
+        .map(|pattern| pattern.compile_matcher().is_match(value))
+        .unwrap_or(false)
+}
+
+fn equal(left: &str, right: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        left == right
+    } else {
+        left.to_lowercase() == right.to_lowercase()
+    }
+}
+
+fn capture_segment(template: &str, value: &str, case_sensitive: bool) -> Option<String> {
+    let literals = template
+        .split(STORE_USER_CAPTURE_MARKER)
+        .collect::<Vec<_>>();
+    if literals.len() < 2
+        || literals
+            .iter()
+            .any(|literal| literal.contains(['*', '?', '[', '{']))
+    {
+        return None;
+    }
+    let prefix = literals[0];
+    if value.len() < prefix.len() || !equal(&value[..prefix.len()], prefix, case_sensitive) {
+        return None;
+    }
+
+    let capture_start = prefix.len();
+    let capture_end = if literals[1].is_empty() {
+        if literals.len() == 2 {
+            value.len()
+        } else {
+            return None;
+        }
+    } else {
+        let haystack = if case_sensitive {
+            value[capture_start..].to_string()
+        } else {
+            value[capture_start..].to_lowercase()
+        };
+        let needle = if case_sensitive {
+            literals[1].to_string()
+        } else {
+            literals[1].to_lowercase()
+        };
+        capture_start + haystack.find(&needle)?
+    };
+    let captured = &value[capture_start..capture_end];
+    if !is_safe_capture(captured) {
+        return None;
+    }
+
+    let mut reconstructed = String::new();
+    for (index, literal) in literals.iter().enumerate() {
+        if index > 0 {
+            reconstructed.push_str(captured);
+        }
+        reconstructed.push_str(literal);
+    }
+    equal(&reconstructed, value, case_sensitive).then(|| captured.to_string())
+}
+
+fn match_segments(
+    templates: &[&str],
+    values: &[&str],
+    case_sensitive: bool,
+    captured: Option<String>,
+) -> Option<String> {
+    if templates.is_empty() {
+        return values.is_empty().then_some(captured).flatten();
+    }
+    if templates[0] == "**" {
+        for consumed in 0..=values.len() {
+            if let Some(result) = match_segments(
+                &templates[1..],
+                &values[consumed..],
+                case_sensitive,
+                captured.clone(),
+            ) {
+                return Some(result);
+            }
+        }
+        return None;
+    }
+    let value = *values.first()?;
+    let next_capture = if templates[0].contains(STORE_USER_CAPTURE_MARKER) {
+        let value = capture_segment(templates[0], value, case_sensitive)?;
+        if captured
+            .as_ref()
+            .is_some_and(|existing| !equal(existing, &value, case_sensitive))
+        {
+            return None;
+        }
+        Some(value)
+    } else {
+        if !segment_matches(templates[0], value, case_sensitive) {
+            return None;
+        }
+        captured
+    };
+    match_segments(&templates[1..], &values[1..], case_sensitive, next_capture)
+}
+
+pub fn capture_store_user(
+    template: &str,
+    concrete_path: &str,
+    case_sensitive: bool,
+) -> Option<String> {
+    let normalized_template = normalize_separators(template);
+    let normalized_path = normalize_separators(concrete_path);
+    match_segments(
+        &path_segments(&normalized_template),
+        &path_segments(&normalized_path),
+        case_sensitive,
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captures_full_embedded_and_repeated_placeholders() {
+        let full = capture_template(
+            "<winAppData>/Sekiro/<storeUserId>",
+            "C:/Users/A/AppData/Roaming/Sekiro/*",
+        )
+        .unwrap();
+        assert_eq!(
+            capture_store_user(&full, "C:/Users/A/AppData/Roaming/Sekiro/111111", false).as_deref(),
+            Some("111111")
+        );
+
+        let embedded = capture_template(
+            "<home>/Game/_steam_<storeUserId>/saves",
+            "/prefix/drive_c/users/steamuser/Game/_steam_*/saves",
+        )
+        .unwrap();
+        assert_eq!(
+            capture_store_user(
+                &embedded,
+                "/prefix/drive_c/users/steamuser/Game/_steam_Goldberg/saves",
+                true
+            )
+            .as_deref(),
+            Some("Goldberg")
+        );
+
+        let repeated = capture_template(
+            "<home>/Game/<storeUserId>/<storeUserId>/saves",
+            "/home/a/Game/*/*/saves",
+        )
+        .unwrap();
+        assert_eq!(
+            capture_store_user(&repeated, "/home/a/Game/Rune/Rune/saves", true).as_deref(),
+            Some("Rune")
+        );
+        assert!(capture_store_user(&repeated, "/home/a/Game/Rune/Goldberg/saves", true).is_none());
+    }
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/capture.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/capture.rs
@@ -66,6 +66,18 @@ fn equal(left: &str, right: &str, case_sensitive: bool) -> bool {
     }
 }
 
+fn matching_prefix_len(value: &str, prefix: &str, case_sensitive: bool) -> Option<usize> {
+    if case_sensitive {
+        return value.starts_with(prefix).then_some(prefix.len());
+    }
+
+    value
+        .char_indices()
+        .map(|(index, _)| index)
+        .chain(std::iter::once(value.len()))
+        .find(|end| equal(&value[..*end], prefix, false))
+}
+
 fn capture_segment(template: &str, value: &str, case_sensitive: bool) -> Option<String> {
     let literals = template
         .split(STORE_USER_CAPTURE_MARKER)
@@ -78,11 +90,7 @@ fn capture_segment(template: &str, value: &str, case_sensitive: bool) -> Option<
         return None;
     }
     let prefix = literals[0];
-    if value.len() < prefix.len() || !equal(&value[..prefix.len()], prefix, case_sensitive) {
-        return None;
-    }
-
-    let capture_start = prefix.len();
+    let capture_start = matching_prefix_len(value, prefix, case_sensitive)?;
     let capture_end = if literals[1].is_empty() {
         if literals.len() == 2 {
             value.len()
@@ -90,17 +98,15 @@ fn capture_segment(template: &str, value: &str, case_sensitive: bool) -> Option<
             return None;
         }
     } else {
-        let haystack = if case_sensitive {
-            value[capture_start..].to_string()
-        } else {
-            value[capture_start..].to_lowercase()
-        };
-        let needle = if case_sensitive {
-            literals[1].to_string()
-        } else {
-            literals[1].to_lowercase()
-        };
-        capture_start + haystack.find(&needle)?
+        let remaining = &value[capture_start..];
+        capture_start
+            + remaining
+                .char_indices()
+                .map(|(index, _)| index)
+                .chain(std::iter::once(remaining.len()))
+                .find(|index| {
+                    matching_prefix_len(&remaining[*index..], literals[1], case_sensitive).is_some()
+                })?
     };
     let captured = &value[capture_start..capture_end];
     if !is_safe_capture(captured) {
@@ -214,5 +220,17 @@ mod tests {
             Some("Rune")
         );
         assert!(capture_store_user(&repeated, "/home/a/Game/Rune/Goldberg/saves", true).is_none());
+    }
+
+    #[test]
+    fn handles_unicode_around_embedded_captures() {
+        let template = format!("_steam_{STORE_USER_CAPTURE_MARKER}");
+        assert_eq!(capture_segment(&template, "日本語です", true), None);
+
+        let template = format!("{STORE_USER_CAPTURE_MARKER}_data");
+        assert_eq!(
+            capture_segment(&template, "ẞé_data", false).as_deref(),
+            Some("ẞé")
+        );
     }
 }

--- a/native/hydra-native/src/cloud_save/path_resolution/context.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/context.rs
@@ -1,0 +1,186 @@
+use super::types::{PathResolutionContext, ResolveSaveRulesInput};
+
+pub(crate) fn normalize_separators(value: &str) -> String {
+    value.replace('\\', "/").trim_end_matches('/').to_string()
+}
+
+fn parent_path(value: &str) -> Option<String> {
+    let normalized = normalize_separators(value);
+    normalized
+        .rsplit_once('/')
+        .map(|(parent, _)| parent.to_string())
+        .filter(|parent| !parent.is_empty())
+}
+
+fn basename(value: &str) -> Option<String> {
+    normalize_separators(value)
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .map(ToString::to_string)
+}
+
+fn install_directory(executable_path: Option<&str>) -> Option<String> {
+    let executable_path = normalize_separators(executable_path?);
+    let marker = "/steamapps/common/";
+
+    if let Some(index) = executable_path.to_ascii_lowercase().find(marker) {
+        let game_start = index + marker.len();
+        let game_end = executable_path[game_start..]
+            .find('/')
+            .map(|offset| game_start + offset)
+            .unwrap_or(executable_path.len());
+
+        return Some(executable_path[..game_end].to_string());
+    }
+    parent_path(&executable_path)
+}
+
+fn join_path(parent: &str, child: &str) -> String {
+    format!(
+        "{}/{}",
+        parent.trim_end_matches('/'),
+        child.trim_start_matches('/')
+    )
+}
+
+type WindowsDirectories = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn fallback_windows_directories(home_dir: &str, app_data_dir: Option<&str>) -> WindowsDirectories {
+    let local_app_data = app_data_dir
+        .and_then(parent_path)
+        .map(|parent| join_path(&parent, "Local"));
+    let public = parent_path(home_dir).map(|users| join_path(&users, "Public"));
+    let system_drive = home_dir
+        .split_once('/')
+        .map(|(root, _)| root)
+        .filter(|root| root.ends_with(':'));
+
+    (
+        local_app_data,
+        public,
+        system_drive.map(|root| join_path(root, "ProgramData")),
+        system_drive.map(|root| join_path(root, "Windows")),
+    )
+}
+
+#[cfg(windows)]
+fn windows_directories(home_dir: &str, app_data_dir: Option<&str>) -> WindowsDirectories {
+    let fallback = fallback_windows_directories(home_dir, app_data_dir);
+    let known = |folder| {
+        known_folders::get_known_folder_path(folder)
+            .map(|path| normalize_separators(&path.to_string_lossy()))
+    };
+
+    (
+        known(known_folders::KnownFolder::LocalAppData).or(fallback.0),
+        known(known_folders::KnownFolder::Public).or(fallback.1),
+        known(known_folders::KnownFolder::ProgramData).or(fallback.2),
+        known(known_folders::KnownFolder::Windows).or(fallback.3),
+    )
+}
+
+#[cfg(not(windows))]
+fn windows_directories(home_dir: &str, app_data_dir: Option<&str>) -> WindowsDirectories {
+    fallback_windows_directories(home_dir, app_data_dir)
+}
+
+fn derived_steam_root(executable_path: Option<&str>) -> Option<String> {
+    let executable_path = normalize_separators(executable_path?);
+    let marker = "/steamapps/common/";
+    let index = executable_path.to_ascii_lowercase().find(marker)?;
+
+    Some(executable_path[..index].to_string())
+}
+
+#[cfg(windows)]
+fn windows_saved_games_dir(home_dir: &str) -> Option<String> {
+    known_folders::get_known_folder_path(known_folders::KnownFolder::SavedGames)
+        .map(|path| normalize_separators(&path.to_string_lossy()))
+        .or_else(|| Some(join_path(home_dir, "Saved Games")))
+}
+
+#[cfg(not(windows))]
+fn windows_saved_games_dir(home_dir: &str) -> Option<String> {
+    Some(join_path(home_dir, "Saved Games"))
+}
+
+pub fn build_context(input: &ResolveSaveRulesInput) -> Result<PathResolutionContext, String> {
+    if !matches!(input.platform.as_str(), "windows" | "linux" | "mac") {
+        return Err(format!(
+            "Unsupported cloud save path platform: {}",
+            input.platform
+        ));
+    }
+
+    let home_dir = normalize_separators(&input.home_dir);
+    let install_dir = install_directory(input.executable_path.as_deref());
+    let wine_prefix_path = input.wine_prefix_path.as_deref().map(normalize_separators);
+    let documents_dir = input.documents_dir.as_deref().map(normalize_separators);
+    let app_data_dir = input.app_data_dir.as_deref().map(normalize_separators);
+    let os_username = basename(&home_dir).unwrap_or_else(|| "*".to_string());
+
+    let (local_app_data_dir, public_dir, program_data_dir, windows_dir) =
+        if input.platform == "windows" {
+            windows_directories(&home_dir, app_data_dir.as_deref())
+        } else {
+            (None, None, None, None)
+        };
+
+    let (xdg_data_dir, xdg_config_dir) = match input.platform.as_str() {
+        "windows" => (None, None),
+        "mac" => (
+            app_data_dir
+                .clone()
+                .or_else(|| Some(join_path(&home_dir, "Library"))),
+            Some(join_path(&home_dir, "Library/Preferences")),
+        ),
+        _ => (
+            Some(join_path(&home_dir, ".local/share")),
+            app_data_dir
+                .clone()
+                .or_else(|| Some(join_path(&home_dir, ".config"))),
+        ),
+    };
+
+    let derived_steam_root = derived_steam_root(input.executable_path.as_deref());
+    let configured_steam_root = input
+        .steam_path
+        .as_deref()
+        .map(normalize_separators)
+        .filter(|root| derived_steam_root.as_ref() != Some(root));
+    let windows_compatibility = input.platform == "linux"
+        && input
+            .executable_path
+            .as_deref()
+            .is_some_and(|path| path.to_ascii_lowercase().ends_with(".exe"));
+
+    Ok(PathResolutionContext {
+        shop: input.shop.clone(),
+        object_id: input.object_id.clone(),
+        platform: input.platform.clone(),
+        home_dir: home_dir.clone(),
+        os_username,
+        documents_dir,
+        app_data_dir,
+        local_app_data_dir,
+        public_dir,
+        program_data_dir,
+        windows_dir,
+        saved_games_dir: (input.platform == "windows")
+            .then(|| windows_saved_games_dir(&home_dir))
+            .flatten(),
+        xdg_data_dir,
+        xdg_config_dir,
+        install_dir,
+        wine_prefix_path,
+        windows_compatibility,
+        derived_steam_root,
+        configured_steam_root,
+    })
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/custom.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/custom.rs
@@ -1,0 +1,192 @@
+pub const CUSTOM_PATH_PREFIX: &str = "<custom>";
+
+const WINDOWS_MARKER: &str = "<windows>";
+const LINUX_MARKER: &str = "<linux>";
+const MAC_MARKER: &str = "<mac>";
+const ABSOLUTE_MARKER: &str = "<absolute>";
+
+const WINDOWS_TOKENS: [&str; 6] = [
+    "<winAppData>",
+    "<winLocalAppData>",
+    "<winDocuments>",
+    "<base>",
+    "<root>",
+    "<home>",
+];
+const UNIX_TOKENS: [&str; 5] = ["<xdgData>", "<xdgConfig>", "<base>", "<root>", "<home>"];
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DecodedCustomPath {
+    pub platform: String,
+    pub path: String,
+}
+
+fn validate_relative_segments(path: &str, windows: bool) -> Result<(), String> {
+    let relative = path.strip_prefix('/').unwrap_or(path);
+    if relative.is_empty() {
+        return Ok(());
+    }
+    if relative.split('/').any(|segment| {
+        segment.is_empty()
+            || segment == "."
+            || segment == ".."
+            || (windows && segment.contains(':'))
+            || segment.chars().any(char::is_control)
+    }) {
+        return Err("cloud_save_custom_path_invalid".to_string());
+    }
+    Ok(())
+}
+
+fn validate_common(path: &str) -> Result<(), String> {
+    if path.contains(['\\', '\0', '*', '?', '[', ']', '{', '}'])
+        || path.chars().any(char::is_control)
+        || path.ends_with('/')
+    {
+        return Err("cloud_save_custom_path_invalid".to_string());
+    }
+    Ok(())
+}
+
+fn portable_token(path: &str, platform: &str) -> Option<&'static str> {
+    let tokens: &[&'static str] = if platform == "windows" {
+        &WINDOWS_TOKENS
+    } else {
+        &UNIX_TOKENS
+    };
+    tokens.iter().copied().find(|token| path.starts_with(token))
+}
+
+fn validate_portable_path(path: &str, platform: &str) -> Result<(), String> {
+    validate_common(path)?;
+    let Some(token) = portable_token(path, platform) else {
+        return Err("cloud_save_custom_path_invalid".to_string());
+    };
+    let suffix = &path[token.len()..];
+    if !suffix.is_empty() && !suffix.starts_with('/') {
+        return Err("cloud_save_custom_path_invalid".to_string());
+    }
+    if suffix
+        .split('/')
+        .any(|segment| segment.contains(['<', '>']) && segment != "<storeUserId>")
+    {
+        return Err("cloud_save_custom_path_invalid".to_string());
+    }
+    validate_relative_segments(suffix, platform == "windows")
+}
+
+fn validate_absolute_path(path: &str, platform: &str) -> Result<(), String> {
+    validate_common(path)?;
+    if path.contains(['<', '>']) {
+        return Err("cloud_save_custom_path_invalid".to_string());
+    }
+
+    let windows = platform == "windows";
+    let absolute = if windows {
+        let bytes = path.as_bytes();
+        bytes.len() > 3 && bytes[0].is_ascii_uppercase() && bytes[1] == b':' && bytes[2] == b'/'
+    } else {
+        path.len() > 1 && path.starts_with('/') && !path.starts_with("//")
+    };
+    if !absolute {
+        return Err("cloud_save_custom_path_must_be_local_absolute".to_string());
+    }
+
+    let without_root = if windows { &path[3..] } else { &path[1..] };
+    validate_relative_segments(without_root, windows)
+}
+
+pub fn decode_custom_path(raw_path: &str) -> Option<Result<DecodedCustomPath, String>> {
+    let encoded = raw_path.strip_prefix(CUSTOM_PATH_PREFIX)?;
+    let (encoded_platform, path) = if let Some(path) = encoded.strip_prefix(WINDOWS_MARKER) {
+        ("windows", path)
+    } else if let Some(path) = encoded.strip_prefix(LINUX_MARKER) {
+        ("linux", path)
+    } else if let Some(path) = encoded.strip_prefix(MAC_MARKER) {
+        ("mac", path)
+    } else {
+        return Some(Err("cloud_save_custom_path_invalid_platform".to_string()));
+    };
+
+    let (decoded_path, validation) = if let Some(absolute_path) = path.strip_prefix(ABSOLUTE_MARKER)
+    {
+        (
+            absolute_path,
+            validate_absolute_path(absolute_path, encoded_platform),
+        )
+    } else if path.starts_with('<') {
+        (path, validate_portable_path(path, encoded_platform))
+    } else {
+        (path, Err("cloud_save_custom_path_legacy".to_string()))
+    };
+    Some(validation.map(|_| DecodedCustomPath {
+        platform: encoded_platform.to_string(),
+        path: decoded_path.to_string(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_portable_and_absolute_paths_for_each_platform() {
+        assert_eq!(
+            decode_custom_path("<custom><windows><winAppData>/Hydra/Saves"),
+            Some(Ok(DecodedCustomPath {
+                platform: "windows".to_string(),
+                path: "<winAppData>/Hydra/Saves".to_string()
+            }))
+        );
+        assert_eq!(
+            decode_custom_path("<custom><linux><xdgData>/game"),
+            Some(Ok(DecodedCustomPath {
+                platform: "linux".to_string(),
+                path: "<xdgData>/game".to_string()
+            }))
+        );
+        assert_eq!(
+            decode_custom_path("<custom><mac><home>/Saves"),
+            Some(Ok(DecodedCustomPath {
+                platform: "mac".to_string(),
+                path: "<home>/Saves".to_string()
+            }))
+        );
+        assert_eq!(
+            decode_custom_path("<custom><windows><base>/saves/<storeUserId>"),
+            Some(Ok(DecodedCustomPath {
+                platform: "windows".to_string(),
+                path: "<base>/saves/<storeUserId>".to_string()
+            }))
+        );
+        assert_eq!(
+            decode_custom_path("<custom><windows><absolute>D:/Saves/Game"),
+            Some(Ok(DecodedCustomPath {
+                platform: "windows".to_string(),
+                path: "D:/Saves/Game".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn rejects_relative_traversing_and_wrong_platform_tokens() {
+        assert!(decode_custom_path("<custom><linux>relative/saves")
+            .unwrap()
+            .is_err());
+        assert!(decode_custom_path("<custom><linux><home>/../etc")
+            .unwrap()
+            .is_err());
+        assert!(decode_custom_path("<custom><windows><xdgData>/Saves")
+            .unwrap()
+            .is_err());
+        assert!(decode_custom_path("<custom><windows>c:/Saves")
+            .unwrap()
+            .is_err());
+        assert!(decode_custom_path("<custom><windows>C:/Users/Hydra/Saves")
+            .unwrap()
+            .is_err());
+        assert!(decode_custom_path("<custom><linux>/home/hydra/Saves")
+            .unwrap()
+            .is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/mod.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/mod.rs
@@ -1,0 +1,22 @@
+mod candidates;
+mod capture;
+mod context;
+mod custom;
+mod resolve_path;
+mod resolve_rules;
+mod tokens;
+mod types;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+pub(crate) use capture::{capture_store_user, capture_template};
+pub use types::{ResolveSaveRulesInput, ResolvedCloudSavePath, ResolvedCloudSaveRule};
+
+#[napi]
+pub fn resolve_save_rules(
+    input: ResolveSaveRulesInput,
+) -> napi::Result<Vec<ResolvedCloudSaveRule>> {
+    let context = context::build_context(&input).map_err(Error::from_reason)?;
+    Ok(resolve_rules::resolve_rules(input.rules, &context))
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/resolve_path.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/resolve_path.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::path::Path;
 
 use super::candidates::{native_paths, normalize_candidate, steam_proton_paths, wine_paths};
 use super::custom::{decode_custom_path, CUSTOM_PATH_PREFIX};
@@ -102,6 +103,22 @@ pub(crate) fn glob_base_path(raw_path: &str) -> Option<String> {
         0 => ".".to_string(),
         index => segments[..index].join("/"),
     })
+}
+
+fn is_absolute_candidate(path: &str, platform: &str) -> bool {
+    if Path::new(path).is_absolute() {
+        return true;
+    }
+    if platform == "windows" {
+        let bytes = path.as_bytes();
+        return (bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && bytes[2] == b'/')
+            || path.starts_with("//");
+    }
+
+    path.starts_with('/')
 }
 
 fn assign_scan_roots(paths: &mut [ResolvedCloudSavePath], roots: &[ResolvedCloudSavePath]) {
@@ -220,15 +237,23 @@ fn resolve_standard_path(raw_path: &str, context: &PathResolutionContext) -> Res
         }
     }
 
+    paths.retain(|candidate| is_absolute_candidate(&candidate.path, &context.platform));
+
     if let Some(raw_scan_root) = glob_base_path(&raw_path) {
         let roots = resolve_path(&raw_scan_root, context).paths;
         assign_scan_roots(&mut paths, &roots);
     }
 
-    let unresolved_tokens = paths
-        .is_empty()
-        .then(|| tokens_in_path(&raw_path))
-        .unwrap_or_default();
+    let unresolved_tokens = if paths.is_empty() {
+        let tokens = tokens_in_path(&raw_path);
+        if tokens.is_empty() {
+            vec!["cloud_save_relative_path".to_string()]
+        } else {
+            tokens
+        }
+    } else {
+        Vec::new()
+    };
 
     ResolvedPath {
         paths,
@@ -417,6 +442,30 @@ mod tests {
                 && candidate.path
                     == "/prefix/drive_*/users/*/Saved Games/The Last of Us Part I/users/*/savedata"
         }));
+    }
+
+    #[test]
+    fn rejects_manifest_paths_that_remain_relative() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".to_string(),
+            object_id: "1".to_string(),
+            platform: "linux".to_string(),
+            home_dir: "/home/player".to_string(),
+            executable_path: Some("/games/Game/game".to_string()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let relative = resolve_path("Saves/profile", &context);
+        let rooted = resolve_path("<home>/Saves/profile", &context);
+
+        assert!(relative.paths.is_empty());
+        assert_eq!(relative.unresolved_tokens, vec!["cloud_save_relative_path"]);
+        assert_eq!(rooted.paths[0].path, "/home/player/Saves/profile");
     }
 
     #[test]

--- a/native/hydra-native/src/cloud_save/path_resolution/resolve_path.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/resolve_path.rs
@@ -1,0 +1,689 @@
+use std::collections::HashSet;
+
+use super::candidates::{native_paths, normalize_candidate, steam_proton_paths, wine_paths};
+use super::custom::{decode_custom_path, CUSTOM_PATH_PREFIX};
+use super::tokens::{has_unresolved_placeholder, tokens_in_path, uses_windows_profile};
+use super::types::{PathResolutionContext, ResolvedCloudSavePath};
+
+pub struct ResolvedPath {
+    pub paths: Vec<ResolvedCloudSavePath>,
+    pub unresolved_tokens: Vec<String>,
+}
+
+fn collect_paths(
+    paths: &mut Vec<ResolvedCloudSavePath>,
+    seen: &mut HashSet<(String, bool)>,
+    candidates: Vec<String>,
+    case_sensitive: bool,
+    dynamic: bool,
+) {
+    for path in candidates {
+        if has_unresolved_placeholder(&path) {
+            continue;
+        }
+
+        if seen.insert((path.clone(), case_sensitive)) {
+            paths.push(ResolvedCloudSavePath {
+                path,
+                case_sensitive,
+                dynamic,
+                scan_root: None,
+            });
+        }
+    }
+}
+
+fn collect_native_paths(
+    paths: &mut Vec<ResolvedCloudSavePath>,
+    seen: &mut HashSet<(String, bool)>,
+    raw_path: &str,
+    context: &PathResolutionContext,
+    root: Option<&str>,
+    dynamic: bool,
+) {
+    collect_paths(
+        paths,
+        seen,
+        native_paths(raw_path, context, root),
+        context.platform == "linux",
+        dynamic,
+    );
+}
+
+fn collect_wine_paths(
+    paths: &mut Vec<ResolvedCloudSavePath>,
+    seen: &mut HashSet<(String, bool)>,
+    raw_path: &str,
+    context: &PathResolutionContext,
+    prefix: &str,
+) {
+    collect_paths(
+        paths,
+        seen,
+        wine_paths(raw_path, context, prefix),
+        false,
+        true,
+    );
+}
+
+fn collect_steam_root_paths(
+    paths: &mut Vec<ResolvedCloudSavePath>,
+    seen: &mut HashSet<(String, bool)>,
+    raw_path: &str,
+    context: &PathResolutionContext,
+    root: &str,
+    dynamic: bool,
+) {
+    if context.platform == "linux" && context.shop == "steam" {
+        collect_paths(
+            paths,
+            seen,
+            steam_proton_paths(raw_path, context, root),
+            false,
+            dynamic,
+        );
+    }
+
+    collect_native_paths(paths, seen, raw_path, context, Some(root), dynamic);
+}
+
+fn is_glob_segment(segment: &str) -> bool {
+    segment.contains(['*', '?', '[', '{'])
+}
+
+pub(crate) fn glob_base_path(raw_path: &str) -> Option<String> {
+    let normalized = normalize_candidate(raw_path);
+    let segments = normalized.split('/').collect::<Vec<_>>();
+    let first_glob = segments
+        .iter()
+        .position(|segment| is_glob_segment(segment))?;
+
+    Some(match first_glob {
+        0 => ".".to_string(),
+        index => segments[..index].join("/"),
+    })
+}
+
+fn assign_scan_roots(paths: &mut [ResolvedCloudSavePath], roots: &[ResolvedCloudSavePath]) {
+    for candidate in paths {
+        candidate.scan_root = roots
+            .iter()
+            .filter(|root| {
+                candidate.path == root.path
+                    || candidate
+                        .path
+                        .starts_with(&format!("{}/", root.path.trim_end_matches('/')))
+            })
+            .max_by_key(|root| root.path.len())
+            .map(|root| root.path.clone());
+    }
+}
+
+fn resolve_standard_path(raw_path: &str, context: &PathResolutionContext) -> ResolvedPath {
+    let raw_path = normalize_candidate(raw_path)
+        .replace("*<storeUserId>", "<storeUserId>")
+        .replace("<storeUserId>*", "<storeUserId>");
+    let store_user_dynamic = raw_path.contains("<storeUserId>");
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+
+    if context.windows_compatibility {
+        if let Some(prefix) = &context.wine_prefix_path {
+            // This is the prefix Hydra passes to the launcher. Other Proton
+            // prefixes are independent environments, not mirrors of it.
+            collect_wine_paths(&mut paths, &mut seen, &raw_path, context, prefix);
+
+            // Keep store-root expansion for rules that use <root>, but bind
+            // Windows profile paths to the exact launcher prefix.
+            if !uses_windows_profile(&raw_path) {
+                if let Some(root) = &context.derived_steam_root {
+                    collect_native_paths(
+                        &mut paths,
+                        &mut seen,
+                        &raw_path,
+                        context,
+                        Some(root),
+                        store_user_dynamic,
+                    );
+                }
+                if let Some(root) = &context.configured_steam_root {
+                    collect_native_paths(
+                        &mut paths,
+                        &mut seen,
+                        &raw_path,
+                        context,
+                        Some(root),
+                        store_user_dynamic,
+                    );
+                }
+            }
+        } else {
+            // Compatibility callers without a known launcher prefix may still
+            // derive Proton's active prefix from the executable's Steam root.
+            if let Some(root) = &context.derived_steam_root {
+                collect_steam_root_paths(
+                    &mut paths,
+                    &mut seen,
+                    &raw_path,
+                    context,
+                    root,
+                    store_user_dynamic,
+                );
+            }
+            if let Some(root) = &context.configured_steam_root {
+                collect_steam_root_paths(
+                    &mut paths,
+                    &mut seen,
+                    &raw_path,
+                    context,
+                    root,
+                    store_user_dynamic,
+                );
+            }
+            collect_native_paths(
+                &mut paths,
+                &mut seen,
+                &raw_path,
+                context,
+                None,
+                store_user_dynamic,
+            );
+        }
+    } else {
+        collect_native_paths(
+            &mut paths,
+            &mut seen,
+            &raw_path,
+            context,
+            None,
+            store_user_dynamic,
+        );
+        if let Some(root) = &context.derived_steam_root {
+            collect_native_paths(
+                &mut paths,
+                &mut seen,
+                &raw_path,
+                context,
+                Some(root),
+                store_user_dynamic,
+            );
+        }
+        if let Some(root) = &context.configured_steam_root {
+            collect_native_paths(
+                &mut paths,
+                &mut seen,
+                &raw_path,
+                context,
+                Some(root),
+                store_user_dynamic,
+            );
+        }
+    }
+
+    if let Some(raw_scan_root) = glob_base_path(&raw_path) {
+        let roots = resolve_path(&raw_scan_root, context).paths;
+        assign_scan_roots(&mut paths, &roots);
+    }
+
+    let unresolved_tokens = paths
+        .is_empty()
+        .then(|| tokens_in_path(&raw_path))
+        .unwrap_or_default();
+
+    ResolvedPath {
+        paths,
+        unresolved_tokens,
+    }
+}
+
+fn unresolved_custom_path(error: &str) -> ResolvedPath {
+    ResolvedPath {
+        paths: vec![],
+        unresolved_tokens: vec![error.to_string()],
+    }
+}
+
+fn resolve_custom_path(raw_path: &str, context: &PathResolutionContext) -> ResolvedPath {
+    let decoded = match decode_custom_path(raw_path) {
+        Some(Ok(decoded)) => decoded,
+        Some(Err(error)) => return unresolved_custom_path(&error),
+        None => return unresolved_custom_path("cloud_save_custom_path_invalid"),
+    };
+    if decoded.platform == "windows" {
+        if context.platform != "windows"
+            && !(context.platform == "linux" && context.windows_compatibility)
+        {
+            return unresolved_custom_path("cloud_save_custom_path_foreign_platform");
+        }
+        if context.platform == "linux" && !decoded.path.starts_with('<') {
+            return unresolved_custom_path("cloud_save_custom_path_non_portable");
+        }
+        if context.platform == "linux" && decoded.path.starts_with("<root>") {
+            let mut paths = Vec::new();
+            let mut seen = HashSet::new();
+            if let Some(root) = &context.derived_steam_root {
+                collect_native_paths(
+                    &mut paths,
+                    &mut seen,
+                    &decoded.path,
+                    context,
+                    Some(root),
+                    decoded.path.contains("<storeUserId>"),
+                );
+            }
+            if let Some(root) = &context.configured_steam_root {
+                collect_native_paths(
+                    &mut paths,
+                    &mut seen,
+                    &decoded.path,
+                    context,
+                    Some(root),
+                    decoded.path.contains("<storeUserId>"),
+                );
+            }
+            return ResolvedPath {
+                unresolved_tokens: paths
+                    .is_empty()
+                    .then(|| tokens_in_path(&decoded.path))
+                    .unwrap_or_default(),
+                paths,
+            };
+        }
+        if decoded.path.starts_with('<') {
+            return resolve_standard_path(&decoded.path, context);
+        }
+    }
+
+    if decoded.platform != context.platform {
+        return unresolved_custom_path("cloud_save_custom_path_foreign_platform");
+    }
+
+    if decoded.path.starts_with('<') {
+        return resolve_standard_path(&decoded.path, context);
+    }
+    let candidates = vec![decoded.path.clone()];
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    collect_paths(
+        &mut paths,
+        &mut seen,
+        candidates,
+        context.platform == "linux",
+        false,
+    );
+    let unresolved_tokens = paths
+        .is_empty()
+        .then(|| tokens_in_path(&decoded.path))
+        .unwrap_or_default();
+    ResolvedPath {
+        paths,
+        unresolved_tokens,
+    }
+}
+
+pub fn resolve_path(raw_path: &str, context: &PathResolutionContext) -> ResolvedPath {
+    if raw_path.starts_with(CUSTOM_PATH_PREFIX) {
+        resolve_custom_path(raw_path, context)
+    } else {
+        resolve_standard_path(raw_path, context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::cloud_save::manifest::{get_save_rules_for_game, GetSaveRulesForGameInput};
+    use crate::cloud_save::path_resolution::context::build_context;
+    use crate::cloud_save::path_resolution::types::ResolveSaveRulesInput;
+
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn resolves_real_balatro_save_path_with_wine() {
+        let shop = "steam";
+        let object_id = "2379780";
+        let cache_directory = tempdir().unwrap();
+
+        let game_rules = get_save_rules_for_game(GetSaveRulesForGameInput {
+            shop: shop.to_string(),
+            object_id: object_id.to_string(),
+            remote_id: None,
+            title: Some("Balatro".to_string()),
+            source_url: None,
+            user_data_path: cache_directory.path().display().to_string(),
+        })
+        .await
+        .unwrap();
+
+        let rule = game_rules
+            .rules
+            .iter()
+            .find(|rule| rule.raw_path == "<winAppData>/Balatro")
+            .expect("Balatro Windows Steam save rule should exist");
+
+        let input = ResolveSaveRulesInput {
+            shop: shop.to_string(),
+            object_id: object_id.to_string(),
+            platform: "linux".to_string(),
+            home_dir: "/home/spectre".to_string(),
+            executable_path: Some("/home/spectre/Games/Balatro/Balatro.exe".to_string()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: Some("/home/spectre/.wine".to_string()),
+            steam_path: None,
+            rules: Vec::new(),
+        };
+
+        let context = build_context(&input).unwrap();
+        let result = resolve_path(&rule.raw_path, &context);
+
+        let expected_path = concat!(
+            "/home/spectre/.wine/",
+            "drive_*/users/*/AppData/Roaming/Balatro"
+        );
+
+        assert_eq!(game_rules.manifest_key.as_deref(), Some(object_id));
+        assert_eq!(rule.kind, "dir");
+        assert_eq!(rule.source, "ludusavi");
+        assert!(rule.tags.iter().any(|tag| tag == "save"));
+        assert!(result.paths.iter().any(|path| path.path == expected_path));
+        assert!(result.unresolved_tokens.is_empty());
+    }
+
+    #[test]
+    fn resolves_store_user_as_dynamic_wildcard() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".to_string(),
+            object_id: "1888930".to_string(),
+            platform: "linux".to_string(),
+            home_dir: "/home/victor".to_string(),
+            executable_path: Some("/games/TLOU/tlou-i.exe".to_string()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: Some("/prefix".to_string()),
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let result = resolve_path(
+            "<home>/Saved Games/The Last of Us Part I/users/<storeUserId>/savedata",
+            &context,
+        );
+
+        assert!(result.paths.iter().any(|candidate| {
+            candidate.dynamic
+                && candidate.path
+                    == "/prefix/drive_*/users/*/Saved Games/The Last of Us Part I/users/*/savedata"
+        }));
+    }
+
+    #[test]
+    fn rebases_portable_custom_paths_but_keeps_absolute_paths_exact() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".to_string(),
+            object_id: "1".to_string(),
+            platform: "windows".to_string(),
+            home_dir: "D:/Users/Maria".to_string(),
+            executable_path: Some("D:/Games/Game/game.exe".to_string()),
+            documents_dir: Some("D:/Users/Maria/Documents".to_string()),
+            app_data_dir: Some("D:/Users/Maria/AppData/Roaming".to_string()),
+            wine_prefix_path: None,
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let portable = resolve_path("<custom><windows><home>/Downloads/Game/Saves", &context);
+        let absolute = resolve_path(
+            "<custom><windows><absolute>C:/Users/Rodrigo/Downloads/Game/Saves",
+            &context,
+        );
+        let absolute_app_data = resolve_path(
+            "<custom><windows><absolute>C:/Users/Rodrigo/AppData/Roaming/Game/Saves",
+            &context,
+        );
+        let legacy = resolve_path(
+            "<custom><windows>C:/Users/Rodrigo/AppData/Roaming/Game/Saves",
+            &context,
+        );
+
+        assert_eq!(
+            portable.paths[0].path,
+            "D:/Users/Maria/Downloads/Game/Saves"
+        );
+        assert_eq!(
+            absolute.paths[0].path,
+            "C:/Users/Rodrigo/Downloads/Game/Saves"
+        );
+        assert_eq!(
+            absolute_app_data.paths[0].path,
+            "C:/Users/Rodrigo/AppData/Roaming/Game/Saves"
+        );
+        assert!(portable.unresolved_tokens.is_empty());
+        assert!(absolute.unresolved_tokens.is_empty());
+        assert!(absolute_app_data.unresolved_tokens.is_empty());
+        assert!(legacy.paths.is_empty());
+        assert_eq!(
+            legacy.unresolved_tokens,
+            vec!["cloud_save_custom_path_legacy"]
+        );
+    }
+
+    #[test]
+    fn resolves_one_windows_custom_identity_natively_and_inside_wine() {
+        let native_input = ResolveSaveRulesInput {
+            shop: "steam".to_string(),
+            object_id: "1".to_string(),
+            platform: "windows".to_string(),
+            home_dir: "C:/Users/Rodrigo".to_string(),
+            executable_path: Some("C:/Games/Game/game.exe".to_string()),
+            documents_dir: Some("C:/Users/Rodrigo/Documents".to_string()),
+            app_data_dir: Some("C:/Users/Rodrigo/AppData/Roaming".to_string()),
+            wine_prefix_path: None,
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let native_context = build_context(&native_input).unwrap();
+        let native = resolve_path("<custom><windows><winAppData>/Game/Saves", &native_context);
+        assert_eq!(
+            native.paths[0].path,
+            "C:/Users/Rodrigo/AppData/Roaming/Game/Saves"
+        );
+
+        let temp = tempdir().unwrap();
+        let prefix = temp.path().join("prefix");
+        let wine_input = ResolveSaveRulesInput {
+            shop: "steam".to_string(),
+            object_id: "1".to_string(),
+            platform: "linux".to_string(),
+            home_dir: temp.path().join("home/maria").display().to_string(),
+            executable_path: Some(temp.path().join("Game/game.exe").display().to_string()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: Some(prefix.display().to_string()),
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let wine_context = build_context(&wine_input).unwrap();
+        let wine = resolve_path("<custom><windows><winAppData>/Game/Saves", &wine_context);
+        let expected = prefix
+            .join("drive_c/users/steamuser/AppData/Roaming/Game/Saves")
+            .display()
+            .to_string()
+            .replace('\\', "/");
+        assert_eq!(wine.paths[0].path, expected);
+        assert!(wine.unresolved_tokens.is_empty());
+    }
+
+    #[test]
+    fn keeps_linux_custom_paths_platform_specific_and_rejects_unmapped_drives() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".to_string(),
+            object_id: "1".to_string(),
+            platform: "windows".to_string(),
+            home_dir: "D:/Users/Maria".to_string(),
+            executable_path: Some("D:/Games/Game/game.exe".to_string()),
+            documents_dir: Some("D:/Users/Maria/Documents".to_string()),
+            app_data_dir: Some("D:/Users/Maria/AppData/Roaming".to_string()),
+            wine_prefix_path: None,
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+        let linux_custom = resolve_path(
+            "<custom><linux><home>/.local/share/hydra/prefix/drive_c/users/steamuser/AppData/Roaming/Game",
+            &context,
+        );
+        assert!(linux_custom.paths.is_empty());
+        assert_eq!(
+            linux_custom.unresolved_tokens,
+            vec!["cloud_save_custom_path_foreign_platform"]
+        );
+
+        let mut wine_input = input;
+        wine_input.platform = "linux".to_string();
+        wine_input.home_dir = "/home/maria".to_string();
+        wine_input.executable_path = Some("/games/Game/game.exe".to_string());
+        wine_input.wine_prefix_path = Some("/home/maria/.wine".to_string());
+        let wine_context = build_context(&wine_input).unwrap();
+        let unmapped = resolve_path(
+            "<custom><windows><absolute>D:/Unmapped/Saves",
+            &wine_context,
+        );
+        assert!(unmapped.paths.is_empty());
+        assert_eq!(
+            unmapped.unresolved_tokens,
+            vec!["cloud_save_custom_path_non_portable"]
+        );
+    }
+
+    #[test]
+    fn uses_active_launcher_prefix_without_scanning_other_compatdata() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "123".into(),
+            platform: "linux".into(),
+            home_dir: "/home/victor".into(),
+            executable_path: Some("/mnt/games/SteamLibrary/steamapps/common/Game/game.exe".into()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: Some("/hydra/prefix".into()),
+            steam_path: Some("/home/victor/.steam/steam".into()),
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let result = resolve_path("<winAppData>/Game", &context);
+        let paths = result
+            .paths
+            .iter()
+            .map(|candidate| candidate.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths[0],
+            "/hydra/prefix/drive_c/users/steamuser/AppData/Roaming/Game"
+        );
+        assert_eq!(
+            paths[1],
+            "/hydra/prefix/drive_c/users/victor/AppData/Roaming/Game"
+        );
+        assert_eq!(
+            paths[2],
+            "/hydra/prefix/drive_*/users/*/AppData/Roaming/Game"
+        );
+        assert_eq!(
+            paths[3],
+            "/hydra/prefix/drive_c/users/steamuser/Application Data/Game"
+        );
+        assert!(paths.iter().all(|path| path.starts_with("/hydra/prefix/")));
+        assert!(paths.iter().all(|path| !path.contains("/compatdata/")));
+    }
+
+    #[test]
+    fn custom_store_root_stays_on_the_host_across_windows_compatibility() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "123".into(),
+            platform: "linux".into(),
+            home_dir: "/home/victor".into(),
+            executable_path: Some("/mnt/games/SteamLibrary/steamapps/common/Game/game.exe".into()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: Some("/hydra/prefix".into()),
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let root = resolve_path(
+            "<custom><windows><root>/userdata/<storeUserId>/123/remote",
+            &context,
+        );
+        let base = resolve_path("<custom><windows><base>/saves", &context);
+
+        assert_eq!(
+            root.paths[0].path,
+            "/mnt/games/SteamLibrary/userdata/*/123/remote"
+        );
+        assert!(root
+            .paths
+            .iter()
+            .all(|candidate| !candidate.path.starts_with("/hydra/prefix")));
+        assert_eq!(
+            base.paths[0].path,
+            "/mnt/games/SteamLibrary/steamapps/common/Game/saves"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_derived_proton_without_active_prefix() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "123".into(),
+            platform: "linux".into(),
+            home_dir: "/home/victor".into(),
+            executable_path: Some("/mnt/games/SteamLibrary/steamapps/common/Game/game.exe".into()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let result = resolve_path("<winDocuments>/Game", &context);
+
+        assert_eq!(
+            result.paths[0].path,
+            "/mnt/games/SteamLibrary/steamapps/compatdata/123/pfx/drive_c/users/steamuser/Documents/Game"
+        );
+    }
+
+    #[test]
+    fn ignores_wine_prefix_for_native_linux_executable() {
+        let input = ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "123".into(),
+            platform: "linux".into(),
+            home_dir: "/home/victor".into(),
+            executable_path: Some("/games/Game/game.x86_64".into()),
+            documents_dir: None,
+            app_data_dir: None,
+            wine_prefix_path: Some("/hydra/prefix".into()),
+            steam_path: None,
+            rules: Vec::new(),
+        };
+        let context = build_context(&input).unwrap();
+
+        let result = resolve_path("<home>/.config/Game", &context);
+
+        assert_eq!(result.paths[0].path, "/home/victor/.config/Game");
+        assert!(result
+            .paths
+            .iter()
+            .all(|path| !path.path.starts_with("/hydra/prefix")));
+    }
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/resolve_rules.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/resolve_rules.rs
@@ -1,0 +1,82 @@
+use crate::cloud_save::manifest::types::CloudSaveRule;
+
+use super::resolve_path::resolve_path;
+use super::types::{PathResolutionContext, ResolvedCloudSaveRule};
+
+pub fn resolve_rules(
+    rules: Vec<CloudSaveRule>,
+    context: &PathResolutionContext,
+) -> Vec<ResolvedCloudSaveRule> {
+    rules
+        .into_iter()
+        .map(|rule| {
+            let mut resolved = resolve_path(&rule.raw_path, context);
+            if rule.raw_path.starts_with("<custom>") {
+                if let Some(preferred_path) = &rule.preferred_path {
+                    resolved.paths = vec![super::types::ResolvedCloudSavePath {
+                        path: preferred_path.replace('\\', "/"),
+                        case_sensitive: context.platform == "linux"
+                            && !context.windows_compatibility,
+                        dynamic: false,
+                        scan_root: None,
+                    }];
+                    resolved.unresolved_tokens.clear();
+                }
+            }
+            ResolvedCloudSaveRule {
+                rule_id: rule.rule_id,
+                kind: rule.kind,
+                raw_path: rule.raw_path,
+                source: rule.source,
+                tags: rule.tags,
+                when: rule.when,
+                resolved_paths: resolved.paths,
+                unresolved_tokens: resolved.unresolved_tokens,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_save::manifest::types::CloudSaveRuleCondition;
+    use crate::cloud_save::path_resolution::context::build_context;
+    use crate::cloud_save::path_resolution::types::ResolveSaveRulesInput;
+
+    #[test]
+    fn a_locally_bound_custom_rule_uses_only_its_approved_path() {
+        let context = build_context(&ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "1".into(),
+            platform: "linux".into(),
+            home_dir: "/home/hydra".into(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: Some("/games/game.exe".into()),
+            wine_prefix_path: Some("/prefix".into()),
+            steam_path: None,
+            rules: Vec::new(),
+        })
+        .unwrap();
+        let result = resolve_rules(
+            vec![CloudSaveRule {
+                rule_id: "custom".into(),
+                kind: "dir".into(),
+                raw_path: "<custom><windows><winDocuments>/Game".into(),
+                source: "custom".into(),
+                tags: vec!["save".into()],
+                when: Vec::<CloudSaveRuleCondition>::new(),
+                preferred_path: Some("/prefix/drive_c/users/player-two/Documents/Game".into()),
+            }],
+            &context,
+        );
+
+        assert_eq!(result[0].resolved_paths.len(), 1);
+        assert_eq!(
+            result[0].resolved_paths[0].path,
+            "/prefix/drive_c/users/player-two/Documents/Game"
+        );
+        assert!(result[0].unresolved_tokens.is_empty());
+    }
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/tokens.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/tokens.rs
@@ -1,0 +1,168 @@
+use super::context::normalize_separators;
+
+const MISSING_TOKEN: &str = "<skip>";
+
+pub struct TokenValues {
+    pub root: String,
+    pub base: String,
+    pub home: String,
+    pub os_username: String,
+    pub app_data: String,
+    pub local_app_data: String,
+    pub documents: String,
+    pub public: String,
+    pub program_data: String,
+    pub windows_dir: String,
+    pub xdg_data: String,
+    pub xdg_config: String,
+}
+
+pub fn literal(value: &str) -> String {
+    globset::escape(&normalize_separators(value)).chars().fold(
+        String::new(),
+        |mut escaped, character| {
+            match character {
+                '{' => escaped.push_str("[{]"),
+                '}' => escaped.push_str("[}]"),
+                _ => escaped.push(character),
+            }
+            escaped
+        },
+    )
+}
+
+pub fn optional_literal(value: Option<&str>) -> String {
+    value.map(|value| literal(value)).unwrap_or_else(missing)
+}
+
+pub fn missing() -> String {
+    MISSING_TOKEN.to_string()
+}
+
+pub fn apply(path: &str, values: &TokenValues) -> String {
+    path.replace("<root>", &values.root)
+        .replace("<base>", &values.base)
+        .replace("<home>", &values.home)
+        .replace("<storeUserId>", "*")
+        .replace("<osUserName>", &values.os_username)
+        .replace("<winAppData>", &values.app_data)
+        .replace("%APPDATA%", &values.app_data)
+        .replace("<winLocalAppData>", &values.local_app_data)
+        .replace("%LOCALAPPDATA%", &values.local_app_data)
+        .replace("<winDocuments>", &values.documents)
+        .replace("<winPublic>", &values.public)
+        .replace("<winProgramData>", &values.program_data)
+        .replace("<winDir>", &values.windows_dir)
+        .replace("<xdgData>", &values.xdg_data)
+        .replace("<xdgConfig>", &values.xdg_config)
+}
+
+pub fn has_unresolved_placeholder(path: &str) -> bool {
+    path.contains('<') || !percent_tokens(path).is_empty()
+}
+
+pub fn uses_windows_profile(path: &str) -> bool {
+    [
+        "<home>",
+        "<winAppData>",
+        "%APPDATA%",
+        "<winLocalAppData>",
+        "%LOCALAPPDATA%",
+        "<winDocuments>",
+        "<winPublic>",
+        "<winProgramData>",
+        "<winDir>",
+    ]
+    .iter()
+    .any(|token| path.contains(token))
+}
+
+fn percent_tokens(path: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let bytes = path.as_bytes();
+    let mut start = 0;
+
+    while start < bytes.len() {
+        if bytes[start] != b'%' {
+            start += 1;
+            continue;
+        }
+
+        let mut end = start + 1;
+        while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+            end += 1;
+        }
+
+        if end > start + 1 && end < bytes.len() && bytes[end] == b'%' {
+            let token = path[start..=end].to_string();
+            if !tokens.contains(&token) {
+                tokens.push(token);
+            }
+            start = end + 1;
+        } else {
+            start += 1;
+        }
+    }
+
+    tokens
+}
+
+pub fn tokens_in_path(path: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut rest = path;
+
+    while let Some(start) = rest.find('<') {
+        let after = &rest[start..];
+        let Some(end) = after.find('>') else {
+            break;
+        };
+
+        let token = &after[..=end];
+        if !tokens.iter().any(|existing| existing == token) {
+            tokens.push(token.to_string());
+        }
+
+        rest = &after[end + 1..];
+    }
+
+    for token in percent_tokens(path) {
+        if !tokens.contains(&token) {
+            tokens.push(token);
+        }
+    }
+
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_and_reports_unknown_percent_tokens() {
+        let path = "%UNKNOWN_HOME%/save/%UNKNOWN_HOME%";
+
+        assert!(has_unresolved_placeholder(path));
+        assert_eq!(tokens_in_path(path), vec!["%UNKNOWN_HOME%"]);
+    }
+
+    #[test]
+    fn ignores_regular_percent_characters() {
+        let path = "100%/save/%UNKNOWN%";
+
+        assert!(has_unresolved_placeholder(path));
+        assert_eq!(tokens_in_path(path), vec!["%UNKNOWN%"]);
+    }
+
+    #[test]
+    fn escapes_braces_in_literal_paths() {
+        assert_eq!(literal("/Games/{Deluxe}"), "/Games/[{]Deluxe[}]");
+    }
+
+    #[test]
+    fn detects_windows_profile_tokens() {
+        assert!(uses_windows_profile("<home>/AppData/LocalLow/Game"));
+        assert!(uses_windows_profile("%LOCALAPPDATA%/Game"));
+        assert!(!uses_windows_profile("<root>/steamapps/common/Game"));
+    }
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/types.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/types.rs
@@ -1,0 +1,60 @@
+use napi_derive::napi;
+
+use crate::cloud_save::manifest::types::{CloudSaveRule, CloudSaveRuleCondition};
+
+#[napi(object)]
+pub struct ResolveSaveRulesInput {
+    pub shop: String,
+    pub object_id: String,
+    pub platform: String,
+    pub home_dir: String,
+    pub documents_dir: Option<String>,
+    pub app_data_dir: Option<String>,
+    pub executable_path: Option<String>,
+    pub wine_prefix_path: Option<String>,
+    pub steam_path: Option<String>,
+    pub rules: Vec<CloudSaveRule>,
+}
+
+pub struct PathResolutionContext {
+    pub shop: String,
+    pub object_id: String,
+    pub platform: String,
+    pub home_dir: String,
+    pub os_username: String,
+    pub documents_dir: Option<String>,
+    pub app_data_dir: Option<String>,
+    pub local_app_data_dir: Option<String>,
+    pub public_dir: Option<String>,
+    pub program_data_dir: Option<String>,
+    pub windows_dir: Option<String>,
+    pub saved_games_dir: Option<String>,
+    pub xdg_data_dir: Option<String>,
+    pub xdg_config_dir: Option<String>,
+    pub install_dir: Option<String>,
+    pub wine_prefix_path: Option<String>,
+    pub windows_compatibility: bool,
+    pub derived_steam_root: Option<String>,
+    pub configured_steam_root: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct ResolvedCloudSavePath {
+    pub path: String,
+    pub case_sensitive: bool,
+    pub dynamic: bool,
+    pub scan_root: Option<String>,
+}
+
+#[napi(object)]
+pub struct ResolvedCloudSaveRule {
+    pub rule_id: String,
+    pub kind: String,
+    pub raw_path: String,
+    pub source: String,
+    pub tags: Vec<String>,
+    pub when: Vec<CloudSaveRuleCondition>,
+    pub resolved_paths: Vec<ResolvedCloudSavePath>,
+    pub unresolved_tokens: Vec<String>,
+}

--- a/native/hydra-native/src/cloud_save/save_scanner/glob.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/glob.rs
@@ -1,0 +1,160 @@
+pub fn normalize_path(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+pub fn has_glob_pattern(path: &str) -> bool {
+    path.contains(['*', '?', '[', '{'])
+}
+
+fn is_escaped(value: &str, index: usize) -> bool {
+    value[..index]
+        .chars()
+        .rev()
+        .take_while(|character| *character == '\\')
+        .count()
+        % 2
+        == 1
+}
+
+fn is_in_character_class(value: &str, index: usize) -> bool {
+    let mut in_class = false;
+    let mut class_has_member = false;
+
+    for (character_index, character) in value.char_indices() {
+        if character_index >= index {
+            break;
+        }
+        if is_escaped(value, character_index) {
+            continue;
+        }
+
+        if in_class {
+            if character == ']' && class_has_member {
+                in_class = false;
+            } else {
+                class_has_member = true;
+            }
+        } else if character == '[' {
+            in_class = true;
+            class_has_member = false;
+        }
+    }
+
+    in_class
+}
+
+fn is_brace_syntax(value: &str, index: usize) -> bool {
+    !is_escaped(value, index) && !is_in_character_class(value, index)
+}
+
+fn matching_brace(pattern: &str, opening: usize) -> Result<usize, String> {
+    let mut depth = 0;
+
+    for (offset, character) in pattern[opening..].char_indices() {
+        let index = opening + offset;
+        if !is_brace_syntax(pattern, index) {
+            continue;
+        }
+
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(index);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Err("cloud_save_invalid_glob: unmatched opening brace".to_string())
+}
+
+fn brace_alternatives(value: &str) -> Vec<&str> {
+    let mut alternatives = Vec::new();
+    let mut start = 0;
+    let mut depth = 0;
+
+    for (index, character) in value.char_indices() {
+        if !is_brace_syntax(value, index) {
+            continue;
+        }
+
+        match character {
+            '{' => depth += 1,
+            '}' => depth -= 1,
+            ',' if depth == 0 => {
+                alternatives.push(&value[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+
+    alternatives.push(&value[start..]);
+    alternatives
+}
+
+pub fn expand_braces(pattern: &str) -> Result<Vec<String>, String> {
+    let opening = pattern
+        .char_indices()
+        .find(|(index, character)| *character == '{' && is_brace_syntax(pattern, *index))
+        .map(|(index, _)| index);
+
+    let Some(opening) = opening else {
+        if pattern
+            .char_indices()
+            .any(|(index, character)| character == '}' && is_brace_syntax(pattern, index))
+        {
+            return Err("cloud_save_invalid_glob: unmatched closing brace".to_string());
+        }
+        return Ok(vec![pattern.to_string()]);
+    };
+
+    let closing = matching_brace(pattern, opening)?;
+    let alternatives = brace_alternatives(&pattern[opening + 1..closing]);
+    if alternatives.len() < 2 {
+        return Err("cloud_save_invalid_glob: brace must contain alternatives".to_string());
+    }
+
+    let mut expanded = Vec::new();
+    for alternative in alternatives {
+        let candidate = format!(
+            "{}{}{}",
+            &pattern[..opening],
+            alternative,
+            &pattern[closing + 1..]
+        );
+        expanded.extend(expand_braces(&candidate)?);
+    }
+
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_nested_braces() {
+        assert_eq!(
+            expand_braces("save/{one,{two,three}}/*.{sav,dat}").unwrap(),
+            vec![
+                "save/one/*.sav",
+                "save/one/*.dat",
+                "save/two/*.sav",
+                "save/two/*.dat",
+                "save/three/*.sav",
+                "save/three/*.dat",
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_literal_braces_in_character_classes() {
+        let pattern = "/Games/[{]Deluxe[}]/save.dat";
+
+        assert_eq!(expand_braces(pattern).unwrap(), vec![pattern]);
+    }
+}

--- a/native/hydra-native/src/cloud_save/save_scanner/glob.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/glob.rs
@@ -97,26 +97,28 @@ fn brace_alternatives(value: &str) -> Vec<&str> {
 }
 
 pub fn expand_braces(pattern: &str) -> Result<Vec<String>, String> {
-    let opening = pattern
-        .char_indices()
-        .find(|(index, character)| *character == '{' && is_brace_syntax(pattern, *index))
-        .map(|(index, _)| index);
-
-    let Some(opening) = opening else {
-        if pattern
-            .char_indices()
-            .any(|(index, character)| character == '}' && is_brace_syntax(pattern, index))
-        {
-            return Err("cloud_save_invalid_glob: unmatched closing brace".to_string());
+    let mut opening = None;
+    let mut closing = None;
+    let mut alternatives = Vec::new();
+    for (index, character) in pattern.char_indices() {
+        if character != '{' || !is_brace_syntax(pattern, index) {
+            continue;
         }
+        let Ok(candidate_closing) = matching_brace(pattern, index) else {
+            continue;
+        };
+        let candidate_alternatives = brace_alternatives(&pattern[index + 1..candidate_closing]);
+        if candidate_alternatives.len() >= 2 {
+            opening = Some(index);
+            closing = Some(candidate_closing);
+            alternatives = candidate_alternatives;
+            break;
+        }
+    }
+
+    let (Some(opening), Some(closing)) = (opening, closing) else {
         return Ok(vec![pattern.to_string()]);
     };
-
-    let closing = matching_brace(pattern, opening)?;
-    let alternatives = brace_alternatives(&pattern[opening + 1..closing]);
-    if alternatives.len() < 2 {
-        return Err("cloud_save_invalid_glob: brace must contain alternatives".to_string());
-    }
 
     let mut expanded = Vec::new();
     for alternative in alternatives {
@@ -156,5 +158,17 @@ mod tests {
         let pattern = "/Games/[{]Deluxe[}]/save.dat";
 
         assert_eq!(expand_braces(pattern).unwrap(), vec![pattern]);
+    }
+
+    #[test]
+    fn preserves_literal_braces_and_expands_later_alternatives() {
+        assert_eq!(
+            expand_braces("save/{random}/*.{sav,dat}").unwrap(),
+            vec!["save/{random}/*.sav", "save/{random}/*.dat"]
+        );
+        assert_eq!(
+            expand_braces("save/{64bitSteamID}/slot.dat").unwrap(),
+            vec!["save/{64bitSteamID}/slot.dat"]
+        );
     }
 }

--- a/native/hydra-native/src/cloud_save/save_scanner/mod.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/mod.rs
@@ -1,0 +1,21 @@
+mod glob;
+mod scan_path;
+mod scan_rules;
+mod types;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+use crate::cloud_save::path_resolution::ResolvedCloudSaveRule;
+
+pub use types::ScannedCloudSaveRule;
+
+#[napi]
+pub async fn scan_resolved_save_rules(
+    rules: Vec<ResolvedCloudSaveRule>,
+) -> napi::Result<Vec<ScannedCloudSaveRule>> {
+    tokio::task::spawn_blocking(move || scan_rules::scan_rules(rules))
+        .await
+        .map_err(|error| Error::from_reason(error.to_string()))?
+        .map_err(Error::from_reason)
+}

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use globetter::MatchOptions;
+use globset::GlobBuilder;
 use walkdir::WalkDir;
 
 use super::glob::{expand_braces, has_glob_pattern, normalize_path};
@@ -34,6 +35,142 @@ fn match_options(case_sensitive: bool, follow_links: bool) -> MatchOptions {
     }
 }
 
+fn can_descend(path: &Path, follow_links: bool) -> Result<bool, String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
+    if metadata.file_type().is_symlink() && !follow_links {
+        return Ok(false);
+    }
+
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_dir())
+        .map_err(|error| format!("cloud_save_filesystem_error: {error}"))
+}
+
+fn component_matches(
+    parent: &Path,
+    pattern: &str,
+    is_last: bool,
+    follow_links: bool,
+) -> Result<Vec<PathBuf>, String> {
+    let has_pattern = pattern.contains(['*', '?', '[']);
+    let exact = parent.join(pattern);
+    if !has_pattern && exact.exists() {
+        if is_last || can_descend(&exact, follow_links)? {
+            return Ok(vec![exact]);
+        }
+        return Ok(Vec::new());
+    }
+
+    let matcher = has_pattern
+        .then(|| {
+            GlobBuilder::new(pattern)
+                .case_insensitive(true)
+                .literal_separator(true)
+                .build()
+                .map(|glob| glob.compile_matcher())
+                .map_err(|error| format!("cloud_save_invalid_glob: {error}"))
+        })
+        .transpose()?;
+    let folded_pattern = (!has_pattern).then(|| pattern.to_lowercase());
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) => {
+            return Ok(Vec::new());
+        }
+        Err(error) => return Err(format!("cloud_save_filesystem_error: {error}")),
+    };
+    let mut matches = Vec::new();
+
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
+        let file_name = entry.file_name();
+        let matches_pattern = if let Some(matcher) = &matcher {
+            matcher.is_match(Path::new(&file_name))
+        } else if let Some(folded_pattern) = &folded_pattern {
+            file_name.to_string_lossy().to_lowercase() == *folded_pattern
+        } else {
+            false
+        };
+        if !matches_pattern {
+            continue;
+        }
+
+        let path = entry.path();
+        if is_last || can_descend(&path, follow_links)? {
+            matches.push(path);
+        }
+    }
+
+    Ok(matches)
+}
+
+fn recursive_components(
+    roots: Vec<PathBuf>,
+    is_last: bool,
+    follow_links: bool,
+) -> Result<Vec<PathBuf>, String> {
+    let mut matches = Vec::new();
+    for root in roots {
+        if !is_last {
+            matches.push(root.clone());
+        }
+        for entry in WalkDir::new(&root)
+            .min_depth(1)
+            .max_depth(MAX_SCAN_DEPTH)
+            .follow_links(follow_links)
+        {
+            let entry = entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
+            if is_last || entry.file_type().is_dir() {
+                matches.push(entry.into_path());
+            }
+        }
+    }
+
+    Ok(matches)
+}
+
+fn case_insensitive_matches(pattern: &str, follow_links: bool) -> Result<Vec<PathBuf>, String> {
+    let mut anchor = PathBuf::new();
+    let mut patterns = Vec::new();
+    for component in Path::new(pattern).components() {
+        match component {
+            Component::Prefix(prefix) => anchor.push(prefix.as_os_str()),
+            Component::RootDir => anchor.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => patterns.push("..".to_string()),
+            Component::Normal(value) => patterns.push(value.to_string_lossy().into_owned()),
+        }
+    }
+    if anchor.as_os_str().is_empty() {
+        anchor.push(".");
+    }
+
+    let mut matches = vec![anchor];
+    for (index, component) in patterns.iter().enumerate() {
+        let is_last = index + 1 == patterns.len();
+        matches = if component == "**" {
+            recursive_components(matches, is_last, follow_links)?
+        } else {
+            let mut next = Vec::new();
+            for parent in matches {
+                next.extend(component_matches(
+                    &parent,
+                    component,
+                    is_last,
+                    follow_links,
+                )?);
+            }
+            next
+        };
+        if matches.is_empty() {
+            break;
+        }
+    }
+
+    Ok(matches)
+}
+
 fn glob_matches(pattern: &str, options: MatchOptions) -> Result<Vec<PathBuf>, String> {
     let direct_path = Path::new(pattern);
     if direct_path.exists() {
@@ -49,10 +186,15 @@ fn glob_matches(pattern: &str, options: MatchOptions) -> Result<Vec<PathBuf>, St
 
     let mut matches = Vec::new();
     for expanded in expand_braces(pattern)? {
-        let entries = globetter::glob_with(&expanded, options)
-            .map_err(|error| format!("cloud_save_invalid_glob: {error}"))?;
-        for entry in entries {
-            matches.push(entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?);
+        if options.case_sensitive {
+            let entries = globetter::glob_with(&expanded, options)
+                .map_err(|error| format!("cloud_save_invalid_glob: {error}"))?;
+            for entry in entries {
+                matches
+                    .push(entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?);
+            }
+        } else {
+            matches.extend(case_insensitive_matches(&expanded, options.follow_links)?);
         }
     }
 
@@ -263,6 +405,15 @@ mod tests {
 
     use super::*;
 
+    fn filesystem_is_case_sensitive(root: &Path) -> bool {
+        let exact = root.join("HydraCaseSensitivityProbe");
+        let different_case = root.join("hydracasesensitivityprobe");
+        fs::write(&exact, b"probe").unwrap();
+        let is_case_sensitive = !different_case.exists();
+        fs::remove_file(exact).unwrap();
+        is_case_sensitive
+    }
+
     #[test]
     fn scans_files_directories_recursive_globs_and_braces() {
         let temp = tempdir().unwrap();
@@ -286,10 +437,12 @@ mod tests {
         assert!(sensitive.is_empty());
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn resolves_a_literal_path_case_insensitively_as_a_fallback() {
         let temp = tempdir().unwrap();
+        if !filesystem_is_case_sensitive(temp.path()) {
+            return;
+        }
         let directory = temp.path().join("Prefix").join("Users").join("SteamUser");
         fs::create_dir_all(&directory).unwrap();
         fs::write(directory.join("Save.DAT"), b"save").unwrap();
@@ -306,6 +459,35 @@ mod tests {
         let sensitive = scan_resolved_path(&requested, true, None).unwrap();
 
         assert_eq!(insensitive[0].files.len(), 1);
+        assert!(sensitive.is_empty());
+    }
+
+    #[test]
+    fn resolves_literal_components_after_wildcards_case_insensitively() {
+        let temp = tempdir().unwrap();
+        if !filesystem_is_case_sensitive(temp.path()) {
+            return;
+        }
+        let directory = temp
+            .path()
+            .join("Prefix")
+            .join("drive_c")
+            .join("users")
+            .join("steamuser")
+            .join("AppData")
+            .join("Roaming")
+            .join("Balatro");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("Save.DAT"), b"save").unwrap();
+
+        let requested = format!(
+            "{}/prefix/drive_*/users/*/appdata/roaming/balatro/*.dat",
+            temp.path().display()
+        );
+        let insensitive = scan_resolved_path(&requested, false, None).unwrap();
+        let sensitive = scan_resolved_path(&requested, true, None).unwrap();
+
+        assert_eq!(insensitive.iter().flat_map(|path| &path.files).count(), 1);
         assert!(sensitive.is_empty());
     }
 

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -71,6 +71,22 @@ fn path_starts_with(path: &Path, root: &Path, case_sensitive: bool) -> bool {
     path == root || path.starts_with(&format!("{}/", root.trim_end_matches('/')))
 }
 
+fn shared_directory_scan_root(
+    matched: &Path,
+    scan_roots: &[PathBuf],
+    case_sensitive: bool,
+) -> Option<(PathBuf, String)> {
+    let root = scan_roots
+        .iter()
+        .filter(|root| root.is_dir() && path_starts_with(matched, root, case_sensitive))
+        .max_by_key(|root| root.components().count())?;
+    let canonical_root = std::fs::canonicalize(root).ok()?;
+    let canonical_matched = std::fs::canonicalize(matched).ok()?;
+    let relative = canonical_matched.strip_prefix(&canonical_root).ok()?;
+
+    Some((canonical_root, normalize_path(&relative.to_string_lossy())))
+}
+
 fn scan_directory(root: &Path, follow_links: bool) -> Result<ScannedCloudSavePath, String> {
     let mut files = Vec::new();
     let traversal_root = std::fs::canonicalize(root)
@@ -176,9 +192,22 @@ pub fn scan_resolved_path_with_capture(
             let mut scanned = scan_directory(&matched, follow_links)?;
             scanned.store_user_id = captured;
             scanned.case_sensitive = case_sensitive;
+            if scanned.store_user_id.is_none() {
+                if let Some((shared_root, relative_root)) =
+                    shared_directory_scan_root(&matched, &scan_roots, case_sensitive)
+                {
+                    if !relative_root.is_empty() {
+                        for file in &mut scanned.files {
+                            file.relative_path = format!("{relative_root}/{}", file.relative_path);
+                        }
+                    }
+                    scanned.resolved_path = canonical_path(&shared_root)?;
+                }
+            }
             scanned.candidate_id = local_id(&[resolved_path, &scanned.resolved_path]);
             scanned_by_root
                 .entry(scanned.resolved_path.clone())
+                .and_modify(|existing| existing.files.extend(scanned.files.iter().cloned()))
                 .or_insert(scanned);
             continue;
         }
@@ -278,7 +307,39 @@ mod tests {
             scan_resolved_path(&pattern, true, Some(&temp.path().display().to_string())).unwrap();
 
         assert_eq!(scanned[0].files.len(), 1);
-        assert_eq!(scanned[0].files[0].relative_path, "save.dat");
+        assert_eq!(scanned[0].files[0].relative_path, "{Deluxe}/save.dat");
+    }
+
+    #[test]
+    fn preserves_every_directory_matched_by_one_glob() {
+        let temp = tempfile::tempdir_in(".").unwrap();
+        let profiles = temp.path().join("Profiles");
+        for profile in ["Profile1", "Profile2"] {
+            let directory = profiles.join(profile);
+            fs::create_dir_all(&directory).unwrap();
+            fs::write(directory.join("slot.dat"), profile.as_bytes()).unwrap();
+        }
+
+        let pattern = profiles.join("Profile*").display().to_string();
+        let scan_root = profiles.display().to_string();
+        assert_eq!(
+            glob_matches(&pattern, match_options(true, true))
+                .unwrap()
+                .len(),
+            2,
+            "pattern: {pattern}"
+        );
+        let scanned = scan_resolved_path(&pattern, true, Some(&scan_root)).unwrap();
+
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(
+            scanned[0]
+                .files
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Profile1/slot.dat", "Profile2/slot.dat"]
+        );
     }
 
     #[test]

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -13,16 +13,37 @@ use crate::cloud_save::path_resolution::capture_store_user;
 
 const MAX_SCAN_DEPTH: usize = 100;
 
+fn filesystem_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+
+    #[cfg(windows)]
+    {
+        path.replace('\\', "/")
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.into_owned()
+    }
+}
+
+fn portable_relative_path(path: &Path) -> String {
+    path.iter()
+        .map(|component| component.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 fn canonical_path(path: &Path) -> Result<String, String> {
     std::fs::canonicalize(path)
         .map_err(|error| format!("cloud_save_filesystem_error: {error}"))
-        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .map(|path| filesystem_path(&path))
 }
 
 fn relative_path(root: &Path, path: &Path) -> Option<String> {
     path.strip_prefix(root)
         .ok()
-        .map(|relative| normalize_path(&relative.to_string_lossy()))
+        .map(portable_relative_path)
         .filter(|relative| !relative.is_empty())
 }
 
@@ -226,7 +247,7 @@ fn shared_directory_scan_root(
     let canonical_matched = std::fs::canonicalize(matched).ok()?;
     let relative = canonical_matched.strip_prefix(&canonical_root).ok()?;
 
-    Some((canonical_root, normalize_path(&relative.to_string_lossy())))
+    Some((canonical_root, portable_relative_path(relative)))
 }
 
 fn scan_directory(root: &Path, follow_links: bool) -> Result<ScannedCloudSavePath, String> {
@@ -277,7 +298,7 @@ fn add_file(
     let relative_path = relative_path(root, file)
         .or_else(|| {
             file.file_name()
-                .map(|name| normalize_path(&name.to_string_lossy()))
+                .map(|name| name.to_string_lossy().into_owned())
         })
         .unwrap_or_default();
 
@@ -513,6 +534,28 @@ mod tests {
 
         assert_eq!(scanned[0].files.len(), 1);
         assert_eq!(scanned[0].files[0].relative_path, "{Deluxe}/save.dat");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_literal_backslashes_in_filesystem_paths() {
+        let temp = tempdir().unwrap();
+        let nested = temp.path().join("save");
+        let backslash = temp.path().join(r"save\slot1.dat");
+        let slash = nested.join("slot1.dat");
+        fs::create_dir(&nested).unwrap();
+        fs::write(&backslash, b"backslash").unwrap();
+        fs::write(&slash, b"slash").unwrap();
+
+        let scanned = scan_resolved_path(&temp.path().display().to_string(), true, None).unwrap();
+        let files = &scanned[0].files;
+
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|file| {
+            file.relative_path == r"save\slot1.dat"
+                && file.absolute_path == backslash.display().to_string()
+        }));
+        assert!(files.iter().any(|file| file.relative_path == "save/slot1.dat"));
     }
 
     #[test]

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -555,7 +555,9 @@ mod tests {
             file.relative_path == r"save\slot1.dat"
                 && file.absolute_path == backslash.display().to_string()
         }));
-        assert!(files.iter().any(|file| file.relative_path == "save/slot1.dat"));
+        assert!(files
+            .iter()
+            .any(|file| file.relative_path == "save/slot1.dat"));
     }
 
     #[test]

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -1,0 +1,381 @@
+use std::collections::BTreeMap;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use globetter::MatchOptions;
+use walkdir::WalkDir;
+
+use super::glob::{expand_braces, has_glob_pattern, normalize_path};
+use super::types::{ScannedCloudSaveFile, ScannedCloudSavePath};
+use crate::cloud_save::identity::local_id;
+use crate::cloud_save::path_resolution::capture_store_user;
+
+const MAX_SCAN_DEPTH: usize = 100;
+
+fn canonical_path(path: &Path) -> Result<String, String> {
+    std::fs::canonicalize(path)
+        .map_err(|error| format!("cloud_save_filesystem_error: {error}"))
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+}
+
+fn relative_path(root: &Path, path: &Path) -> Option<String> {
+    path.strip_prefix(root)
+        .ok()
+        .map(|relative| normalize_path(&relative.to_string_lossy()))
+        .filter(|relative| !relative.is_empty())
+}
+
+fn match_options(case_sensitive: bool, follow_links: bool) -> MatchOptions {
+    MatchOptions {
+        case_sensitive,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+        follow_links,
+    }
+}
+
+fn glob_matches(pattern: &str, options: MatchOptions) -> Result<Vec<PathBuf>, String> {
+    let direct_path = Path::new(pattern);
+    if direct_path.exists() {
+        return Ok(vec![direct_path.to_path_buf()]);
+    }
+    if !has_glob_pattern(pattern) {
+        return match std::fs::metadata(direct_path) {
+            Ok(_) => Ok(vec![direct_path.to_path_buf()]),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(Vec::new()),
+            Err(error) => Err(format!("cloud_save_filesystem_error: {error}")),
+        };
+    }
+
+    let mut matches = Vec::new();
+    for expanded in expand_braces(pattern)? {
+        let entries = globetter::glob_with(&expanded, options)
+            .map_err(|error| format!("cloud_save_invalid_glob: {error}"))?;
+        for entry in entries {
+            matches.push(entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?);
+        }
+    }
+
+    matches.sort_by_key(|path| normalize_path(&path.to_string_lossy()));
+    matches.dedup();
+    Ok(matches)
+}
+
+fn path_starts_with(path: &Path, root: &Path, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        return path.starts_with(root);
+    }
+
+    let path = normalize_path(&path.to_string_lossy()).to_lowercase();
+    let root = normalize_path(&root.to_string_lossy()).to_lowercase();
+    path == root || path.starts_with(&format!("{}/", root.trim_end_matches('/')))
+}
+
+fn scan_directory(root: &Path, follow_links: bool) -> Result<ScannedCloudSavePath, String> {
+    let mut files = Vec::new();
+    let traversal_root = std::fs::canonicalize(root)
+        .map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
+
+    for entry in WalkDir::new(&traversal_root)
+        .max_depth(MAX_SCAN_DEPTH)
+        .follow_links(follow_links)
+    {
+        let entry = entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let Some(relative_path) = relative_path(&traversal_root, entry.path()) else {
+            continue;
+        };
+        files.push(ScannedCloudSaveFile {
+            absolute_path: canonical_path(entry.path())?,
+            relative_path,
+        });
+    }
+
+    files.sort_by(|left, right| {
+        left.relative_path
+            .cmp(&right.relative_path)
+            .then(left.absolute_path.cmp(&right.absolute_path))
+    });
+    files.dedup_by(|left, right| left.absolute_path == right.absolute_path);
+
+    Ok(ScannedCloudSavePath {
+        candidate_id: String::new(),
+        resolved_path: canonical_path(&traversal_root)?,
+        store_user_id: None,
+        case_sensitive: true,
+        files,
+    })
+}
+
+fn add_file(
+    scanned_by_root: &mut BTreeMap<String, ScannedCloudSavePath>,
+    root: &Path,
+    file: &Path,
+) -> Result<(), String> {
+    let resolved_root = canonical_path(root)?;
+    let relative_path = relative_path(root, file)
+        .or_else(|| {
+            file.file_name()
+                .map(|name| normalize_path(&name.to_string_lossy()))
+        })
+        .unwrap_or_default();
+
+    if relative_path.is_empty() {
+        return Ok(());
+    }
+
+    scanned_by_root
+        .entry(resolved_root.clone())
+        .or_insert_with(|| ScannedCloudSavePath {
+            candidate_id: String::new(),
+            resolved_path: resolved_root,
+            store_user_id: None,
+            case_sensitive: true,
+            files: Vec::new(),
+        })
+        .files
+        .push(ScannedCloudSaveFile {
+            absolute_path: canonical_path(file)?,
+            relative_path,
+        });
+
+    Ok(())
+}
+
+pub fn scan_resolved_path_with_capture(
+    resolved_path: &str,
+    case_sensitive: bool,
+    scan_root_pattern: Option<&str>,
+    capture_template: Option<&str>,
+    follow_links: bool,
+) -> Result<Vec<ScannedCloudSavePath>, String> {
+    let options = match_options(case_sensitive, follow_links);
+    let matches = glob_matches(resolved_path, options)?;
+    let scan_roots = scan_root_pattern
+        .map(|pattern| glob_matches(pattern, options))
+        .transpose()?
+        .unwrap_or_default();
+    let mut scanned_by_root = BTreeMap::<String, ScannedCloudSavePath>::new();
+
+    for matched in matches {
+        let concrete = normalize_path(&matched.to_string_lossy());
+        let captured = match capture_template {
+            Some(template) => match capture_store_user(template, &concrete, case_sensitive) {
+                Some(value) => Some(value),
+                None => continue,
+            },
+            None => None,
+        };
+        let metadata = std::fs::metadata(&matched)
+            .map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
+
+        if metadata.is_dir() {
+            let mut scanned = scan_directory(&matched, follow_links)?;
+            scanned.store_user_id = captured;
+            scanned.case_sensitive = case_sensitive;
+            scanned.candidate_id = local_id(&[resolved_path, &scanned.resolved_path]);
+            scanned_by_root
+                .entry(scanned.resolved_path.clone())
+                .or_insert(scanned);
+            continue;
+        }
+
+        if metadata.is_file() {
+            let root = scan_roots
+                .iter()
+                .filter(|root| root.is_dir() && path_starts_with(&matched, root, case_sensitive))
+                .max_by_key(|root| root.components().count())
+                .map(PathBuf::as_path)
+                .or_else(|| matched.parent());
+
+            if let Some(root) = root {
+                add_file(&mut scanned_by_root, root, &matched)?;
+                let resolved_root = canonical_path(root)?;
+                if let Some(scanned) = scanned_by_root.get_mut(&resolved_root) {
+                    scanned.store_user_id = captured;
+                    scanned.case_sensitive = case_sensitive;
+                    scanned.candidate_id = local_id(&[resolved_path, &resolved_root]);
+                }
+            }
+        }
+    }
+
+    for scanned in scanned_by_root.values_mut() {
+        scanned.files.sort_by(|left, right| {
+            left.relative_path
+                .cmp(&right.relative_path)
+                .then(left.absolute_path.cmp(&right.absolute_path))
+        });
+        scanned
+            .files
+            .dedup_by(|left, right| left.absolute_path == right.absolute_path);
+    }
+
+    Ok(scanned_by_root.into_values().collect())
+}
+
+#[cfg(test)]
+pub fn scan_resolved_path(
+    resolved_path: &str,
+    case_sensitive: bool,
+    scan_root_pattern: Option<&str>,
+) -> Result<Vec<ScannedCloudSavePath>, String> {
+    scan_resolved_path_with_capture(resolved_path, case_sensitive, scan_root_pattern, None, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn scans_files_directories_recursive_globs_and_braces() {
+        let temp = tempdir().unwrap();
+        let nested = temp.path().join("Saves/Profile");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("slot.SAV"), b"save").unwrap();
+        fs::write(nested.join("meta.dat"), b"meta").unwrap();
+
+        let exact =
+            scan_resolved_path(&nested.join("slot.SAV").display().to_string(), true, None).unwrap();
+        let directory = scan_resolved_path(&nested.display().to_string(), true, None).unwrap();
+        let pattern = format!("{}/saves/**/*.{{sav,dat}}", temp.path().display());
+        let insensitive =
+            scan_resolved_path(&pattern, false, Some(&temp.path().display().to_string())).unwrap();
+        let sensitive =
+            scan_resolved_path(&pattern, true, Some(&temp.path().display().to_string())).unwrap();
+
+        assert_eq!(exact[0].files.len(), 1);
+        assert_eq!(directory[0].files.len(), 2);
+        assert_eq!(insensitive.iter().flat_map(|path| &path.files).count(), 2);
+        assert!(sensitive.is_empty());
+    }
+
+    #[test]
+    fn missing_path_is_empty_and_invalid_pattern_fails() {
+        let missing = scan_resolved_path("/missing/cloud-save/path", true, None).unwrap();
+        let invalid = scan_resolved_path("/tmp/[invalid", true, None).unwrap_err();
+
+        assert!(missing.is_empty());
+        assert!(invalid.starts_with("cloud_save_invalid_glob:"));
+    }
+
+    #[test]
+    fn scans_paths_with_literal_braces() {
+        let temp = tempdir().unwrap();
+        let directory = temp.path().join("{Deluxe}");
+        fs::create_dir(&directory).unwrap();
+        fs::write(directory.join("save.dat"), b"save").unwrap();
+        let pattern = directory.display().to_string();
+
+        let scanned =
+            scan_resolved_path(&pattern, true, Some(&temp.path().display().to_string())).unwrap();
+
+        assert_eq!(scanned[0].files.len(), 1);
+        assert_eq!(scanned[0].files[0].relative_path, "save.dat");
+    }
+
+    #[test]
+    fn limits_recursive_scans_to_one_hundred_levels() {
+        let temp = tempdir().unwrap();
+        let mut current = temp.path().to_path_buf();
+
+        for depth in 1..=101 {
+            current.push(depth.to_string());
+            fs::create_dir(&current).unwrap();
+            fs::write(current.join(format!("{depth}.sav")), b"save").unwrap();
+        }
+
+        let scanned = scan_resolved_path(&temp.path().display().to_string(), true, None).unwrap();
+        let files = &scanned[0].files;
+
+        assert_eq!(files.len(), 99);
+        assert!(files
+            .iter()
+            .any(|file| file.relative_path.ends_with("99.sav")));
+        assert!(!files
+            .iter()
+            .any(|file| file.relative_path.ends_with("100.sav")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn can_refuse_symlinks_that_leave_a_custom_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("custom");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("save.dat"), b"save").unwrap();
+        symlink(&outside, root.join("linked")).unwrap();
+
+        let scanned =
+            scan_resolved_path_with_capture(&root.display().to_string(), true, None, None, false)
+                .unwrap();
+
+        assert!(scanned[0].files.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn traverses_a_custom_root_that_is_itself_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let real = temp.path().join("real");
+        let linked = temp.path().join("linked");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("save.dat"), b"save").unwrap();
+        symlink(&real, &linked).unwrap();
+
+        let scanned =
+            scan_resolved_path_with_capture(&linked.display().to_string(), true, None, None, false)
+                .unwrap();
+
+        assert_eq!(scanned[0].files.len(), 1);
+        assert_eq!(scanned[0].files[0].relative_path, "save.dat");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn follows_directory_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let real = temp.path().join("real");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("save.dat"), b"save").unwrap();
+        let linked = temp.path().join("linked");
+        symlink(&real, &linked).unwrap();
+
+        let scanned = scan_resolved_path(&linked.display().to_string(), true, None).unwrap();
+
+        assert_eq!(scanned[0].files.len(), 1);
+        assert_eq!(scanned[0].files[0].relative_path, "save.dat");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deduplicates_a_file_reached_through_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("root");
+        let real = root.join("real");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("save.dat"), b"save").unwrap();
+        symlink(&real, root.join("linked")).unwrap();
+
+        let scanned = scan_resolved_path(&root.display().to_string(), true, None).unwrap();
+
+        assert_eq!(scanned[0].files.len(), 1);
+    }
+}

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -39,7 +39,7 @@ fn glob_matches(pattern: &str, options: MatchOptions) -> Result<Vec<PathBuf>, St
     if direct_path.exists() {
         return Ok(vec![direct_path.to_path_buf()]);
     }
-    if !has_glob_pattern(pattern) {
+    if !has_glob_pattern(pattern) && options.case_sensitive {
         return match std::fs::metadata(direct_path) {
             Ok(_) => Ok(vec![direct_path.to_path_buf()]),
             Err(error) if error.kind() == ErrorKind::NotFound => Ok(Vec::new()),
@@ -283,6 +283,29 @@ mod tests {
         assert_eq!(exact[0].files.len(), 1);
         assert_eq!(directory[0].files.len(), 2);
         assert_eq!(insensitive.iter().flat_map(|path| &path.files).count(), 2);
+        assert!(sensitive.is_empty());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn resolves_a_literal_path_case_insensitively_as_a_fallback() {
+        let temp = tempdir().unwrap();
+        let directory = temp.path().join("Prefix").join("Users").join("SteamUser");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("Save.DAT"), b"save").unwrap();
+
+        let requested = temp
+            .path()
+            .join("prefix")
+            .join("users")
+            .join("steamuser")
+            .join("save.dat")
+            .display()
+            .to_string();
+        let insensitive = scan_resolved_path(&requested, false, None).unwrap();
+        let sensitive = scan_resolved_path(&requested, true, None).unwrap();
+
+        assert_eq!(insensitive[0].files.len(), 1);
         assert!(sensitive.is_empty());
     }
 

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_rules.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_rules.rs
@@ -1,0 +1,608 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::cloud_save::identity::{local_id, UserLocationCoverage};
+use crate::cloud_save::path_resolution::{capture_template, ResolvedCloudSaveRule};
+
+use super::scan_path::scan_resolved_path_with_capture;
+use super::types::{ScannedCloudSavePath, ScannedCloudSaveRule};
+
+pub fn scan_rules(rules: Vec<ResolvedCloudSaveRule>) -> Result<Vec<ScannedCloudSaveRule>, String> {
+    rules
+        .into_iter()
+        .map(|rule| {
+            let mut selected_paths = Vec::<ScannedCloudSavePath>::new();
+            let mut coverage = Vec::<UserLocationCoverage>::new();
+            let user_bound = rule.raw_path.contains("<storeUserId>");
+
+            if rule.unresolved_tokens.is_empty() {
+                for candidate in &rule.resolved_paths {
+                    let template = capture_template(&rule.raw_path, &candidate.path);
+                    let mut scanned_paths = match scan_resolved_path_with_capture(
+                        &candidate.path,
+                        candidate.case_sensitive,
+                        candidate.scan_root.as_deref(),
+                        template.as_deref(),
+                        !rule.raw_path.starts_with("<custom>"),
+                    ) {
+                        Ok(paths) => paths,
+                        Err(error) => {
+                            coverage.push(UserLocationCoverage {
+                                candidate_id: local_id(&[&candidate.path]),
+                                rule_id: rule.rule_id.clone(),
+                                variant_id: None,
+                                raw_path: Some(rule.raw_path.clone()),
+                                relative_path: None,
+                                selected_root: false,
+                                authority: "inferred".to_string(),
+                                outcome: "failed".to_string(),
+                                enumerated_completely: false,
+                                warning_codes: vec![error
+                                    .split(':')
+                                    .next()
+                                    .unwrap_or("cloud_save_filesystem_error")
+                                    .to_string()],
+                            });
+                            continue;
+                        }
+                    };
+                    if scanned_paths.is_empty() && rule.kind == "file" {
+                        let existing_root = candidate
+                            .scan_root
+                            .as_deref()
+                            .map(Path::new)
+                            .filter(|path| path.is_dir())
+                            .or_else(|| {
+                                Path::new(&candidate.path)
+                                    .parent()
+                                    .filter(|path| path.is_dir())
+                            });
+                        if let Some(root) = existing_root {
+                            if let Ok(root) = std::fs::canonicalize(root) {
+                                let resolved_path = root.to_string_lossy().replace('\\', "/");
+                                scanned_paths.push(ScannedCloudSavePath {
+                                    candidate_id: local_id(&[&candidate.path, &resolved_path]),
+                                    resolved_path,
+                                    store_user_id: None,
+                                    case_sensitive: candidate.case_sensitive,
+                                    files: vec![],
+                                });
+                            }
+                        }
+                    }
+                    let shared_scan_root = candidate.scan_root.as_deref().and_then(|root| {
+                        std::fs::canonicalize(root)
+                            .ok()
+                            .map(|root| root.to_string_lossy().replace('\\', "/"))
+                    });
+                    if scanned_paths.is_empty() {
+                        coverage.push(UserLocationCoverage {
+                            candidate_id: local_id(&[&candidate.path]),
+                            rule_id: rule.rule_id.clone(),
+                            variant_id: None,
+                            raw_path: Some(rule.raw_path.clone()),
+                            relative_path: None,
+                            selected_root: false,
+                            authority: "inferred".to_string(),
+                            outcome: "confirmed-missing".to_string(),
+                            enumerated_completely: true,
+                            warning_codes: vec![],
+                        });
+                    }
+                    let mut selected_concrete_root = false;
+                    let mut candidate_selected_paths = Vec::new();
+                    let candidate_has_files = scanned_paths
+                        .iter()
+                        .any(|scanned| !scanned.files.is_empty());
+                    if !user_bound && candidate_has_files {
+                        for item in &mut coverage {
+                            item.selected_root = false;
+                        }
+                        selected_paths.clear();
+                    }
+                    for scanned in &scanned_paths {
+                        let is_shared_scan_root = shared_scan_root
+                            .as_ref()
+                            .is_some_and(|root| root == &scanned.resolved_path);
+                        let selected_root = if user_bound {
+                            !is_shared_scan_root && scanned.store_user_id.is_some()
+                        } else if !selected_paths.is_empty() && !candidate_has_files {
+                            false
+                        } else {
+                            is_shared_scan_root || !selected_concrete_root
+                        };
+                        if selected_root && !is_shared_scan_root {
+                            selected_concrete_root = true;
+                        }
+                        coverage.push(UserLocationCoverage {
+                            candidate_id: scanned.candidate_id.clone(),
+                            rule_id: rule.rule_id.clone(),
+                            variant_id: None,
+                            raw_path: Some(rule.raw_path.clone()),
+                            relative_path: None,
+                            selected_root,
+                            authority: "inferred".to_string(),
+                            outcome: "scanned".to_string(),
+                            enumerated_completely: true,
+                            warning_codes: vec![],
+                        });
+
+                        if selected_root {
+                            candidate_selected_paths.push(scanned.clone());
+                        }
+                    }
+                    selected_paths.extend(candidate_selected_paths);
+
+                    if !user_bound && candidate_has_files {
+                        let mut seen_absolute_paths = HashSet::new();
+                        let mut seen_relative_paths = HashSet::new();
+                        for scanned in &mut selected_paths {
+                            scanned.files.retain(|file| {
+                                seen_absolute_paths.insert(file.absolute_path.clone())
+                                    && seen_relative_paths.insert(file.relative_path.clone())
+                            });
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if user_bound {
+                let mut seen = HashSet::new();
+                for scanned in &mut selected_paths {
+                    scanned.files.retain(|file| {
+                        seen.insert((scanned.store_user_id.clone(), file.absolute_path.clone()))
+                    });
+                }
+                selected_paths.sort_by(|left, right| {
+                    left.store_user_id
+                        .cmp(&right.store_user_id)
+                        .then_with(|| left.resolved_path.cmp(&right.resolved_path))
+                });
+                selected_paths.dedup_by(|left, right| {
+                    left.store_user_id == right.store_user_id
+                        && left.resolved_path == right.resolved_path
+                });
+            }
+
+            Ok(ScannedCloudSaveRule {
+                rule_id: rule.rule_id,
+                kind: rule.kind,
+                raw_path: rule.raw_path,
+                source: rule.source,
+                tags: rule.tags,
+                when: rule.when,
+                resolved_paths: rule.resolved_paths,
+                unresolved_tokens: rule.unresolved_tokens,
+                scanned_paths: selected_paths,
+                coverage,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::cloud_save::manifest::types::CloudSaveRule;
+    use crate::cloud_save::path_resolution::{
+        resolve_save_rules, ResolveSaveRulesInput, ResolvedCloudSavePath,
+    };
+
+    fn resolve(prefix: &std::path::Path, raw_path: &str) -> Vec<ResolvedCloudSaveRule> {
+        resolve_save_rules(ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "1888930".into(),
+            platform: "linux".into(),
+            home_dir: "/home/victor".into(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: Some("/games/TLOU/tlou-i.exe".into()),
+            wine_prefix_path: Some(prefix.display().to_string()),
+            steam_path: None,
+            rules: vec![CloudSaveRule {
+                rule_id: "test-rule".into(),
+                kind: "dir".into(),
+                raw_path: raw_path.into(),
+                source: "ludusavi".into(),
+                tags: vec!["save".into()],
+                when: vec![],
+                preferred_path: None,
+            }],
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn preserves_same_relative_file_across_store_users() {
+        let temp = tempdir().unwrap();
+        for user in ["Goldberg", "Rune"] {
+            let root = temp.path().join(format!(
+                "drive_c/users/steamuser/Saved Games/The Last of Us Part I/users/{user}/savedata"
+            ));
+            fs::create_dir_all(&root).unwrap();
+            fs::write(root.join("slot.dat"), user.as_bytes()).unwrap();
+        }
+
+        let scanned = scan_rules(resolve(
+            temp.path(),
+            "<home>/Saved Games/The Last of Us Part I/users/<storeUserId>/savedata",
+        ))
+        .unwrap();
+
+        assert_eq!(scanned[0].scanned_paths.len(), 2);
+        assert_eq!(
+            scanned[0]
+                .scanned_paths
+                .iter()
+                .flat_map(|path| &path.files)
+                .count(),
+            2
+        );
+        let users = scanned[0]
+            .scanned_paths
+            .iter()
+            .filter_map(|path| path.store_user_id.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(users, vec!["Goldberg", "Rune"]);
+    }
+
+    #[test]
+    fn preserves_selected_empty_store_user_roots_as_complete_coverage() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().join(
+            "drive_c/users/steamuser/Saved Games/The Last of Us Part I/users/Goldberg/savedata",
+        );
+        fs::create_dir_all(&root).unwrap();
+
+        let scanned = scan_rules(resolve(
+            temp.path(),
+            "<home>/Saved Games/The Last of Us Part I/users/<storeUserId>/savedata",
+        ))
+        .unwrap();
+
+        assert_eq!(scanned[0].scanned_paths.len(), 1);
+        assert!(scanned[0].scanned_paths[0].files.is_empty());
+        assert_eq!(
+            scanned[0].scanned_paths[0].store_user_id.as_deref(),
+            Some("Goldberg")
+        );
+        assert!(scanned[0].coverage.iter().any(|coverage| {
+            coverage.selected_root
+                && coverage.outcome == "scanned"
+                && coverage.enumerated_completely
+        }));
+    }
+
+    #[test]
+    fn proves_an_exact_file_is_absent_when_its_parent_was_enumerated() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("game");
+        fs::create_dir_all(&root).unwrap();
+        let rules = resolve_save_rules(ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "1".into(),
+            platform: "linux".into(),
+            home_dir: temp.path().display().to_string(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            rules: vec![CloudSaveRule {
+                rule_id: "file-rule".into(),
+                kind: "file".into(),
+                raw_path: "<home>/game/slot.sav".into(),
+                source: "test".into(),
+                tags: vec!["save".into()],
+                when: vec![],
+                preferred_path: None,
+            }],
+        })
+        .unwrap();
+
+        let scanned = scan_rules(rules).unwrap();
+
+        assert_eq!(scanned[0].scanned_paths.len(), 1);
+        assert!(scanned[0].scanned_paths[0].files.is_empty());
+        assert!(scanned[0].coverage.iter().any(|coverage| {
+            coverage.selected_root
+                && coverage.outcome == "scanned"
+                && coverage.enumerated_completely
+        }));
+    }
+
+    #[test]
+    fn does_not_mix_different_logical_files_across_store_users() {
+        let temp = tempdir().unwrap();
+        for (user, file) in [("Goldberg", "slot.dat"), ("Rune", "profile.dat")] {
+            let root = temp.path().join(format!(
+                "drive_c/users/steamuser/Saved Games/The Last of Us Part I/users/{user}/savedata"
+            ));
+            fs::create_dir_all(&root).unwrap();
+            fs::write(root.join(file), user.as_bytes()).unwrap();
+        }
+
+        let scanned = scan_rules(resolve(
+            temp.path(),
+            "<home>/Saved Games/The Last of Us Part I/users/<storeUserId>/savedata",
+        ))
+        .unwrap();
+
+        let paths = &scanned[0].scanned_paths;
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].files.len(), 1);
+        assert_eq!(paths[1].files.len(), 1);
+        assert_eq!(paths[0].store_user_id.as_deref(), Some("Goldberg"));
+        assert_eq!(paths[1].store_user_id.as_deref(), Some("Rune"));
+        assert_eq!(paths[0].files[0].relative_path, "slot.dat");
+        assert_eq!(paths[1].files[0].relative_path, "profile.dat");
+    }
+
+    #[test]
+    fn prefers_modern_windows_aliases() {
+        let temp = tempdir().unwrap();
+        let cases = [
+            ("<winDocuments>/Docs", "Documents/Docs", "My Documents/Docs"),
+            (
+                "<winAppData>/Roaming",
+                "AppData/Roaming/Roaming",
+                "Application Data/Roaming",
+            ),
+            (
+                "<winLocalAppData>/Local",
+                "AppData/Local/Local",
+                "Local Settings/Application Data/Local",
+            ),
+        ];
+
+        for (raw_path, modern, legacy) in cases {
+            let user = temp.path().join("drive_c/users/steamuser");
+            fs::create_dir_all(user.join(modern)).unwrap();
+            fs::create_dir_all(user.join(legacy)).unwrap();
+            fs::write(user.join(modern).join("save.dat"), b"modern").unwrap();
+            fs::write(user.join(legacy).join("save.dat"), b"legacy").unwrap();
+
+            let scanned = scan_rules(resolve(temp.path(), raw_path)).unwrap();
+            let files = scanned[0]
+                .scanned_paths
+                .iter()
+                .flat_map(|path| &path.files)
+                .collect::<Vec<_>>();
+
+            assert_eq!(files.len(), 1);
+            assert!(files[0].absolute_path.contains(modern));
+        }
+    }
+
+    #[test]
+    fn active_root_wins_without_mixing_fallback_files() {
+        let temp = tempdir().unwrap();
+        let active = temp.path().join("active");
+        let fallback = temp.path().join("fallback");
+        fs::create_dir_all(&active).unwrap();
+        fs::create_dir_all(&fallback).unwrap();
+        fs::write(active.join("save.dat"), b"active").unwrap();
+        fs::write(fallback.join("save.dat"), b"fallback").unwrap();
+        fs::write(fallback.join("extra.dat"), b"fallback-only").unwrap();
+
+        let scanned = scan_rules(vec![ResolvedCloudSaveRule {
+            rule_id: "test-rule".into(),
+            kind: "dir".into(),
+            raw_path: "<winAppData>/Game".into(),
+            source: "test".into(),
+            tags: vec!["save".into()],
+            when: vec![],
+            resolved_paths: vec![
+                ResolvedCloudSavePath {
+                    path: active.display().to_string(),
+                    case_sensitive: true,
+                    dynamic: false,
+                    scan_root: None,
+                },
+                ResolvedCloudSavePath {
+                    path: fallback.display().to_string(),
+                    case_sensitive: true,
+                    dynamic: false,
+                    scan_root: None,
+                },
+            ],
+            unresolved_tokens: vec![],
+        }])
+        .unwrap();
+        let files = &scanned[0].scanned_paths[0].files;
+        let active = fs::canonicalize(active)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        assert_eq!(files.len(), 1);
+        assert!(files[0].absolute_path.starts_with(&active));
+    }
+
+    #[test]
+    fn scans_hydra_launcher_prefix_without_mixing_steam_compatdata() {
+        let temp = tempdir().unwrap();
+        let steam_root = temp.path().join("SteamLibrary");
+        let executable = steam_root.join("steamapps/common/Cyberpunk 2077/game.exe");
+        let proton_save = steam_root.join(
+            "steamapps/compatdata/1091500/pfx/drive_c/users/steamuser/AppData/Local/CD Projekt Red/Cyberpunk 2077",
+        );
+        let hydra_prefix = temp.path().join("hydra-prefix");
+        let hydra_save = hydra_prefix
+            .join("drive_c/users/steamuser/AppData/Local/CD Projekt Red/Cyberpunk 2077");
+        fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        fs::write(&executable, b"exe").unwrap();
+        fs::create_dir_all(&proton_save).unwrap();
+        fs::create_dir_all(&hydra_save).unwrap();
+        fs::write(proton_save.join("UserSettings.json"), b"steam-old").unwrap();
+        fs::write(hydra_save.join("UserSettings.json"), b"hydra-active").unwrap();
+
+        let rules = resolve_save_rules(ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "1091500".into(),
+            platform: "linux".into(),
+            home_dir: "/home/victor".into(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: Some(executable.display().to_string()),
+            wine_prefix_path: Some(hydra_prefix.display().to_string()),
+            steam_path: None,
+            rules: vec![CloudSaveRule {
+                rule_id: "test-rule".into(),
+                kind: "dir".into(),
+                raw_path: "<winLocalAppData>/CD Projekt Red/Cyberpunk 2077".into(),
+                source: "ludusavi".into(),
+                tags: vec!["save".into()],
+                when: vec![],
+                preferred_path: None,
+            }],
+        })
+        .unwrap();
+
+        let scanned = scan_rules(rules).unwrap();
+        let files = scanned[0]
+            .scanned_paths
+            .iter()
+            .flat_map(|path| &path.files)
+            .collect::<Vec<_>>();
+
+        assert_eq!(files.len(), 1);
+        assert!(files[0].absolute_path.starts_with(
+            &fs::canonicalize(hydra_prefix)
+                .unwrap()
+                .display()
+                .to_string()
+                .replace('\\', "/")
+        ));
+        assert!(!files[0].absolute_path.contains("/compatdata/"));
+    }
+
+    #[test]
+    fn active_empty_prefix_does_not_fall_back_to_host_home() {
+        let temp = tempdir().unwrap();
+        let active_prefix = temp.path().join("hydralauncher/wine-prefixes/953490");
+        let active_profile = active_prefix.join("drive_c/users/steamuser");
+        let old_home = temp.path().join("old-prefix/drive_c/users/steamuser");
+        let old_save = old_home.join("AppData/LocalLow/Phobia/Carrion");
+        fs::create_dir_all(&active_profile).unwrap();
+        fs::create_dir_all(&old_save).unwrap();
+        fs::write(old_save.join("settings.json"), b"old").unwrap();
+
+        let rules = resolve_save_rules(ResolveSaveRulesInput {
+            shop: "steam".into(),
+            object_id: "953490".into(),
+            platform: "linux".into(),
+            home_dir: old_home.display().to_string(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: Some("/games/Carrion/Carrion.exe".into()),
+            wine_prefix_path: Some(active_prefix.display().to_string()),
+            steam_path: None,
+            rules: vec![CloudSaveRule {
+                rule_id: "test-rule".into(),
+                kind: "dir".into(),
+                raw_path: "<home>/AppData/LocalLow/Phobia/Carrion".into(),
+                source: "ludusavi".into(),
+                tags: vec!["save".into()],
+                when: vec![],
+                preferred_path: None,
+            }],
+        })
+        .unwrap();
+
+        let scanned = scan_rules(rules).unwrap();
+
+        assert!(scanned[0].scanned_paths.is_empty());
+        let active_prefix = active_prefix.display().to_string().replace('\\', "/");
+        assert!(scanned[0]
+            .resolved_paths
+            .iter()
+            .all(|candidate| candidate.path.starts_with(&active_prefix)));
+    }
+
+    #[test]
+    fn scans_elden_ring_file_and_user_directory() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("EldenRing");
+        let user = root.join("76561198000000000");
+        fs::create_dir_all(&user).unwrap();
+        fs::write(root.join("GraphicsConfig.xml"), b"config").unwrap();
+        fs::write(user.join("ER0000.sl2"), b"save").unwrap();
+
+        let scanned = scan_rules(vec![ResolvedCloudSaveRule {
+            rule_id: "test-rule".into(),
+            kind: "dir".into(),
+            raw_path: "<winAppData>/EldenRing/<storeUserId>".into(),
+            source: "ludusavi".into(),
+            tags: vec!["save".into()],
+            when: vec![],
+            resolved_paths: vec![ResolvedCloudSavePath {
+                path: format!("{}/*", root.display()),
+                case_sensitive: false,
+                dynamic: true,
+                scan_root: Some(root.display().to_string()),
+            }],
+            unresolved_tokens: vec![],
+        }])
+        .unwrap();
+
+        let files = scanned[0]
+            .scanned_paths
+            .iter()
+            .flat_map(|path| &path.files)
+            .map(|file| file.absolute_path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(files.len(), 1);
+        assert!(files.iter().any(|path| path.ends_with("ER0000.sl2")));
+    }
+
+    #[test]
+    fn unresolved_rule_returns_empty_scan() {
+        let scanned = scan_rules(vec![ResolvedCloudSaveRule {
+            rule_id: "test-rule".into(),
+            kind: "dir".into(),
+            raw_path: "<unknown>/save".into(),
+            source: "ludusavi".into(),
+            tags: vec!["save".into()],
+            when: vec![],
+            resolved_paths: vec![],
+            unresolved_tokens: vec!["<unknown>".into()],
+        }])
+        .unwrap();
+
+        assert!(scanned[0].scanned_paths.is_empty());
+    }
+
+    #[test]
+    fn deduplicates_overlapping_paths_within_a_rule() {
+        let temp = tempdir().unwrap();
+        fs::write(temp.path().join("save.dat"), b"save").unwrap();
+        let candidate = ResolvedCloudSavePath {
+            path: temp.path().display().to_string(),
+            case_sensitive: true,
+            dynamic: false,
+            scan_root: None,
+        };
+
+        let scanned = scan_rules(vec![ResolvedCloudSaveRule {
+            rule_id: "test-rule".into(),
+            kind: "file".into(),
+            raw_path: "ignored-kind".into(),
+            source: "ludusavi".into(),
+            tags: vec!["save".into()],
+            when: vec![],
+            resolved_paths: vec![candidate.clone(), candidate],
+            unresolved_tokens: vec![],
+        }])
+        .unwrap();
+
+        assert_eq!(scanned[0].scanned_paths.len(), 1);
+        assert_eq!(scanned[0].scanned_paths[0].files.len(), 1);
+    }
+}

--- a/native/hydra-native/src/cloud_save/save_scanner/types.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/types.rs
@@ -1,0 +1,37 @@
+use napi_derive::napi;
+
+use crate::cloud_save::identity::UserLocationCoverage;
+use crate::cloud_save::manifest::types::CloudSaveRuleCondition;
+use crate::cloud_save::path_resolution::ResolvedCloudSavePath;
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct ScannedCloudSaveFile {
+    pub absolute_path: String,
+    pub relative_path: String,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct ScannedCloudSavePath {
+    pub candidate_id: String,
+    pub resolved_path: String,
+    pub store_user_id: Option<String>,
+    pub case_sensitive: bool,
+    pub files: Vec<ScannedCloudSaveFile>,
+}
+
+#[napi(object)]
+#[derive(Debug)]
+pub struct ScannedCloudSaveRule {
+    pub rule_id: String,
+    pub kind: String,
+    pub raw_path: String,
+    pub source: String,
+    pub tags: Vec<String>,
+    pub when: Vec<CloudSaveRuleCondition>,
+    pub resolved_paths: Vec<ResolvedCloudSavePath>,
+    pub unresolved_tokens: Vec<String>,
+    pub scanned_paths: Vec<ScannedCloudSavePath>,
+    pub coverage: Vec<UserLocationCoverage>,
+}

--- a/native/hydra-native/src/constants.rs
+++ b/native/hydra-native/src/constants.rs
@@ -1,0 +1,1 @@
+pub(crate) const MANIFEST_INDEX_VERSION: u8 = 1;

--- a/native/hydra-native/src/lib.rs
+++ b/native/hydra-native/src/lib.rs
@@ -1,3 +1,10 @@
+mod cloud_save;
+mod constants;
+
+pub use cloud_save::manifest::get_save_rules_for_game;
+pub use cloud_save::path_resolution::resolve_save_rules;
+pub use cloud_save::save_scanner::scan_resolved_save_rules;
+
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
@@ -297,7 +304,8 @@ fn encode_animation_frames_to_gif<I>(
 where
     I: IntoIterator<Item = ImageResult<Frame>>,
 {
-    let output_file = File::create(output_path).map_err(|err| Error::from_reason(err.to_string()))?;
+    let output_file =
+        File::create(output_path).map_err(|err| Error::from_reason(err.to_string()))?;
     let mut encoder = GifEncoder::new(BufWriter::new(output_file));
     encoder
         .set_repeat(Repeat::Infinite)
@@ -350,12 +358,7 @@ fn resize_cover_rgba(image: &RgbaImage, width: u32, height: u32) -> napi::Result
 
     let resized_width = ((source_width as f32 * scale).ceil() as u32).max(width);
     let resized_height = ((source_height as f32 * scale).ceil() as u32).max(height);
-    let resized = resize(
-        image,
-        resized_width,
-        resized_height,
-        FilterType::Lanczos3,
-    );
+    let resized = resize(image, resized_width, resized_height, FilterType::Lanczos3);
 
     let left = (resized_width.saturating_sub(width)) / 2;
     let top = (resized_height.saturating_sub(height)) / 2;


### PR DESCRIPTION
## Summary

- add native cloud-save manifest downloading, caching, and indexing
- resolve cross-platform save paths and custom paths
- scan resolved rules and expose the native APIs through N-API

## Context

This is the first independent slice extracted from the final Cloud Saves V2 implementation and rebased onto the latest `main`. Follow-up PRs will build the snapshot, upload, restore, and UI layers on top of it.

## Validation

- `cargo fmt -- --check`
- `cargo check`
- `cargo test --lib` (42 passed)

**When submitting this pull request, I confirm the following:**

- [ ] I have read the Hydra documentation.
- [ ] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
