### PR TITLE
feat(cloud-save): add native snapshot building

### DIFF
--- a/native/hydra-native/Cargo.lock
+++ b/native/hydra-native/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "unicode-normalization",
  "uuid",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/native/hydra-native/Cargo.lock
+++ b/native/hydra-native/Cargo.lock
@@ -268,6 +268,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +317,15 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -334,6 +368,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encoding_rs"
@@ -668,6 +708,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "rayon",
  "reqwest",
  "serde",
  "serde_json",
@@ -675,6 +716,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tempfile",
+ "time",
  "tokio",
  "unicode-normalization",
  "uuid",
@@ -1154,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1280,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -1360,6 +1414,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1833,6 +1907,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/native/hydra-native/Cargo.toml
+++ b/native/hydra-native/Cargo.toml
@@ -16,12 +16,14 @@ indexmap = { version = "2.14", features = ["serde"] }
 mime_guess = "2.0.5"
 napi = { version = "3.5.2", default-features = false, features = ["napi8", "tokio_rt"] }
 napi-derive = "3.3.2"
+rayon = "=1.11.0"
 reqwest = { version = "0.13", features = ["stream"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml_ng = "0.10"
 sha2 = "0.10"
 sysinfo = "0.37.2"
+time = { version = "=0.3.44", features = ["parsing"] }
 tokio = { version = "1.52", features = ["fs", "rt", "sync", "macros"] }
 unicode-normalization = "0.1.25"
 uuid = { version = "1.11.0", features = ["v4"] }

--- a/native/hydra-native/Cargo.toml
+++ b/native/hydra-native/Cargo.toml
@@ -31,6 +31,7 @@ walkdir = "=2.5.0"
 
 [target.'cfg(windows)'.dependencies]
 known-folders = "=1.2.0"
+windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/native/hydra-native/src/cloud_save/hashing/aggregate.rs
+++ b/native/hydra-native/src/cloud_save/hashing/aggregate.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use super::types::BuildSnapshotAggregateHashInput;
-use crate::cloud_save::identity::{normalize_rule_path, SnapshotVariant};
+use crate::cloud_save::identity::{normalize_rule_path, normalize_text, SnapshotVariant};
 
 const SNAPSHOT_HASH_VERSION: u32 = 1;
 
@@ -72,7 +72,7 @@ fn validate_variant(variant: &SnapshotVariant) -> Result<(), String> {
 pub fn build_hash(mut input: BuildSnapshotAggregateHashInput) -> Result<String, String> {
     for file in &mut input.files {
         file.raw_path = normalize_rule_path(&file.raw_path);
-        file.relative_path = normalize_rule_path(&file.relative_path);
+        file.relative_path = normalize_text(&file.relative_path);
     }
     input
         .variants
@@ -173,6 +173,17 @@ mod tests {
         assert_eq!(
             hash(vec![variant("v")], vec![nfc]),
             hash(vec![variant("v")], vec![nfd])
+        );
+    }
+
+    #[test]
+    fn aggregate_hash_preserves_literal_backslashes_in_relative_paths() {
+        let backslash = file("v", "<home>/game", r"save\slot1.dat", "a", 10.0);
+        let slash = file("v", "<home>/game", "save/slot1.dat", "a", 10.0);
+
+        assert_ne!(
+            hash(vec![variant("v")], vec![backslash]),
+            hash(vec![variant("v")], vec![slash])
         );
     }
 

--- a/native/hydra-native/src/cloud_save/hashing/aggregate.rs
+++ b/native/hydra-native/src/cloud_save/hashing/aggregate.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use super::types::BuildSnapshotAggregateHashInput;
-use crate::cloud_save::identity::SnapshotVariant;
+use crate::cloud_save::identity::{normalize_rule_path, SnapshotVariant};
 
 const SNAPSHOT_HASH_VERSION: u32 = 1;
 
@@ -70,6 +70,10 @@ fn validate_variant(variant: &SnapshotVariant) -> Result<(), String> {
 }
 
 pub fn build_hash(mut input: BuildSnapshotAggregateHashInput) -> Result<String, String> {
+    for file in &mut input.files {
+        file.raw_path = normalize_rule_path(&file.raw_path);
+        file.relative_path = normalize_rule_path(&file.relative_path);
+    }
     input
         .variants
         .sort_by(|left, right| left.variant_id.cmp(&right.variant_id));
@@ -158,6 +162,17 @@ mod tests {
         assert_eq!(
             hash(vec![variant("v")], vec![first.clone(), second.clone()]),
             hash(vec![variant("v")], vec![second, first])
+        );
+    }
+
+    #[test]
+    fn aggregate_hash_normalizes_unicode_paths() {
+        let nfc = file("v", "<home>/Café", "Café/save.dat", "a", 10.0);
+        let nfd = file("v", "<home>/Cafe\u{301}", "Cafe\u{301}/save.dat", "a", 10.0);
+
+        assert_eq!(
+            hash(vec![variant("v")], vec![nfc]),
+            hash(vec![variant("v")], vec![nfd])
         );
     }
 

--- a/native/hydra-native/src/cloud_save/hashing/aggregate.rs
+++ b/native/hydra-native/src/cloud_save/hashing/aggregate.rs
@@ -1,0 +1,192 @@
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::types::BuildSnapshotAggregateHashInput;
+use crate::cloud_save::identity::SnapshotVariant;
+
+const SNAPSHOT_HASH_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalSnapshotVariant<'a> {
+    variant_id: &'a str,
+    kind: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    steam_id64: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    concrete_folder_id: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalSnapshotFile<'a> {
+    variant_id: &'a str,
+    raw_path: &'a str,
+    relative_path: &'a str,
+    hash: &'a str,
+    size_bytes: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalSnapshot<'a> {
+    snapshot_hash_version: u32,
+    variants: Vec<CanonicalSnapshotVariant<'a>>,
+    files: Vec<CanonicalSnapshotFile<'a>>,
+}
+
+fn canonical_size_bytes(size_bytes: f64) -> Result<u64, String> {
+    if !size_bytes.is_finite()
+        || size_bytes < 0.0
+        || size_bytes.fract() != 0.0
+        || size_bytes >= u64::MAX as f64
+    {
+        return Err("cloud_save_invalid_size_bytes".to_string());
+    }
+
+    Ok(size_bytes as u64)
+}
+
+fn validate_variant(variant: &SnapshotVariant) -> Result<(), String> {
+    let valid = match variant.kind.as_str() {
+        "default" => variant.steam_id64.is_none() && variant.concrete_folder_id.is_none(),
+        "steam-account" => {
+            variant.steam_id64.as_deref().is_some_and(|value| {
+                value.len() == 17 && value.bytes().all(|byte| byte.is_ascii_digit())
+            }) && variant.concrete_folder_id.is_none()
+        }
+        "opaque-folder" => {
+            variant.steam_id64.is_none()
+                && variant
+                    .concrete_folder_id
+                    .as_deref()
+                    .is_some_and(crate::cloud_save::identity::is_safe_capture)
+        }
+        _ => false,
+    };
+    valid
+        .then_some(())
+        .ok_or_else(|| "cloud_save_invalid_snapshot_variant".to_string())
+}
+
+pub fn build_hash(mut input: BuildSnapshotAggregateHashInput) -> Result<String, String> {
+    input
+        .variants
+        .sort_by(|left, right| left.variant_id.cmp(&right.variant_id));
+    input.files.sort_by(|left, right| {
+        left.variant_id
+            .cmp(&right.variant_id)
+            .then_with(|| left.raw_path.cmp(&right.raw_path))
+            .then_with(|| left.relative_path.cmp(&right.relative_path))
+            .then_with(|| left.hash.cmp(&right.hash))
+            .then_with(|| left.size_bytes.total_cmp(&right.size_bytes))
+    });
+
+    for variant in &input.variants {
+        validate_variant(variant)?;
+    }
+
+    let snapshot = CanonicalSnapshot {
+        snapshot_hash_version: SNAPSHOT_HASH_VERSION,
+        variants: input
+            .variants
+            .iter()
+            .map(|variant| CanonicalSnapshotVariant {
+                variant_id: &variant.variant_id,
+                kind: &variant.kind,
+                steam_id64: variant.steam_id64.as_deref(),
+                concrete_folder_id: variant.concrete_folder_id.as_deref(),
+            })
+            .collect(),
+        files: input
+            .files
+            .iter()
+            .map(|file| {
+                Ok(CanonicalSnapshotFile {
+                    variant_id: &file.variant_id,
+                    raw_path: &file.raw_path,
+                    relative_path: &file.relative_path,
+                    hash: &file.hash,
+                    size_bytes: canonical_size_bytes(file.size_bytes)?,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?,
+    };
+    let serialized = serde_json::to_vec(&snapshot).map_err(|error| error.to_string())?;
+    Ok(format!("{:x}", Sha256::digest(serialized)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_save::hashing::types::SnapshotAggregateHashFile;
+
+    fn variant(id: &str) -> SnapshotVariant {
+        SnapshotVariant {
+            variant_id: id.into(),
+            kind: "default".into(),
+            steam_id64: None,
+            concrete_folder_id: None,
+        }
+    }
+
+    fn file(
+        variant_id: &str,
+        raw_path: &str,
+        relative_path: &str,
+        hash: &str,
+        size_bytes: f64,
+    ) -> SnapshotAggregateHashFile {
+        SnapshotAggregateHashFile {
+            variant_id: variant_id.into(),
+            raw_path: raw_path.into(),
+            relative_path: relative_path.into(),
+            hash: hash.into(),
+            size_bytes,
+        }
+    }
+
+    fn hash(variants: Vec<SnapshotVariant>, files: Vec<SnapshotAggregateHashFile>) -> String {
+        build_hash(BuildSnapshotAggregateHashInput { variants, files }).unwrap()
+    }
+
+    #[test]
+    fn aggregate_hash_is_independent_of_input_order() {
+        let first = file("v", "<home>/game", "one.sav", "a", 10.0);
+        let second = file("v", "<home>/game", "two.sav", "b", 20.0);
+
+        assert_eq!(
+            hash(vec![variant("v")], vec![first.clone(), second.clone()]),
+            hash(vec![variant("v")], vec![second, first])
+        );
+    }
+
+    #[test]
+    fn identity_changes_with_variant_path_hash_or_size() {
+        let baseline = hash(
+            vec![variant("v")],
+            vec![file("v", "<home>/game", "save.dat", "a", 10.0)],
+        );
+        for changed in [
+            file("other", "<home>/game", "save.dat", "a", 10.0),
+            file("v", "<home>/other", "save.dat", "a", 10.0),
+            file("v", "<home>/game", "other.dat", "a", 10.0),
+            file("v", "<home>/game", "save.dat", "b", 10.0),
+            file("v", "<home>/game", "save.dat", "a", 11.0),
+        ] {
+            assert_ne!(baseline, hash(vec![variant("v")], vec![changed]));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_sizes() {
+        for size_bytes in [f64::NAN, f64::INFINITY, -1.0, 1.5, u64::MAX as f64] {
+            let error = build_hash(BuildSnapshotAggregateHashInput {
+                variants: vec![variant("v")],
+                files: vec![file("v", "<home>/game", "save.dat", "a", size_bytes)],
+            })
+            .unwrap_err();
+            assert_eq!(error, "cloud_save_invalid_size_bytes");
+        }
+    }
+}

--- a/native/hydra-native/src/cloud_save/hashing/batch.rs
+++ b/native/hydra-native/src/cloud_save/hashing/batch.rs
@@ -1,0 +1,241 @@
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::sync::OnceLock;
+
+use rayon::prelude::*;
+use time::OffsetDateTime;
+
+use super::file::hash_file;
+use super::types::{HashFilesResult, HashedLocalFile, LocalFileHashCacheEntry};
+
+pub struct HashFilesBestEffortResult {
+    pub result: HashFilesResult,
+    pub failures: Vec<(String, String)>,
+}
+
+pub const MAX_CONCURRENT_HASHES: usize = 8;
+const SHA256_HEX_HASH_LENGTH: usize = 64;
+const HASH_ALGORITHM: &str = "sha256";
+static HASHING_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+fn hashing_pool() -> &'static rayon::ThreadPool {
+    HASHING_POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(MAX_CONCURRENT_HASHES)
+            .thread_name(|index| format!("cloud-save-hash-{index}"))
+            .build()
+            .expect("failed to create cloud save hashing pool")
+    })
+}
+
+pub(crate) fn format_modified_at(modified: std::time::SystemTime) -> String {
+    let datetime = OffsetDateTime::from(modified);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:09}Z",
+        datetime.year(),
+        u8::from(datetime.month()),
+        datetime.day(),
+        datetime.hour(),
+        datetime.minute(),
+        datetime.second(),
+        datetime.nanosecond()
+    )
+}
+
+fn is_valid_hash(hash: &str) -> bool {
+    hash.len() == SHA256_HEX_HASH_LENGTH
+        && hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn hash_file_with_cache(
+    absolute_path: String,
+    cached: Option<&LocalFileHashCacheEntry>,
+) -> Result<HashedLocalFile, String> {
+    let metadata = fs::metadata(&absolute_path).map_err(|error| error.to_string())?;
+    if !metadata.is_file() {
+        return Err("cloud_save_hash_path_is_not_file".to_string());
+    }
+
+    let size_bytes = metadata.len() as f64;
+    let last_modified_at = metadata
+        .modified()
+        .map(format_modified_at)
+        .map_err(|error| error.to_string())?;
+    let hash = cached
+        .filter(|entry| {
+            entry.absolute_path == absolute_path
+                && entry.size_bytes == size_bytes
+                && entry.last_modified_at == last_modified_at
+                && entry.algorithm.as_deref() == Some(HASH_ALGORITHM)
+                && is_valid_hash(&entry.hash)
+        })
+        .map(|entry| entry.hash.clone())
+        .map_or_else(|| hash_file(&absolute_path), Ok)?;
+
+    Ok(HashedLocalFile {
+        absolute_path,
+        size_bytes,
+        last_modified_at,
+        hash,
+    })
+}
+
+pub fn hash_files(
+    absolute_paths: Vec<String>,
+    hash_cache: Vec<LocalFileHashCacheEntry>,
+) -> Result<HashFilesResult, String> {
+    let result = hash_files_best_effort(absolute_paths, hash_cache);
+    if let Some((_, error)) = result.failures.into_iter().next() {
+        return Err(error);
+    }
+    Ok(result.result)
+}
+
+pub fn hash_files_best_effort(
+    absolute_paths: Vec<String>,
+    hash_cache: Vec<LocalFileHashCacheEntry>,
+) -> HashFilesBestEffortResult {
+    let paths = absolute_paths
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let cache_by_path = hash_cache
+        .into_iter()
+        .map(|entry| (entry.absolute_path.clone(), entry))
+        .collect::<HashMap<_, _>>();
+
+    let results = hashing_pool().install(|| {
+        paths
+            .into_par_iter()
+            .map(|absolute_path| {
+                let cached = cache_by_path.get(&absolute_path);
+                let path = absolute_path.clone();
+                hash_file_with_cache(absolute_path, cached).map_err(|error| (path, error))
+            })
+            .collect::<Vec<_>>()
+    });
+    let mut files = Vec::new();
+    let mut failures = Vec::new();
+    for result in results {
+        match result {
+            Ok(file) => files.push(file),
+            Err(failure) => failures.push(failure),
+        }
+    }
+    let hash_cache = files
+        .iter()
+        .map(|file| LocalFileHashCacheEntry {
+            absolute_path: file.absolute_path.clone(),
+            size_bytes: file.size_bytes,
+            last_modified_at: file.last_modified_at.clone(),
+            hash: file.hash.clone(),
+            algorithm: Some(HASH_ALGORITHM.to_string()),
+        })
+        .collect();
+
+    HashFilesBestEffortResult {
+        result: HashFilesResult { files, hash_cache },
+        failures,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn reuses_valid_cache_and_processes_duplicate_paths_once() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("save.dat").display().to_string();
+        fs::write(&path, b"save").unwrap();
+        let initial = hash_files(vec![path.clone()], vec![]).unwrap();
+        let mut cache = initial.hash_cache;
+        let cached_hash = "a".repeat(64);
+        cache[0].hash = cached_hash.clone();
+
+        let result = hash_files(vec![path.clone(), path], cache).unwrap();
+
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.hash_cache.len(), 1);
+        assert_eq!(result.files[0].hash, cached_hash);
+        assert_eq!(hashing_pool().current_num_threads(), MAX_CONCURRENT_HASHES);
+    }
+
+    #[test]
+    fn invalidates_cache_mismatches() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("save.dat").display().to_string();
+        let expected = "157dca92e4250458339d4b835250d44c238f3355e1b7986195188ee434e9baff";
+        fs::write(&path, b"save").unwrap();
+        let initial = hash_files(vec![path.clone()], vec![]).unwrap();
+
+        for mutate in [
+            |entry: &mut LocalFileHashCacheEntry| entry.hash = "invalid".into(),
+            |entry: &mut LocalFileHashCacheEntry| entry.size_bytes += 1.0,
+            |entry: &mut LocalFileHashCacheEntry| entry.last_modified_at = "changed".into(),
+            |entry: &mut LocalFileHashCacheEntry| entry.algorithm = None,
+        ] {
+            let mut cache = initial.hash_cache.clone();
+            mutate(&mut cache[0]);
+            assert_eq!(
+                hash_files(vec![path.clone()], cache).unwrap().files[0].hash,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn drops_removed_files_and_sorts_results() {
+        let temp = tempdir().unwrap();
+        let first = temp.path().join("a.dat").display().to_string();
+        let removed = temp.path().join("removed.dat").display().to_string();
+        let second = temp.path().join("z.dat").display().to_string();
+        fs::write(&first, b"a").unwrap();
+        fs::write(&removed, b"removed").unwrap();
+        fs::write(&second, b"z").unwrap();
+        let initial =
+            hash_files(vec![removed.clone(), second.clone(), first.clone()], vec![]).unwrap();
+
+        let result = hash_files(vec![second.clone(), first.clone()], initial.hash_cache).unwrap();
+
+        assert_eq!(
+            result
+                .files
+                .iter()
+                .map(|file| file.absolute_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![first.as_str(), second.as_str()]
+        );
+        assert_eq!(result.hash_cache.len(), 2);
+        assert!(!result
+            .hash_cache
+            .iter()
+            .any(|entry| entry.absolute_path == removed));
+    }
+
+    #[test]
+    fn accepts_empty_files_and_rejects_non_files() {
+        let temp = tempdir().unwrap();
+        let empty = temp.path().join("empty.dat").display().to_string();
+        fs::write(&empty, b"").unwrap();
+
+        let result = hash_files(vec![empty], vec![]).unwrap();
+
+        assert_eq!(result.files[0].size_bytes, 0.0);
+        assert_eq!(
+            result.files[0].hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            hash_files(vec![temp.path().display().to_string()], vec![]).unwrap_err(),
+            "cloud_save_hash_path_is_not_file"
+        );
+    }
+}

--- a/native/hydra-native/src/cloud_save/hashing/batch.rs
+++ b/native/hydra-native/src/cloud_save/hashing/batch.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rayon::prelude::*;
-use time::OffsetDateTime;
+use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
 
 use super::file::hash_file;
 use super::types::{HashFilesResult, HashedLocalFile, LocalFileHashCacheEntry};
@@ -16,6 +17,7 @@ pub struct HashFilesBestEffortResult {
 pub const MAX_CONCURRENT_HASHES: usize = 8;
 const SHA256_HEX_HASH_LENGTH: usize = 64;
 const HASH_ALGORITHM: &str = "sha256";
+const CACHE_RACY_TIMESTAMP_WINDOW: Duration = Duration::seconds(2);
 static HASHING_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
 
 fn hashing_pool() -> &'static rayon::ThreadPool {
@@ -28,9 +30,26 @@ fn hashing_pool() -> &'static rayon::ThreadPool {
     })
 }
 
-pub(crate) fn format_modified_at(modified: std::time::SystemTime) -> String {
-    let datetime = OffsetDateTime::from(modified);
-    format!(
+fn offset_datetime(value: SystemTime) -> Result<OffsetDateTime, String> {
+    let datetime = match value.duration_since(UNIX_EPOCH) {
+        Ok(duration) => Duration::try_from(duration)
+            .ok()
+            .and_then(|duration| OffsetDateTime::UNIX_EPOCH.checked_add(duration)),
+        Err(error) => Duration::try_from(error.duration())
+            .ok()
+            .and_then(|duration| OffsetDateTime::UNIX_EPOCH.checked_sub(duration)),
+    }
+    .ok_or_else(|| "cloud_save_invalid_file_timestamp".to_string())?;
+
+    (0..=9999)
+        .contains(&datetime.year())
+        .then_some(datetime)
+        .ok_or_else(|| "cloud_save_invalid_file_timestamp".to_string())
+}
+
+pub(crate) fn format_modified_at(modified: SystemTime) -> Result<String, String> {
+    let datetime = offset_datetime(modified)?;
+    Ok(format!(
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:09}Z",
         datetime.year(),
         u8::from(datetime.month()),
@@ -39,7 +58,72 @@ pub(crate) fn format_modified_at(modified: std::time::SystemTime) -> String {
         datetime.minute(),
         datetime.second(),
         datetime.nanosecond()
-    )
+    ))
+}
+
+#[cfg(unix)]
+fn metadata_fingerprint(_path: &str, metadata: &fs::Metadata) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(format!(
+        "unix:{}:{}:{}:{}",
+        metadata.dev(),
+        metadata.ino(),
+        metadata.ctime(),
+        metadata.ctime_nsec()
+    ))
+}
+
+#[cfg(windows)]
+fn metadata_fingerprint(path: &str, metadata: &fs::Metadata) -> Option<String> {
+    use std::os::windows::fs::MetadataExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileBasicInfo, GetFileInformationByHandleEx, FILE_BASIC_INFO,
+    };
+
+    let file = fs::File::open(path).ok()?;
+    let mut basic_info = FILE_BASIC_INFO::default();
+    // SAFETY: `file` keeps the handle alive and `basic_info` provides the
+    // correctly sized writable buffer required for `FileBasicInfo`.
+    let succeeded = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            std::ptr::from_mut(&mut basic_info).cast(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    };
+    if succeeded == 0 {
+        return None;
+    }
+
+    Some(format!(
+        "windows:{}:{}:{}",
+        metadata.creation_time(),
+        metadata.file_attributes(),
+        basic_info.ChangeTime
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn metadata_fingerprint(_path: &str, _metadata: &fs::Metadata) -> Option<String> {
+    None
+}
+
+fn cache_timestamp_is_stable(modified: SystemTime, hashed_at: &str) -> bool {
+    let Ok(modified) = offset_datetime(modified) else {
+        return false;
+    };
+    let Ok(hashed_at) = OffsetDateTime::parse(hashed_at, &Rfc3339) else {
+        return false;
+    };
+
+    // Filesystems with coarse mtimes can report the same timestamp for two
+    // adjacent writes. Rehash once after that window before trusting the cache.
+    hashed_at
+        .checked_sub(CACHE_RACY_TIMESTAMP_WINDOW)
+        .is_some_and(|safe_before| modified <= safe_before)
 }
 
 fn is_valid_hash(hash: &str) -> bool {
@@ -59,26 +143,39 @@ fn hash_file_with_cache(
     }
 
     let size_bytes = metadata.len() as f64;
-    let last_modified_at = metadata
-        .modified()
-        .map(format_modified_at)
-        .map_err(|error| error.to_string())?;
-    let hash = cached
-        .filter(|entry| {
-            entry.absolute_path == absolute_path
-                && entry.size_bytes == size_bytes
-                && entry.last_modified_at == last_modified_at
-                && entry.algorithm.as_deref() == Some(HASH_ALGORITHM)
-                && is_valid_hash(&entry.hash)
-        })
-        .map(|entry| entry.hash.clone())
-        .map_or_else(|| hash_file(&absolute_path), Ok)?;
+    let modified = metadata.modified().map_err(|error| error.to_string())?;
+    let last_modified_at = format_modified_at(modified)?;
+    let metadata_fingerprint = metadata_fingerprint(&absolute_path, &metadata);
+    let cached = cached.filter(|entry| {
+        entry.absolute_path == absolute_path
+            && entry.size_bytes == size_bytes
+            && entry.last_modified_at == last_modified_at
+            && entry.algorithm.as_deref() == Some(HASH_ALGORITHM)
+            && is_valid_hash(&entry.hash)
+            && metadata_fingerprint.is_some()
+            && entry.metadata_fingerprint == metadata_fingerprint
+            && entry
+                .hashed_at
+                .as_deref()
+                .is_some_and(|hashed_at| cache_timestamp_is_stable(modified, hashed_at))
+    });
+    let cached =
+        cached.and_then(|entry| entry.hashed_at.as_ref().map(|hashed_at| (entry, hashed_at)));
+    let (hash, hashed_at) = match cached {
+        Some((entry, hashed_at)) => (entry.hash.clone(), hashed_at.clone()),
+        None => (
+            hash_file(&absolute_path)?,
+            format_modified_at(SystemTime::now())?,
+        ),
+    };
 
     Ok(HashedLocalFile {
         absolute_path,
         size_bytes,
         last_modified_at,
         hash,
+        hashed_at,
+        metadata_fingerprint,
     })
 }
 
@@ -133,6 +230,8 @@ pub fn hash_files_best_effort(
             last_modified_at: file.last_modified_at.clone(),
             hash: file.hash.clone(),
             algorithm: Some(HASH_ALGORITHM.to_string()),
+            hashed_at: Some(file.hashed_at.clone()),
+            metadata_fingerprint: file.metadata_fingerprint.clone(),
         })
         .collect();
 
@@ -145,6 +244,8 @@ pub fn hash_files_best_effort(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::fs::FileTimes;
+    use std::time::{Duration as StdDuration, UNIX_EPOCH};
 
     use tempfile::tempdir;
 
@@ -159,6 +260,10 @@ mod tests {
         let mut cache = initial.hash_cache;
         let cached_hash = "a".repeat(64);
         cache[0].hash = cached_hash.clone();
+        let modified = fs::metadata(&path).unwrap().modified().unwrap();
+        cache[0].hashed_at = Some(
+            format_modified_at(modified.checked_add(StdDuration::from_secs(3)).unwrap()).unwrap(),
+        );
 
         let result = hash_files(vec![path.clone(), path], cache).unwrap();
 
@@ -166,6 +271,70 @@ mod tests {
         assert_eq!(result.hash_cache.len(), 1);
         assert_eq!(result.files[0].hash, cached_hash);
         assert_eq!(hashing_pool().current_num_threads(), MAX_CONCURRENT_HASHES);
+    }
+
+    #[test]
+    fn distrusts_cache_entries_with_racy_timestamps() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("save.dat").display().to_string();
+        fs::write(&path, b"save").unwrap();
+        let initial = hash_files(vec![path.clone()], vec![]).unwrap();
+        let mut cache = initial.hash_cache;
+        cache[0].hash = "a".repeat(64);
+        cache[0].hashed_at = Some(cache[0].last_modified_at.clone());
+
+        let result = hash_files(vec![path], cache).unwrap();
+
+        assert_eq!(
+            result.files[0].hash,
+            "157dca92e4250458339d4b835250d44c238f3355e1b7986195188ee434e9baff"
+        );
+    }
+
+    #[test]
+    fn invalidates_cache_when_contents_change_but_size_and_mtime_do_not() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("save.dat").display().to_string();
+        fs::write(&path, b"AAAA").unwrap();
+        let original_modified = fs::metadata(&path).unwrap().modified().unwrap();
+        let initial = hash_files(vec![path.clone()], vec![]).unwrap();
+        let initial_hash = initial.files[0].hash.clone();
+        let mut cache = initial.hash_cache;
+        cache[0].hashed_at = Some(
+            format_modified_at(
+                original_modified
+                    .checked_add(StdDuration::from_secs(3))
+                    .unwrap(),
+            )
+            .unwrap(),
+        );
+
+        fs::write(&path, b"BBBB").unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(original_modified))
+            .unwrap();
+        let result = hash_files(vec![path], cache).unwrap();
+
+        assert_ne!(result.files[0].hash, initial_hash);
+        assert_eq!(
+            result.files[0].last_modified_at,
+            initial.files[0].last_modified_at
+        );
+    }
+
+    #[test]
+    fn rejects_timestamps_outside_the_portable_date_range() {
+        let year_ten_thousand = UNIX_EPOCH
+            .checked_add(StdDuration::from_secs(253_402_300_800))
+            .unwrap();
+
+        assert_eq!(
+            format_modified_at(year_ten_thousand).unwrap_err(),
+            "cloud_save_invalid_file_timestamp"
+        );
     }
 
     #[test]

--- a/native/hydra-native/src/cloud_save/hashing/file.rs
+++ b/native/hydra-native/src/cloud_save/hashing/file.rs
@@ -1,0 +1,51 @@
+use std::fs::File;
+use std::io::Read;
+
+use sha2::{Digest, Sha256};
+
+pub fn hash_file(file_path: &str) -> Result<String, String> {
+    let mut file = File::open(file_path).map_err(|error| error.to_string())?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn hashes_regular_and_empty_files() {
+        let temp = tempdir().unwrap();
+        let regular = temp.path().join("save.dat");
+        let empty = temp.path().join("empty.dat");
+        fs::write(&regular, b"hydra cloud save").unwrap();
+        fs::write(&empty, b"").unwrap();
+
+        assert_eq!(
+            hash_file(&regular.display().to_string()).unwrap(),
+            "e3cf52377baee611e9767b7bbe309f96fa9de20d50083050ef175256975b8bff"
+        );
+        assert_eq!(
+            hash_file(&empty.display().to_string()).unwrap(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn missing_file_fails() {
+        assert!(hash_file("/missing/hydra-cloud-save").is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/hashing/mod.rs
+++ b/native/hydra-native/src/cloud_save/hashing/mod.rs
@@ -1,0 +1,39 @@
+mod aggregate;
+pub(crate) mod batch;
+mod file;
+pub(crate) mod types;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+pub(crate) use aggregate::build_hash as build_aggregate_hash;
+pub(crate) use file::hash_file;
+pub use types::{
+    BuildSnapshotAggregateHashInput, LocalFileHashCacheEntry, SnapshotAggregateHashFile,
+};
+
+#[napi]
+pub async fn hash_local_save_file(file_path: String) -> napi::Result<String> {
+    tokio::task::spawn_blocking(move || {
+        let types::HashFilesResult {
+            mut files,
+            hash_cache,
+        } = batch::hash_files(vec![file_path], vec![])?;
+        debug_assert_eq!(files.len(), hash_cache.len());
+
+        files
+            .pop()
+            .map(|file| file.hash)
+            .ok_or_else(|| "cloud_save_hash_result_missing".to_string())
+    })
+    .await
+    .map_err(|error| Error::from_reason(error.to_string()))?
+    .map_err(Error::from_reason)
+}
+
+#[napi]
+pub fn build_snapshot_aggregate_hash(
+    input: BuildSnapshotAggregateHashInput,
+) -> napi::Result<String> {
+    aggregate::build_hash(input).map_err(Error::from_reason)
+}

--- a/native/hydra-native/src/cloud_save/hashing/types.rs
+++ b/native/hydra-native/src/cloud_save/hashing/types.rs
@@ -1,0 +1,42 @@
+use crate::cloud_save::identity::SnapshotVariant;
+use napi_derive::napi;
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct SnapshotAggregateHashFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+}
+
+#[napi(object)]
+pub struct BuildSnapshotAggregateHashInput {
+    pub variants: Vec<SnapshotVariant>,
+    pub files: Vec<SnapshotAggregateHashFile>,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct LocalFileHashCacheEntry {
+    pub absolute_path: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+    pub hash: String,
+    pub algorithm: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct HashedLocalFile {
+    pub absolute_path: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+    pub hash: String,
+}
+
+#[derive(Debug)]
+pub struct HashFilesResult {
+    pub files: Vec<HashedLocalFile>,
+    pub hash_cache: Vec<LocalFileHashCacheEntry>,
+}

--- a/native/hydra-native/src/cloud_save/hashing/types.rs
+++ b/native/hydra-native/src/cloud_save/hashing/types.rs
@@ -25,6 +25,8 @@ pub struct LocalFileHashCacheEntry {
     pub last_modified_at: String,
     pub hash: String,
     pub algorithm: Option<String>,
+    pub hashed_at: Option<String>,
+    pub metadata_fingerprint: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -33,6 +35,8 @@ pub struct HashedLocalFile {
     pub size_bytes: f64,
     pub last_modified_at: String,
     pub hash: String,
+    pub hashed_at: String,
+    pub metadata_fingerprint: Option<String>,
 }
 
 #[derive(Debug)]

--- a/native/hydra-native/src/cloud_save/identity/mod.rs
+++ b/native/hydra-native/src/cloud_save/identity/mod.rs
@@ -8,6 +8,26 @@ use crate::cloud_save::manifest::types::{CloudSaveRule, CloudSaveRuleCondition};
 pub const RULE_ID_VERSION: u32 = 1;
 
 #[napi(object)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotVariant {
+    pub variant_id: String,
+    pub kind: String,
+    pub steam_id64: Option<String>,
+    pub concrete_folder_id: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct LocalResolutionBindings {
+    pub environment_id: String,
+    pub root_id: String,
+    pub prefix_generation_id: Option<String>,
+    pub concrete_user_segment: String,
+    pub concrete_path: String,
+}
+
+#[napi(object)]
 #[derive(Clone, Debug)]
 pub struct UserLocationCoverage {
     pub candidate_id: String,

--- a/native/hydra-native/src/cloud_save/local_snapshot/build.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/build.rs
@@ -4,7 +4,9 @@ use crate::cloud_save::hashing::{
     batch::{format_modified_at, hash_files_best_effort},
     build_aggregate_hash, BuildSnapshotAggregateHashInput, SnapshotAggregateHashFile,
 };
-use crate::cloud_save::identity::{local_id, normalize_rule_path, UserLocationCoverage};
+use crate::cloud_save::identity::{
+    local_id, normalize_rule_path, normalize_text, UserLocationCoverage,
+};
 
 use super::guardrails::{prepare_snapshot_files_best_effort, validate_built_files};
 use super::types::{
@@ -17,14 +19,14 @@ pub fn build_snapshot(
 ) -> Result<LocalGameSnapshotWithHash, String> {
     for file in &mut input.files {
         file.raw_path = normalize_rule_path(&file.raw_path);
-        file.relative_path = normalize_rule_path(&file.relative_path);
+        file.relative_path = normalize_text(&file.relative_path);
     }
     for coverage in &mut input.coverage {
         if let Some(raw_path) = &mut coverage.raw_path {
             *raw_path = normalize_rule_path(raw_path);
         }
         if let Some(relative_path) = &mut coverage.relative_path {
-            *relative_path = normalize_rule_path(relative_path);
+            *relative_path = normalize_text(relative_path);
         }
     }
 
@@ -341,5 +343,30 @@ mod tests {
             snapshot.coverage[0].relative_path.as_deref(),
             Some("Café/save.dat")
         );
+    }
+
+    #[test]
+    fn preserves_literal_backslashes_in_relative_paths() {
+        let temp = tempdir().unwrap();
+        let backslash = temp.path().join("backslash.dat");
+        let slash = temp.path().join("slash.dat");
+        fs::write(&backslash, b"backslash").unwrap();
+        fs::write(&slash, b"slash").unwrap();
+
+        let snapshot = build_snapshot(input(vec![
+            discovered(&backslash, r"save\slot1.dat"),
+            discovered(&slash, "save/slot1.dat"),
+        ]))
+        .unwrap();
+
+        assert_eq!(snapshot.files.len(), 2);
+        assert!(snapshot
+            .files
+            .iter()
+            .any(|file| file.relative_path == r"save\slot1.dat"));
+        assert!(snapshot
+            .files
+            .iter()
+            .any(|file| file.relative_path == "save/slot1.dat"));
     }
 }

--- a/native/hydra-native/src/cloud_save/local_snapshot/build.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/build.rs
@@ -1,0 +1,283 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::cloud_save::hashing::{
+    batch::{format_modified_at, hash_files_best_effort},
+    build_aggregate_hash, BuildSnapshotAggregateHashInput, SnapshotAggregateHashFile,
+};
+use crate::cloud_save::identity::{local_id, UserLocationCoverage};
+
+use super::guardrails::{prepare_snapshot_files_best_effort, validate_built_files};
+use super::types::{
+    BuildLocalGameSnapshotInput, BuiltLocalSaveFile, DiscoveredLocalSaveFile,
+    LocalGameSnapshotFile, LocalGameSnapshotSourceFile, LocalGameSnapshotWithHash,
+};
+
+pub fn build_snapshot(
+    mut input: BuildLocalGameSnapshotInput,
+) -> Result<LocalGameSnapshotWithHash, String> {
+    let prepared =
+        prepare_snapshot_files_best_effort(&input.files).map_err(|error| error.to_string())?;
+    let unavailable = prepared
+        .unavailable_paths
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let hashed = hash_files_best_effort(
+        input
+            .files
+            .iter()
+            .filter(|file| !unavailable.contains(&file.absolute_path))
+            .map(|file| file.absolute_path.clone())
+            .collect(),
+        input.hash_cache,
+    );
+    let hash_failures = hashed
+        .failures
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect::<HashSet<_>>();
+    let hashed_by_path = hashed
+        .result
+        .files
+        .into_iter()
+        .map(|file| (file.absolute_path.clone(), file))
+        .collect::<HashMap<_, _>>();
+    let warning = |file: &DiscoveredLocalSaveFile, code: &str| UserLocationCoverage {
+        candidate_id: local_id(&[code, &file.variant_id, &file.raw_path, &file.relative_path]),
+        rule_id: file.rule_id.clone(),
+        variant_id: Some(file.variant_id.clone()),
+        raw_path: Some(file.raw_path.clone()),
+        relative_path: Some(file.relative_path.clone()),
+        selected_root: true,
+        authority: file.confidence.clone(),
+        outcome: "partial".to_string(),
+        enumerated_completely: false,
+        warning_codes: vec![code.to_string()],
+    };
+    let mut built_files = input
+        .files
+        .into_iter()
+        .filter_map(|file| {
+            if unavailable.contains(&file.absolute_path) {
+                input
+                    .coverage
+                    .push(warning(&file, "file-metadata-unavailable"));
+                return None;
+            }
+            if hash_failures.contains(&file.absolute_path) {
+                input.coverage.push(warning(&file, "file-hash-failed"));
+                return None;
+            }
+            let hashed = hashed_by_path.get(&file.absolute_path)?;
+            let initial = prepared.metadata_by_path.get(&file.absolute_path)?;
+            let current = std::fs::metadata(&file.absolute_path)
+                .ok()
+                .filter(|metadata| metadata.is_file())
+                .and_then(|metadata| {
+                    let modified = metadata.modified().ok()?;
+                    Some((metadata.len() as f64, format_modified_at(modified)))
+                });
+            if initial.size_bytes != hashed.size_bytes
+                || initial.last_modified_at != hashed.last_modified_at
+                || current.as_ref() != Some(&(hashed.size_bytes, hashed.last_modified_at.clone()))
+            {
+                input
+                    .coverage
+                    .push(warning(&file, "file-changed-during-snapshot"));
+                return None;
+            }
+            Some(BuiltLocalSaveFile {
+                variant_id: file.variant_id,
+                rule_id: file.rule_id,
+                raw_path: file.raw_path,
+                relative_path: file.relative_path,
+                absolute_path: file.absolute_path,
+                hash: hashed.hash.clone(),
+                size_bytes: hashed.size_bytes,
+                last_modified_at: hashed.last_modified_at.clone(),
+                local_bindings: file.local_bindings,
+                confidence: file.confidence,
+                provenance: file.provenance,
+            })
+        })
+        .collect::<Vec<_>>();
+    let total_size_bytes = validate_built_files(&built_files).map_err(|error| error.to_string())?;
+
+    built_files.sort_by(|left, right| {
+        left.variant_id
+            .cmp(&right.variant_id)
+            .then_with(|| left.raw_path.cmp(&right.raw_path))
+            .then_with(|| left.relative_path.cmp(&right.relative_path))
+    });
+
+    let files = built_files
+        .iter()
+        .map(|file| LocalGameSnapshotFile {
+            variant_id: file.variant_id.clone(),
+            raw_path: file.raw_path.clone(),
+            relative_path: file.relative_path.clone(),
+            hash: file.hash.clone(),
+            size_bytes: file.size_bytes,
+            last_modified_at: file.last_modified_at.clone(),
+        })
+        .collect::<Vec<_>>();
+    let source_files = built_files
+        .iter()
+        .map(|file| LocalGameSnapshotSourceFile {
+            variant_id: file.variant_id.clone(),
+            rule_id: file.rule_id.clone(),
+            raw_path: file.raw_path.clone(),
+            relative_path: file.relative_path.clone(),
+            absolute_path: file.absolute_path.clone(),
+            hash: file.hash.clone(),
+            size_bytes: file.size_bytes,
+            last_modified_at: file.last_modified_at.clone(),
+            local_bindings: file.local_bindings.clone(),
+            confidence: file.confidence.clone(),
+            provenance: file.provenance.clone(),
+        })
+        .collect();
+
+    let used_variant_ids = files
+        .iter()
+        .map(|file| file.variant_id.as_str())
+        .collect::<HashSet<_>>();
+    let mut variants = input
+        .variants
+        .into_iter()
+        .filter(|variant| used_variant_ids.contains(variant.variant_id.as_str()))
+        .collect::<Vec<_>>();
+    variants.sort_by(|left, right| left.variant_id.cmp(&right.variant_id));
+    variants.dedup_by(|left, right| left.variant_id == right.variant_id);
+    if variants.len() != used_variant_ids.len() {
+        return Err("cloud_save_snapshot_variant_missing".to_string());
+    }
+
+    let aggregate_hash = build_aggregate_hash(BuildSnapshotAggregateHashInput {
+        variants: variants.clone(),
+        files: files
+            .iter()
+            .map(|file| SnapshotAggregateHashFile {
+                variant_id: file.variant_id.clone(),
+                raw_path: file.raw_path.clone(),
+                relative_path: file.relative_path.clone(),
+                hash: file.hash.clone(),
+                size_bytes: file.size_bytes,
+            })
+            .collect(),
+    })?;
+
+    Ok(LocalGameSnapshotWithHash {
+        game_id: input.game_id,
+        manifest_key: input.manifest_key,
+        rule_source_revision: input.rule_source_revision,
+        discovery_engine_version: input.discovery_engine_version,
+        coverage: input.coverage,
+        variants,
+        file_count: files.len() as u32,
+        total_size_bytes: total_size_bytes as f64,
+        files,
+        aggregate_hash,
+        source_files,
+        hash_cache: hashed.result.hash_cache,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::cloud_save::identity::{LocalResolutionBindings, SnapshotVariant};
+    use crate::cloud_save::manifest::types::CloudSaveGameId;
+
+    fn input(files: Vec<DiscoveredLocalSaveFile>) -> BuildLocalGameSnapshotInput {
+        BuildLocalGameSnapshotInput {
+            game_id: CloudSaveGameId {
+                shop: "steam".into(),
+                object_id: "2379780".into(),
+            },
+            manifest_key: Some("2379780".into()),
+            rule_source_revision: "test-v1".into(),
+            discovery_engine_version: 2,
+            coverage: vec![],
+            variants: vec![SnapshotVariant {
+                variant_id: "variant".into(),
+                kind: "default".into(),
+                steam_id64: None,
+                concrete_folder_id: None,
+            }],
+            files,
+            hash_cache: vec![],
+        }
+    }
+
+    fn discovered(path: &std::path::Path, relative_path: &str) -> DiscoveredLocalSaveFile {
+        DiscoveredLocalSaveFile {
+            variant_id: "variant".into(),
+            rule_id: "rule".into(),
+            raw_path: "<home>/game".into(),
+            absolute_path: path.display().to_string(),
+            relative_path: relative_path.into(),
+            local_bindings: LocalResolutionBindings {
+                environment_id: "environment".into(),
+                root_id: "root".into(),
+                prefix_generation_id: None,
+                concrete_user_segment: "__default__".into(),
+                concrete_path: path.display().to_string(),
+            },
+            confidence: "inferred".into(),
+            provenance: vec!["test".into()],
+        }
+    }
+
+    #[test]
+    fn builds_deterministic_snapshot_with_source_files() {
+        let temp = tempdir().unwrap();
+        let empty = temp.path().join("empty.dat");
+        let save = temp.path().join("save.dat");
+        fs::write(&empty, b"").unwrap();
+        fs::write(&save, b"save").unwrap();
+
+        let first = build_snapshot(input(vec![
+            discovered(&save, "save.dat"),
+            discovered(&empty, "empty.dat"),
+        ]))
+        .unwrap();
+        let second = build_snapshot(input(vec![
+            discovered(&empty, "empty.dat"),
+            discovered(&save, "save.dat"),
+        ]))
+        .unwrap();
+
+        assert_eq!(first.file_count, 2);
+        assert_eq!(first.total_size_bytes, 4.0);
+        assert_eq!(first.files[0].relative_path, "empty.dat");
+        assert_eq!(first.source_files.len(), 2);
+        assert_eq!(first.aggregate_hash, second.aggregate_hash);
+        assert_eq!(first.files[0].size_bytes, 0.0);
+    }
+
+    #[test]
+    fn skips_unavailable_file_and_marks_partial_coverage() {
+        let temp = tempdir().unwrap();
+        let save = temp.path().join("save.dat");
+        let missing = temp.path().join("missing.dat");
+        fs::write(&save, b"save").unwrap();
+
+        let snapshot = build_snapshot(input(vec![
+            discovered(&save, "save.dat"),
+            discovered(&missing, "missing.dat"),
+        ]))
+        .unwrap();
+
+        assert_eq!(snapshot.files.len(), 1);
+        assert_eq!(snapshot.files[0].relative_path, "save.dat");
+        assert_eq!(snapshot.coverage.len(), 1);
+        assert_eq!(
+            snapshot.coverage[0].warning_codes,
+            vec!["file-metadata-unavailable"]
+        );
+    }
+}

--- a/native/hydra-native/src/cloud_save/local_snapshot/build.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/build.rs
@@ -4,7 +4,7 @@ use crate::cloud_save::hashing::{
     batch::{format_modified_at, hash_files_best_effort},
     build_aggregate_hash, BuildSnapshotAggregateHashInput, SnapshotAggregateHashFile,
 };
-use crate::cloud_save::identity::{local_id, UserLocationCoverage};
+use crate::cloud_save::identity::{local_id, normalize_rule_path, UserLocationCoverage};
 
 use super::guardrails::{prepare_snapshot_files_best_effort, validate_built_files};
 use super::types::{
@@ -15,6 +15,19 @@ use super::types::{
 pub fn build_snapshot(
     mut input: BuildLocalGameSnapshotInput,
 ) -> Result<LocalGameSnapshotWithHash, String> {
+    for file in &mut input.files {
+        file.raw_path = normalize_rule_path(&file.raw_path);
+        file.relative_path = normalize_rule_path(&file.relative_path);
+    }
+    for coverage in &mut input.coverage {
+        if let Some(raw_path) = &mut coverage.raw_path {
+            *raw_path = normalize_rule_path(raw_path);
+        }
+        if let Some(relative_path) = &mut coverage.relative_path {
+            *relative_path = normalize_rule_path(relative_path);
+        }
+    }
+
     let prepared =
         prepare_snapshot_files_best_effort(&input.files).map_err(|error| error.to_string())?;
     let unavailable = prepared
@@ -74,7 +87,8 @@ pub fn build_snapshot(
                 .filter(|metadata| metadata.is_file())
                 .and_then(|metadata| {
                     let modified = metadata.modified().ok()?;
-                    Some((metadata.len() as f64, format_modified_at(modified)))
+                    let last_modified_at = format_modified_at(modified).ok()?;
+                    Some((metadata.len() as f64, last_modified_at))
                 });
             if initial.size_bytes != hashed.size_bytes
                 || initial.last_modified_at != hashed.last_modified_at
@@ -100,6 +114,16 @@ pub fn build_snapshot(
             })
         })
         .collect::<Vec<_>>();
+    let accepted_paths = built_files
+        .iter()
+        .map(|file| file.absolute_path.as_str())
+        .collect::<HashSet<_>>();
+    let hash_cache = hashed
+        .result
+        .hash_cache
+        .into_iter()
+        .filter(|entry| accepted_paths.contains(entry.absolute_path.as_str()))
+        .collect();
     let total_size_bytes = validate_built_files(&built_files).map_err(|error| error.to_string())?;
 
     built_files.sort_by(|left, right| {
@@ -178,7 +202,7 @@ pub fn build_snapshot(
         files,
         aggregate_hash,
         source_files,
-        hash_cache: hashed.result.hash_cache,
+        hash_cache,
     })
 }
 
@@ -278,6 +302,44 @@ mod tests {
         assert_eq!(
             snapshot.coverage[0].warning_codes,
             vec!["file-metadata-unavailable"]
+        );
+    }
+
+    #[test]
+    fn normalizes_portable_paths_but_preserves_absolute_paths() {
+        let temp = tempdir().unwrap();
+        let save = temp.path().join("save.dat");
+        fs::write(&save, b"save").unwrap();
+        let mut input = input(vec![discovered(&save, "Cafe\u{301}/save.dat")]);
+        input.files[0].raw_path = "<home>/Cafe\u{301}".into();
+        input.coverage.push(UserLocationCoverage {
+            candidate_id: "candidate".into(),
+            rule_id: "rule".into(),
+            variant_id: Some("variant".into()),
+            raw_path: Some("<home>/Cafe\u{301}".into()),
+            relative_path: Some("Cafe\u{301}/save.dat".into()),
+            selected_root: true,
+            authority: "inferred".into(),
+            outcome: "scanned".into(),
+            enumerated_completely: true,
+            warning_codes: vec![],
+        });
+
+        let snapshot = build_snapshot(input).unwrap();
+
+        assert_eq!(snapshot.files[0].raw_path, "<home>/Café");
+        assert_eq!(snapshot.files[0].relative_path, "Café/save.dat");
+        assert_eq!(
+            snapshot.source_files[0].absolute_path,
+            save.display().to_string()
+        );
+        assert_eq!(
+            snapshot.coverage[0].raw_path.as_deref(),
+            Some("<home>/Café")
+        );
+        assert_eq!(
+            snapshot.coverage[0].relative_path.as_deref(),
+            Some("Café/save.dat")
         );
     }
 }

--- a/native/hydra-native/src/cloud_save/local_snapshot/guardrails.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/guardrails.rs
@@ -78,11 +78,13 @@ pub fn prepare_snapshot_files(
         let modified = metadata
             .modified()
             .map_err(|_| LocalSnapshotGuardError::FileMetadataUnavailable)?;
+        let last_modified_at = format_modified_at(modified)
+            .map_err(|_| LocalSnapshotGuardError::FileMetadataUnavailable)?;
         metadata_by_path.insert(
             file.absolute_path.clone(),
             InitialFileMetadata {
                 size_bytes: metadata.len() as f64,
-                last_modified_at: format_modified_at(modified),
+                last_modified_at,
             },
         );
     }
@@ -109,11 +111,15 @@ pub fn prepare_snapshot_files_best_effort(
             unavailable_paths.push(file.absolute_path.clone());
             continue;
         };
+        let Ok(last_modified_at) = format_modified_at(modified) else {
+            unavailable_paths.push(file.absolute_path.clone());
+            continue;
+        };
         metadata_by_path.insert(
             file.absolute_path.clone(),
             InitialFileMetadata {
                 size_bytes: metadata.len() as f64,
-                last_modified_at: format_modified_at(modified),
+                last_modified_at,
             },
         );
     }

--- a/native/hydra-native/src/cloud_save/local_snapshot/guardrails.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/guardrails.rs
@@ -1,0 +1,238 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::fs;
+
+use super::types::{BuiltLocalSaveFile, DiscoveredLocalSaveFile};
+use crate::cloud_save::hashing::batch::format_modified_at;
+
+pub const MAX_SNAPSHOT_FILE_COUNT: usize = 500;
+pub const MAX_SNAPSHOT_TOTAL_SIZE_BYTES: u64 = 2_147_483_647;
+
+#[derive(Debug, PartialEq)]
+pub struct InitialFileMetadata {
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+}
+
+pub struct PreparedSnapshotFiles {
+    pub metadata_by_path: HashMap<String, InitialFileMetadata>,
+    pub unavailable_paths: Vec<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LocalSnapshotGuardError {
+    TooManyFiles,
+    SnapshotTooLarge,
+    DuplicateFile,
+    HashSizeMismatch,
+    #[cfg(test)]
+    FileMetadataUnavailable,
+}
+
+impl fmt::Display for LocalSnapshotGuardError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TooManyFiles => "cloud_save_too_many_files",
+            Self::SnapshotTooLarge => "cloud_save_snapshot_too_large",
+            Self::DuplicateFile => "cloud_save_duplicate_file",
+            Self::HashSizeMismatch => "cloud_save_hash_size_mismatch",
+            #[cfg(test)]
+            Self::FileMetadataUnavailable => "cloud_save_file_metadata_unavailable",
+        })
+    }
+}
+
+fn validate_unique(files: &[DiscoveredLocalSaveFile]) -> Result<(), LocalSnapshotGuardError> {
+    let mut identities = HashSet::with_capacity(files.len());
+    for file in files {
+        if !identities.insert((&file.variant_id, &file.raw_path, &file.relative_path)) {
+            return Err(LocalSnapshotGuardError::DuplicateFile);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub fn prepare_snapshot_files(
+    files: &[DiscoveredLocalSaveFile],
+) -> Result<HashMap<String, InitialFileMetadata>, LocalSnapshotGuardError> {
+    if files.len() > MAX_SNAPSHOT_FILE_COUNT {
+        return Err(LocalSnapshotGuardError::TooManyFiles);
+    }
+    validate_unique(files)?;
+
+    let mut total_size_bytes = 0_u64;
+    let mut metadata_by_path = HashMap::with_capacity(files.len());
+    for file in files {
+        let metadata = fs::metadata(&file.absolute_path)
+            .map_err(|_| LocalSnapshotGuardError::FileMetadataUnavailable)?;
+        if !metadata.is_file() {
+            return Err(LocalSnapshotGuardError::FileMetadataUnavailable);
+        }
+        total_size_bytes = total_size_bytes
+            .checked_add(metadata.len())
+            .ok_or(LocalSnapshotGuardError::SnapshotTooLarge)?;
+        if total_size_bytes > MAX_SNAPSHOT_TOTAL_SIZE_BYTES {
+            return Err(LocalSnapshotGuardError::SnapshotTooLarge);
+        }
+        let modified = metadata
+            .modified()
+            .map_err(|_| LocalSnapshotGuardError::FileMetadataUnavailable)?;
+        metadata_by_path.insert(
+            file.absolute_path.clone(),
+            InitialFileMetadata {
+                size_bytes: metadata.len() as f64,
+                last_modified_at: format_modified_at(modified),
+            },
+        );
+    }
+    Ok(metadata_by_path)
+}
+
+pub fn prepare_snapshot_files_best_effort(
+    files: &[DiscoveredLocalSaveFile],
+) -> Result<PreparedSnapshotFiles, LocalSnapshotGuardError> {
+    validate_unique(files)?;
+
+    let mut metadata_by_path = HashMap::with_capacity(files.len());
+    let mut unavailable_paths = Vec::new();
+    for file in files {
+        let Ok(metadata) = fs::metadata(&file.absolute_path) else {
+            unavailable_paths.push(file.absolute_path.clone());
+            continue;
+        };
+        if !metadata.is_file() {
+            unavailable_paths.push(file.absolute_path.clone());
+            continue;
+        }
+        let Ok(modified) = metadata.modified() else {
+            unavailable_paths.push(file.absolute_path.clone());
+            continue;
+        };
+        metadata_by_path.insert(
+            file.absolute_path.clone(),
+            InitialFileMetadata {
+                size_bytes: metadata.len() as f64,
+                last_modified_at: format_modified_at(modified),
+            },
+        );
+    }
+    Ok(PreparedSnapshotFiles {
+        metadata_by_path,
+        unavailable_paths,
+    })
+}
+
+pub fn validate_built_files(files: &[BuiltLocalSaveFile]) -> Result<u64, LocalSnapshotGuardError> {
+    let mut total_size_bytes = 0_u64;
+    let mut size_by_hash = HashMap::new();
+    for file in files {
+        let size_bytes = file.size_bytes as u64;
+        total_size_bytes = total_size_bytes
+            .checked_add(size_bytes)
+            .ok_or(LocalSnapshotGuardError::SnapshotTooLarge)?;
+        if let Some(previous_size) = size_by_hash.insert(&file.hash, size_bytes) {
+            if previous_size != size_bytes {
+                return Err(LocalSnapshotGuardError::HashSizeMismatch);
+            }
+        }
+    }
+    Ok(total_size_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use super::*;
+    use crate::cloud_save::identity::LocalResolutionBindings;
+
+    fn discovered(variant_id: &str, relative_path: &str) -> DiscoveredLocalSaveFile {
+        DiscoveredLocalSaveFile {
+            variant_id: variant_id.into(),
+            rule_id: "rule".into(),
+            raw_path: "<home>/game".into(),
+            absolute_path: relative_path.into(),
+            relative_path: relative_path.into(),
+            local_bindings: LocalResolutionBindings {
+                environment_id: "environment".into(),
+                root_id: "root".into(),
+                prefix_generation_id: None,
+                concrete_user_segment: "__default__".into(),
+                concrete_path: relative_path.into(),
+            },
+            confidence: "inferred".into(),
+            provenance: vec!["test".into()],
+        }
+    }
+
+    #[test]
+    fn validates_count_and_composite_identity() {
+        let too_many = (0..=MAX_SNAPSHOT_FILE_COUNT)
+            .map(|index| discovered("variant", &index.to_string()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            prepare_snapshot_files(&too_many),
+            Err(LocalSnapshotGuardError::TooManyFiles)
+        );
+
+        let file = discovered("variant", "save.dat");
+        assert_eq!(
+            prepare_snapshot_files(&[file.clone(), file]),
+            Err(LocalSnapshotGuardError::DuplicateFile)
+        );
+        assert!(prepare_snapshot_files(&[
+            discovered("one", "save.dat"),
+            discovered("two", "save.dat")
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn best_effort_discovery_keeps_files_above_the_upload_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let save = temp.path().join("large.sav");
+        File::create(&save)
+            .unwrap()
+            .set_len(MAX_SNAPSHOT_TOTAL_SIZE_BYTES + 1)
+            .unwrap();
+
+        let prepared =
+            prepare_snapshot_files_best_effort(&[discovered("variant", &save.to_string_lossy())])
+                .unwrap();
+
+        assert_eq!(
+            prepared.metadata_by_path[&save.to_string_lossy().to_string()].size_bytes,
+            (MAX_SNAPSHOT_TOTAL_SIZE_BYTES + 1) as f64
+        );
+        assert!(prepared.unavailable_paths.is_empty());
+    }
+
+    #[test]
+    fn built_snapshot_can_be_analyzed_above_the_upload_limit() {
+        let file = BuiltLocalSaveFile {
+            variant_id: "variant".into(),
+            rule_id: "rule".into(),
+            raw_path: "<home>/game".into(),
+            relative_path: "large.sav".into(),
+            absolute_path: "/game/large.sav".into(),
+            hash: "a".repeat(64),
+            size_bytes: (MAX_SNAPSHOT_TOTAL_SIZE_BYTES + 1) as f64,
+            last_modified_at: "2026-07-30T00:00:00.000Z".into(),
+            local_bindings: LocalResolutionBindings {
+                environment_id: "environment".into(),
+                root_id: "root".into(),
+                prefix_generation_id: None,
+                concrete_user_segment: "__default__".into(),
+                concrete_path: "/game".into(),
+            },
+            confidence: "inferred".into(),
+            provenance: vec!["test".into()],
+        };
+
+        assert_eq!(
+            validate_built_files(&[file]).unwrap(),
+            MAX_SNAPSHOT_TOTAL_SIZE_BYTES + 1
+        );
+    }
+}

--- a/native/hydra-native/src/cloud_save/local_snapshot/mod.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/mod.rs
@@ -1,0 +1,18 @@
+mod build;
+mod guardrails;
+pub(crate) mod types;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+pub use types::{BuildLocalGameSnapshotInput, LocalGameSnapshotWithHash};
+
+#[napi]
+pub async fn build_local_game_snapshot(
+    input: BuildLocalGameSnapshotInput,
+) -> napi::Result<LocalGameSnapshotWithHash> {
+    tokio::task::spawn_blocking(move || build::build_snapshot(input))
+        .await
+        .map_err(|error| Error::from_reason(error.to_string()))?
+        .map_err(Error::from_reason)
+}

--- a/native/hydra-native/src/cloud_save/local_snapshot/types.rs
+++ b/native/hydra-native/src/cloud_save/local_snapshot/types.rs
@@ -1,0 +1,88 @@
+use napi_derive::napi;
+
+use crate::cloud_save::hashing::LocalFileHashCacheEntry;
+use crate::cloud_save::identity::{LocalResolutionBindings, SnapshotVariant, UserLocationCoverage};
+use crate::cloud_save::manifest::types::CloudSaveGameId;
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct DiscoveredLocalSaveFile {
+    pub variant_id: String,
+    pub rule_id: String,
+    pub raw_path: String,
+    pub absolute_path: String,
+    pub relative_path: String,
+    pub local_bindings: LocalResolutionBindings,
+    pub confidence: String,
+    pub provenance: Vec<String>,
+}
+
+#[napi(object)]
+pub struct BuildLocalGameSnapshotInput {
+    pub game_id: CloudSaveGameId,
+    pub manifest_key: Option<String>,
+    pub rule_source_revision: String,
+    pub discovery_engine_version: u32,
+    pub coverage: Vec<UserLocationCoverage>,
+    pub variants: Vec<SnapshotVariant>,
+    pub files: Vec<DiscoveredLocalSaveFile>,
+    pub hash_cache: Vec<LocalFileHashCacheEntry>,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct LocalGameSnapshotFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct LocalGameSnapshotSourceFile {
+    pub variant_id: String,
+    pub rule_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub absolute_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+    pub local_bindings: LocalResolutionBindings,
+    pub confidence: String,
+    pub provenance: Vec<String>,
+}
+
+#[napi(object)]
+pub struct LocalGameSnapshotWithHash {
+    pub game_id: CloudSaveGameId,
+    pub manifest_key: Option<String>,
+    pub rule_source_revision: String,
+    pub discovery_engine_version: u32,
+    pub coverage: Vec<UserLocationCoverage>,
+    pub variants: Vec<SnapshotVariant>,
+    pub file_count: u32,
+    pub total_size_bytes: f64,
+    pub files: Vec<LocalGameSnapshotFile>,
+    pub aggregate_hash: String,
+    pub source_files: Vec<LocalGameSnapshotSourceFile>,
+    pub hash_cache: Vec<LocalFileHashCacheEntry>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BuiltLocalSaveFile {
+    pub variant_id: String,
+    pub rule_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub absolute_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+    pub local_bindings: LocalResolutionBindings,
+    pub confidence: String,
+    pub provenance: Vec<String>,
+}

--- a/native/hydra-native/src/cloud_save/mod.rs
+++ b/native/hydra-native/src/cloud_save/mod.rs
@@ -1,4 +1,6 @@
+pub mod hashing;
 pub mod identity;
+pub mod local_snapshot;
 pub mod manifest;
 pub mod path_resolution;
 pub mod save_scanner;

--- a/native/hydra-native/src/lib.rs
+++ b/native/hydra-native/src/lib.rs
@@ -1,6 +1,8 @@
 mod cloud_save;
 mod constants;
 
+pub use cloud_save::hashing::{build_snapshot_aggregate_hash, hash_local_save_file};
+pub use cloud_save::local_snapshot::build_local_game_snapshot;
 pub use cloud_save::manifest::get_save_rules_for_game;
 pub use cloud_save::path_resolution::resolve_save_rules;
 pub use cloud_save::save_scanner::scan_resolved_save_rules;


### PR DESCRIPTION
## Summary

- hash local save files in parallel with a reusable metadata cache
- build normalized local snapshots and aggregate hashes
- preserve variant and local-resolution metadata in snapshot files

## Context

This PR is stacked on #2606. It replaces the useful native snapshot work from #2532 and #2533, while intentionally omitting the obsolete snapshot comparator from #2534.

## Validation

- `cargo check`
- `git diff --check`

**When submitting this pull request, I confirm the following:**

- [ ] I have read the Hydra documentation.
- [ ] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
