### PR TITLE
feat(cloud-save): add native transfer pipeline

### DIFF
--- a/native/hydra-native/Cargo.lock
+++ b/native/hydra-native/Cargo.lock
@@ -416,6 +416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +709,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "filetime",
  "globetter",
  "globset",
  "image",

--- a/native/hydra-native/Cargo.toml
+++ b/native/hydra-native/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0"
 blake3 = "=1.8.5"
+filetime = "0.2"
 globetter = "=0.2.0"
 globset = "=0.4.15"
 image = { version = "0.25.8", default-features = false, features = ["gif", "jpeg", "png", "webp"] }

--- a/native/hydra-native/src/cloud_save/http.rs
+++ b/native/hydra-native/src/cloud_save/http.rs
@@ -1,0 +1,30 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+const BLOB_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOB_READ_TIMEOUT: Duration = Duration::from_secs(60);
+const BLOB_TOTAL_TIMEOUT: Duration = Duration::from_secs(4 * 60 * 60);
+
+static BLOB_HTTP_CLIENT: OnceLock<Result<reqwest::Client, String>> = OnceLock::new();
+
+pub(crate) fn build_blob_http_client(
+    connect_timeout: Duration,
+    read_timeout: Duration,
+    total_timeout: Duration,
+) -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .read_timeout(read_timeout)
+        .timeout(total_timeout)
+        .build()
+        .map_err(|error| format!("Failed to build cloud save transfer HTTP client: {error}"))
+}
+
+pub(crate) fn blob_http_client() -> Result<&'static reqwest::Client, String> {
+    BLOB_HTTP_CLIENT
+        .get_or_init(|| {
+            build_blob_http_client(BLOB_CONNECT_TIMEOUT, BLOB_READ_TIMEOUT, BLOB_TOTAL_TIMEOUT)
+        })
+        .as_ref()
+        .map_err(Clone::clone)
+}

--- a/native/hydra-native/src/cloud_save/identity/mod.rs
+++ b/native/hydra-native/src/cloud_save/identity/mod.rs
@@ -5,7 +5,11 @@ use unicode_normalization::UnicodeNormalization;
 
 use crate::cloud_save::manifest::types::{CloudSaveRule, CloudSaveRuleCondition};
 
+pub const IDENTITY_VERSION: u32 = 1;
 pub const RULE_ID_VERSION: u32 = 1;
+pub const DISCOVERY_ENGINE_VERSION: u32 = 2;
+
+const STEAM_INDIVIDUAL_ACCOUNT_BASE: u64 = 76_561_197_960_265_728;
 
 #[napi(object)]
 #[derive(Clone, Debug, Serialize)]
@@ -15,6 +19,55 @@ pub struct SnapshotVariant {
     pub kind: String,
     pub steam_id64: Option<String>,
     pub concrete_folder_id: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct KnownStoreAccount {
+    pub store: String,
+    pub steam_id64: Option<String>,
+    pub account_id32: Option<String>,
+    pub source: String,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug, Default)]
+pub struct StoreUserContext {
+    pub active: Option<KnownStoreAccount>,
+    pub known: Vec<KnownStoreAccount>,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoreUserIdentity {
+    pub kind: String,
+    pub store: String,
+    pub steam_id64: Option<String>,
+    pub account_id32: Option<String>,
+    pub concrete_folder_id: String,
+    pub source: String,
+    pub authority: String,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortableStoreUserIdentity {
+    pub kind: String,
+    pub store: String,
+    pub steam_id64: Option<String>,
+    pub account_id32: Option<String>,
+    pub concrete_folder_id: String,
+}
+
+#[napi(object)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortableBindings {
+    pub store: String,
+    pub store_game_id: String,
+    pub store_user: PortableStoreUserIdentity,
 }
 
 #[napi(object)]
@@ -57,6 +110,19 @@ struct CanonicalRule<'a> {
     raw_rule: &'a str,
     target_semantics: &'a str,
     constraints: Vec<CanonicalRuleCondition<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalVariant<'a> {
+    variant_id_version: u32,
+    shop: &'a str,
+    object_id: &'a str,
+    kind: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    steam_id64: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    concrete_folder_id: Option<&'a str>,
 }
 
 fn hash_json<T: Serialize>(value: &T) -> String {
@@ -113,6 +179,185 @@ pub fn build_rule_id(rule: &CloudSaveRule) -> String {
     })
 }
 
+fn validated_steam_account(account: &KnownStoreAccount) -> Option<(String, String)> {
+    if account.store != "steam" {
+        return None;
+    }
+    let steam_id64 = account.steam_id64.as_deref()?.parse::<u64>().ok()?;
+    let account_id = steam_id64.checked_sub(STEAM_INDIVIDUAL_ACCOUNT_BASE)?;
+    if account_id > u32::MAX as u64 {
+        return None;
+    }
+    let account_id32 = account_id.to_string();
+    if account.account_id32.as_deref() != Some(account_id32.as_str()) {
+        return None;
+    }
+    Some((steam_id64.to_string(), account_id32))
+}
+
+fn account_matches(account: &KnownStoreAccount, captured: &str) -> Option<(String, String)> {
+    let validated = validated_steam_account(account)?;
+    ((captured == validated.0) || (captured == validated.1)).then_some(validated)
+}
+
+pub fn store_user_identity(
+    store: &str,
+    captured: Option<&str>,
+    context: &StoreUserContext,
+) -> StoreUserIdentity {
+    let concrete = captured.unwrap_or("__unbound__");
+    if captured.is_none() {
+        return StoreUserIdentity {
+            kind: "default".to_string(),
+            store: store.to_string(),
+            steam_id64: None,
+            account_id32: None,
+            concrete_folder_id: concrete.to_string(),
+            source: "unbound-rule".to_string(),
+            authority: "inferred".to_string(),
+        };
+    }
+    let active_match = context
+        .active
+        .as_ref()
+        .and_then(|account| account_matches(account, concrete).map(|ids| (account, ids)));
+    let known_match = context
+        .known
+        .iter()
+        .find_map(|account| account_matches(account, concrete).map(|ids| (account, ids)));
+
+    if let Some((account, (steam_id64, account_id32))) = active_match.or(known_match) {
+        let authority = if context.active.as_ref().is_some_and(|active| {
+            validated_steam_account(active).is_some_and(|ids| ids.0 == steam_id64)
+        }) {
+            "active"
+        } else {
+            "known"
+        };
+        return StoreUserIdentity {
+            kind: "validated-account".to_string(),
+            store: store.to_string(),
+            steam_id64: Some(steam_id64),
+            account_id32: Some(account_id32),
+            concrete_folder_id: concrete.to_string(),
+            source: account.source.clone(),
+            authority: authority.to_string(),
+        };
+    }
+
+    StoreUserIdentity {
+        kind: "opaque-folder".to_string(),
+        store: store.to_string(),
+        steam_id64: None,
+        account_id32: None,
+        concrete_folder_id: concrete.to_string(),
+        source: if captured.is_some() {
+            "folder-match".to_string()
+        } else {
+            "unbound-rule".to_string()
+        },
+        authority: "inferred".to_string(),
+    }
+}
+
+pub fn portable_bindings(
+    store: &str,
+    store_game_id: &str,
+    store_user: StoreUserIdentity,
+) -> PortableBindings {
+    PortableBindings {
+        store: store.to_string(),
+        store_game_id: store_game_id.to_string(),
+        store_user: PortableStoreUserIdentity {
+            kind: store_user.kind,
+            store: store_user.store,
+            steam_id64: store_user.steam_id64,
+            account_id32: store_user.account_id32,
+            concrete_folder_id: store_user.concrete_folder_id,
+        },
+    }
+}
+
+pub fn build_variant_id(
+    _save_namespace_key: &str,
+    bindings: &PortableBindings,
+    case_sensitive: bool,
+) -> String {
+    let store_user = &bindings.store_user;
+    if store_user.kind == "default" {
+        return hash_json(&CanonicalVariant {
+            variant_id_version: IDENTITY_VERSION,
+            shop: &bindings.store,
+            object_id: &bindings.store_game_id,
+            kind: "default",
+            steam_id64: None,
+            concrete_folder_id: None,
+        });
+    }
+    if store_user.kind == "validated-account" {
+        return hash_json(&CanonicalVariant {
+            variant_id_version: IDENTITY_VERSION,
+            shop: &bindings.store,
+            object_id: &bindings.store_game_id,
+            kind: "steam-account",
+            steam_id64: store_user.steam_id64.as_deref(),
+            concrete_folder_id: None,
+        });
+    }
+
+    let normalized = normalize_text(&store_user.concrete_folder_id);
+    let normalized = if case_sensitive {
+        normalized
+    } else {
+        normalized.to_lowercase()
+    };
+    hash_json(&CanonicalVariant {
+        variant_id_version: IDENTITY_VERSION,
+        shop: &bindings.store,
+        object_id: &bindings.store_game_id,
+        kind: "opaque-folder",
+        steam_id64: None,
+        concrete_folder_id: Some(&normalized),
+    })
+}
+
+pub fn build_snapshot_variant(
+    save_namespace_key: &str,
+    bindings: &PortableBindings,
+    case_sensitive: bool,
+) -> SnapshotVariant {
+    let variant_id = build_variant_id(save_namespace_key, bindings, case_sensitive);
+    let store_user = &bindings.store_user;
+    match store_user.kind.as_str() {
+        "default" => SnapshotVariant {
+            variant_id,
+            kind: "default".to_string(),
+            steam_id64: None,
+            concrete_folder_id: None,
+        },
+        "validated-account" => SnapshotVariant {
+            variant_id,
+            kind: "steam-account".to_string(),
+            steam_id64: store_user.steam_id64.clone(),
+            concrete_folder_id: None,
+        },
+        _ => {
+            let concrete_folder_id = normalize_text(&store_user.concrete_folder_id);
+            let concrete_folder_id = if case_sensitive {
+                concrete_folder_id
+            } else {
+                concrete_folder_id.to_lowercase()
+            };
+            SnapshotVariant {
+                variant_id,
+                kind: "opaque-folder".to_string(),
+                steam_id64: None,
+                concrete_folder_id: Some(concrete_folder_id),
+            }
+        }
+    }
+}
+
 pub fn local_id(parts: &[&str]) -> String {
     let mut hasher = blake3::Hasher::new();
     for part in parts {
@@ -160,16 +405,130 @@ mod tests {
     }
 
     #[test]
-    fn local_ids_are_length_delimited() {
-        assert_ne!(local_id(&["ab", "c"]), local_id(&["a", "bc"]));
-        assert_eq!(local_id(&["same"]), local_id(&["same"]));
+    fn steam_representations_share_a_variant() {
+        let steam_id64 = "76561198051718575";
+        let account_id32 = "91452847";
+        let account = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some(steam_id64.into()),
+            account_id32: Some(account_id32.into()),
+            source: "active-login".into(),
+        };
+        let context = StoreUserContext {
+            active: Some(account.clone()),
+            known: vec![account],
+        };
+        let namespace = "steam:814380";
+        let for_64 = portable_bindings(
+            "steam",
+            "814380",
+            store_user_identity("steam", Some(steam_id64), &context),
+        );
+        let for_32 = portable_bindings(
+            "steam",
+            "814380",
+            store_user_identity("steam", Some(account_id32), &context),
+        );
+        assert_eq!(
+            build_variant_id(namespace, &for_64, false),
+            build_variant_id(namespace, &for_32, false)
+        );
     }
 
     #[test]
-    fn capture_validation_rejects_path_segments() {
-        assert!(is_safe_capture("76561198012345678"));
-        for value in ["", ".", "..", "a/b", "a\\b", "a\0b"] {
-            assert!(!is_safe_capture(value));
+    fn remote_snapshot_account_hint_recognizes_both_steam_representations() {
+        let steam_id64 = "76561199800542110";
+        let account_id32 = "1840276382";
+        let account = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some(steam_id64.into()),
+            account_id32: Some(account_id32.into()),
+            source: "remote-snapshot".into(),
+        };
+        let context = StoreUserContext {
+            active: None,
+            known: vec![account],
+        };
+
+        for captured in [steam_id64, account_id32] {
+            let identity = store_user_identity("steam", Some(captured), &context);
+            assert_eq!(identity.kind, "validated-account");
+            assert_eq!(identity.steam_id64.as_deref(), Some(steam_id64));
+            assert_eq!(identity.account_id32.as_deref(), Some(account_id32));
+            assert_eq!(identity.source, "remote-snapshot");
         }
+    }
+
+    #[test]
+    fn builds_default_and_opaque_wire_variants_without_local_bindings() {
+        let default_bindings = portable_bindings(
+            "steam",
+            "1",
+            store_user_identity("steam", None, &StoreUserContext::default()),
+        );
+        let default = build_snapshot_variant("steam:1", &default_bindings, false);
+        assert_eq!(default.kind, "default");
+        assert!(default.steam_id64.is_none());
+        assert!(default.concrete_folder_id.is_none());
+
+        let opaque_bindings = portable_bindings(
+            "steam",
+            "1",
+            store_user_identity("steam", Some("Goldberg"), &StoreUserContext::default()),
+        );
+        let opaque = build_snapshot_variant("steam:1", &opaque_bindings, false);
+        assert_eq!(opaque.kind, "opaque-folder");
+        assert_eq!(opaque.concrete_folder_id.as_deref(), Some("goldberg"));
+        assert!(opaque.steam_id64.is_none());
+        assert_ne!(default.variant_id, opaque.variant_id);
+    }
+
+    #[test]
+    fn canonical_sekiro_fixture_uses_sha256_variant_and_snapshot() {
+        use crate::cloud_save::hashing::{
+            build_aggregate_hash, BuildSnapshotAggregateHashInput, SnapshotAggregateHashFile,
+        };
+
+        let mut rule = rule("<winAppData>/Sekiro/<storeUserId>/S0000.sl2");
+        rule.kind = "file".into();
+        rule.rule_id = build_rule_id(&rule);
+        let account = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some("76561197960278073".into()),
+            account_id32: Some("12345".into()),
+            source: "active-login".into(),
+        };
+        let context = StoreUserContext {
+            active: Some(account.clone()),
+            known: vec![account],
+        };
+        let bindings = portable_bindings(
+            "steam",
+            "814380",
+            store_user_identity("steam", Some("12345"), &context),
+        );
+        let variant = build_snapshot_variant("steam:814380", &bindings, false);
+        let variant_id = variant.variant_id.clone();
+        let aggregate_hash = build_aggregate_hash(BuildSnapshotAggregateHashInput {
+            variants: vec![variant],
+            files: vec![SnapshotAggregateHashFile {
+                variant_id: variant_id.clone(),
+                raw_path: rule.raw_path.clone(),
+                relative_path: "S0000.sl2".into(),
+                hash: "a".repeat(64),
+                size_bytes: 4.0,
+            }],
+        })
+        .unwrap();
+
+        assert_eq!(rule.rule_id.len(), 64);
+        assert_eq!(
+            variant_id,
+            "a3a47f520bfece378832d82e5c972ebdd0c596a6632a3804e5b71054d0d14c23"
+        );
+        assert_eq!(
+            aggregate_hash,
+            "8965f06a9d4fb91d0c353e4becd1ecac7a5b8ab7f8b66b7fe3f26c03375772bb"
+        );
     }
 }

--- a/native/hydra-native/src/cloud_save/mod.rs
+++ b/native/hydra-native/src/cloud_save/mod.rs
@@ -1,4 +1,5 @@
 pub mod hashing;
+mod http;
 pub mod identity;
 pub mod local_snapshot;
 pub mod manifest;

--- a/native/hydra-native/src/cloud_save/mod.rs
+++ b/native/hydra-native/src/cloud_save/mod.rs
@@ -3,4 +3,7 @@ pub mod identity;
 pub mod local_snapshot;
 pub mod manifest;
 pub mod path_resolution;
+pub mod pipeline;
+pub mod restore;
 pub mod save_scanner;
+pub mod upload;

--- a/native/hydra-native/src/cloud_save/path_resolution/context.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/context.rs
@@ -182,5 +182,6 @@ pub fn build_context(input: &ResolveSaveRulesInput) -> Result<PathResolutionCont
         windows_compatibility,
         derived_steam_root,
         configured_steam_root,
+        store_user_id: None,
     })
 }

--- a/native/hydra-native/src/cloud_save/path_resolution/mod.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/mod.rs
@@ -4,6 +4,7 @@ mod context;
 mod custom;
 mod resolve_path;
 mod resolve_rules;
+mod restore_root;
 mod tokens;
 mod types;
 
@@ -11,6 +12,9 @@ use napi::bindgen_prelude::Error;
 use napi_derive::napi;
 
 pub(crate) use capture::{capture_store_user, capture_template};
+pub(crate) use context::build_context;
+pub(crate) use resolve_path::glob_base_path;
+pub(crate) use restore_root::resolve_restore_root;
 pub use types::{ResolveSaveRulesInput, ResolvedCloudSavePath, ResolvedCloudSaveRule};
 
 #[napi]

--- a/native/hydra-native/src/cloud_save/path_resolution/restore_root.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/restore_root.rs
@@ -1,0 +1,367 @@
+use std::path::{Path, PathBuf};
+
+use globetter::MatchOptions;
+
+use super::context::normalize_separators;
+use super::resolve_path::resolve_path;
+use super::tokens::{literal, uses_windows_profile};
+use super::types::{PathResolutionContext, ResolvedCloudSavePath};
+use crate::cloud_save::save_scanner::scan_resolved_path;
+
+fn is_glob_segment(segment: &str) -> bool {
+    segment.contains(['*', '?', '[', '{'])
+}
+
+fn is_system_wine_profile(parent: &Path, name: &str) -> bool {
+    let parent = normalize_separators(&parent.to_string_lossy()).to_ascii_lowercase();
+    parent.ends_with("/users")
+        && matches!(
+            name.to_ascii_lowercase().as_str(),
+            "public" | "default" | "default user" | "all users" | "defaultuser0"
+        )
+}
+
+fn segment_matches(pattern: &str, value: &str, case_sensitive: bool) -> bool {
+    globset::GlobBuilder::new(pattern)
+        .case_insensitive(!case_sensitive)
+        .literal_separator(true)
+        .build()
+        .map(|pattern| pattern.compile_matcher().is_match(value))
+        .unwrap_or(false)
+}
+
+fn has_expected_type(path: &Path, directory: bool) -> bool {
+    if directory {
+        path.is_dir()
+    } else {
+        path.is_file()
+    }
+}
+
+fn exact_windows_profile(path: &str) -> Option<PathBuf> {
+    let lower = path.to_ascii_lowercase();
+    let marker = "/drive_c/users/";
+    let profile_start = lower.find(marker)? + marker.len();
+    let profile_end = path[profile_start..]
+        .find('/')
+        .map(|offset| profile_start + offset)
+        .unwrap_or(path.len());
+    let profile = &path[profile_start..profile_end];
+
+    (!profile.is_empty() && !is_glob_segment(profile)).then(|| PathBuf::from(&path[..profile_end]))
+}
+
+fn materialize_candidate(candidate: &ResolvedCloudSavePath, directory: bool) -> Vec<String> {
+    let normalized = normalize_separators(&candidate.path);
+    let absolute = normalized.starts_with('/');
+    let segments = normalized
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    let Some(last_dynamic) = segments
+        .iter()
+        .rposition(|segment| is_glob_segment(segment))
+    else {
+        let path = Path::new(&normalized);
+        let can_create = !path.exists()
+            && exact_windows_profile(&normalized).is_none_or(|profile| profile.is_dir());
+        return (can_create || has_expected_type(path, directory))
+            .then_some(normalized)
+            .into_iter()
+            .collect();
+    };
+    let windows_drive = !absolute
+        && segments
+            .first()
+            .is_some_and(|segment| segment.ends_with(':'));
+    let mut paths = if absolute {
+        vec![PathBuf::from("/")]
+    } else if windows_drive {
+        vec![PathBuf::from(format!("{}/", segments[0]))]
+    } else {
+        vec![PathBuf::new()]
+    };
+    let start = usize::from(windows_drive);
+
+    for (index, segment) in segments.iter().enumerate().skip(start) {
+        if index > last_dynamic {
+            for path in &mut paths {
+                path.push(segment);
+            }
+            continue;
+        }
+        if !is_glob_segment(segment) {
+            for path in &mut paths {
+                path.push(segment);
+            }
+            if index < last_dynamic {
+                paths.retain(|path| path.is_dir());
+            }
+            continue;
+        }
+
+        let mut expanded = Vec::new();
+        for parent in paths {
+            let Ok(entries) = std::fs::read_dir(&parent) else {
+                continue;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if !file_type.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                if !is_system_wine_profile(&parent, &name)
+                    && segment_matches(segment, &name, candidate.case_sensitive)
+                {
+                    expanded.push(entry.path());
+                }
+            }
+        }
+        paths = expanded;
+    }
+
+    paths
+        .into_iter()
+        .map(|path| normalize_separators(&path.to_string_lossy()))
+        .collect()
+}
+
+fn complete_matches(
+    candidate: &ResolvedCloudSavePath,
+    directory: bool,
+) -> Result<Vec<String>, String> {
+    let entries = globetter::glob_with(
+        &candidate.path,
+        MatchOptions {
+            case_sensitive: candidate.case_sensitive,
+            require_literal_separator: true,
+            require_literal_leading_dot: false,
+            follow_links: true,
+        },
+    )
+    .map_err(|error| format!("cloud_save_invalid_glob: {error}"))?;
+
+    entries
+        .map(|entry| {
+            entry
+                .map_err(|error| format!("cloud_save_filesystem_error: {error}"))
+                .map(|path| (has_expected_type(&path, directory), path))
+        })
+        .filter_map(|entry| match entry {
+            Ok((true, path)) => Some(Ok(normalize_separators(&path.to_string_lossy()))),
+            Ok((false, _)) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect()
+}
+
+fn first_sorted(mut paths: Vec<String>) -> Option<String> {
+    paths.sort();
+    paths.dedup();
+    paths.into_iter().next()
+}
+
+fn valid_store_user_id(value: &str) -> bool {
+    (5..=20).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn concrete_store_user_path(raw_path: &str, store_user_id: &str) -> String {
+    raw_path
+        .replace("*<storeUserId>", store_user_id)
+        .replace("<storeUserId>*", store_user_id)
+        .replace("<storeUserId>", store_user_id)
+}
+
+fn authoritative_candidates(
+    raw_path: &str,
+    context: &PathResolutionContext,
+    candidates: Vec<ResolvedCloudSavePath>,
+) -> Result<Vec<ResolvedCloudSavePath>, String> {
+    if !context.windows_compatibility || !uses_windows_profile(raw_path) {
+        return Ok(candidates);
+    }
+    let Some(prefix) = context.wine_prefix_path.as_deref() else {
+        return Ok(candidates);
+    };
+    let prefix = literal(prefix);
+    let prefix_with_separator = format!("{}/", prefix.trim_end_matches('/'));
+    let filtered = candidates
+        .into_iter()
+        .filter(|candidate| {
+            candidate.path == prefix || candidate.path.starts_with(&prefix_with_separator)
+        })
+        .collect::<Vec<_>>();
+
+    if filtered.is_empty() {
+        return Err(format!(
+            "cloud_save_restore_prefix_mismatch: raw_path={raw_path}; wine_prefix_path={prefix}"
+        ));
+    }
+    Ok(filtered)
+}
+
+fn existing_wine_profiles(context: &PathResolutionContext) -> Vec<String> {
+    let Some(prefix) = context.wine_prefix_path.as_deref() else {
+        return Vec::new();
+    };
+    let users = Path::new(prefix).join("drive_c/users");
+    let Ok(entries) = std::fs::read_dir(&users) else {
+        return Vec::new();
+    };
+    let mut profiles = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            (!is_system_wine_profile(&users, &name)
+                && entry
+                    .path()
+                    .metadata()
+                    .is_ok_and(|metadata| metadata.is_dir()))
+            .then_some(name)
+        })
+        .collect::<Vec<_>>();
+    profiles.sort_by(|left, right| {
+        let priority = |value: &str| {
+            if value.eq_ignore_ascii_case("steamuser") {
+                0
+            } else if value.eq_ignore_ascii_case(&context.os_username) {
+                1
+            } else {
+                2
+            }
+        };
+        priority(left)
+            .cmp(&priority(right))
+            .then_with(|| left.cmp(right))
+    });
+    profiles
+}
+
+fn profile_unresolved(raw_path: &str, context: &PathResolutionContext) -> String {
+    format!(
+        "cloud_save_restore_profile_unresolved: raw_path={raw_path}; store_user_id_present={}; wine_prefix_path={}",
+        context.store_user_id.is_some(),
+        context.wine_prefix_path.as_deref().unwrap_or("none")
+    )
+}
+
+fn restore_root_not_found(
+    raw_path: &str,
+    context: &PathResolutionContext,
+    candidates: &[ResolvedCloudSavePath],
+) -> String {
+    let candidate_paths = candidates
+        .iter()
+        .take(6)
+        .map(|candidate| candidate.path.as_str())
+        .collect::<Vec<_>>()
+        .join(" | ");
+    format!(
+        "cloud_save_restore_root_not_found: raw_path={raw_path}; store_user_id_present={}; wine_prefix_path={}; candidates={candidate_paths}",
+        context.store_user_id.is_some(),
+        context.wine_prefix_path.as_deref().unwrap_or("none")
+    )
+}
+
+pub fn resolve_restore_root(
+    raw_path: &str,
+    context: &PathResolutionContext,
+    directory: bool,
+    relative_paths: &[String],
+) -> Result<String, String> {
+    let resolved = resolve_path(raw_path, context);
+    if resolved.paths.is_empty() {
+        return Err(format!(
+            "cloud_save_unresolved_restore_tokens: {}",
+            resolved.unresolved_tokens.join(", ")
+        ));
+    }
+    let candidates = authoritative_candidates(raw_path, context, resolved.paths)?;
+    let mut complete_by_candidate = Vec::with_capacity(candidates.len());
+    for candidate in &candidates {
+        let mut complete = complete_matches(candidate, directory)?;
+        complete.sort();
+        complete.dedup();
+        if directory {
+            let requested_target = complete.iter().find(|root| {
+                relative_paths.iter().any(|relative_path| {
+                    Path::new(root)
+                        .join(relative_path.replace('\\', "/"))
+                        .is_file()
+                })
+            });
+            if let Some(root) = requested_target {
+                return Ok(root.clone());
+            }
+        } else if let Some(file) = first_sorted(complete.clone()) {
+            return Ok(file);
+        }
+        complete_by_candidate.push(complete);
+    }
+
+    if directory {
+        for candidate in &candidates {
+            let scanned_paths = scan_resolved_path(
+                &candidate.path,
+                candidate.case_sensitive,
+                candidate.scan_root.as_deref(),
+            )?;
+            if let Some(scanned) = scanned_paths
+                .into_iter()
+                .find(|scanned| !scanned.files.is_empty())
+            {
+                return Ok(scanned.resolved_path);
+            }
+        }
+    }
+
+    for complete in complete_by_candidate {
+        if let Some(existing) = first_sorted(complete) {
+            return Ok(existing);
+        }
+    }
+
+    if raw_path.contains("<storeUserId>") {
+        for candidate in &candidates {
+            if let Some(materialized) = first_sorted(materialize_candidate(candidate, directory)) {
+                return Ok(materialized);
+            }
+        }
+
+        let store_user_id = context
+            .store_user_id
+            .as_deref()
+            .filter(|value| valid_store_user_id(value))
+            .ok_or_else(|| "cloud_save_store_user_id_unresolved".to_string())?;
+        let concrete = concrete_store_user_path(raw_path, store_user_id);
+        let resolved = resolve_path(&concrete, context);
+        let candidates = authoritative_candidates(raw_path, context, resolved.paths)?;
+        for candidate in &candidates {
+            if let Some(materialized) = first_sorted(materialize_candidate(candidate, directory)) {
+                return Ok(materialized);
+            }
+        }
+        if context.windows_compatibility && existing_wine_profiles(context).is_empty() {
+            return Err(profile_unresolved(raw_path, context));
+        }
+        return Err(restore_root_not_found(raw_path, context, &candidates));
+    }
+
+    for candidate in &candidates {
+        if let Some(materialized) = first_sorted(materialize_candidate(candidate, directory)) {
+            return Ok(materialized);
+        }
+    }
+
+    if context.windows_compatibility
+        && uses_windows_profile(raw_path)
+        && existing_wine_profiles(context).is_empty()
+    {
+        return Err(profile_unresolved(raw_path, context));
+    }
+
+    Err(restore_root_not_found(raw_path, context, &candidates))
+}

--- a/native/hydra-native/src/cloud_save/path_resolution/types.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/types.rs
@@ -36,6 +36,7 @@ pub struct PathResolutionContext {
     pub windows_compatibility: bool,
     pub derived_steam_root: Option<String>,
     pub configured_steam_root: Option<String>,
+    pub store_user_id: Option<String>,
 }
 
 #[napi(object)]

--- a/native/hydra-native/src/cloud_save/pipeline/mod.rs
+++ b/native/hydra-native/src/cloud_save/pipeline/mod.rs
@@ -1,0 +1,398 @@
+mod types;
+
+use std::collections::{btree_map::Entry, BTreeMap, HashSet};
+use std::path::Path;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+use super::identity::{
+    build_snapshot_variant, local_id, normalize_text, portable_bindings, store_user_identity,
+    LocalResolutionBindings, SnapshotVariant, StoreUserContext, UserLocationCoverage,
+    DISCOVERY_ENGINE_VERSION,
+};
+use super::local_snapshot::types::DiscoveredLocalSaveFile;
+use super::local_snapshot::{
+    build_local_game_snapshot, BuildLocalGameSnapshotInput, LocalGameSnapshotWithHash,
+};
+use super::manifest::types::CloudSaveGameId;
+use super::manifest::{get_save_rules_for_game, GetSaveRulesForGameInput};
+use super::path_resolution::{resolve_save_rules, ResolveSaveRulesInput};
+use super::save_scanner::{scan_resolved_save_rules, ScannedCloudSaveRule};
+
+pub use types::BuildLocalGameSnapshotPipelineInput;
+
+const DYNAMIC_PATH_PRIORITY: u8 = 0;
+const STATIC_PATH_PRIORITY: u8 = 1;
+const STATIC_FILE_PRIORITY: u8 = 2;
+
+fn coverage_authority(identity_authority: &str) -> String {
+    match identity_authority {
+        "active" => "authoritative",
+        "known" => "exact",
+        _ => "inferred",
+    }
+    .to_string()
+}
+
+fn collect_discovered_files(
+    shop: &str,
+    object_id: &str,
+    save_namespace_key: &str,
+    environment_id: &str,
+    store_user_context: &StoreUserContext,
+    scanned_rules: Vec<ScannedCloudSaveRule>,
+) -> Result<
+    (
+        Vec<SnapshotVariant>,
+        Vec<DiscoveredLocalSaveFile>,
+        Vec<UserLocationCoverage>,
+    ),
+    String,
+> {
+    let mut discovered_by_path = BTreeMap::new();
+    let mut coverage = Vec::new();
+    let mut identity_by_candidate = BTreeMap::<String, (String, String)>::new();
+    let mut variants_by_id = BTreeMap::<String, SnapshotVariant>::new();
+
+    for rule in scanned_rules {
+        let path_priority = if rule
+            .resolved_paths
+            .iter()
+            .any(|path| !path.dynamic && Path::new(&path.path).is_file())
+        {
+            STATIC_FILE_PRIORITY
+        } else if rule.resolved_paths.iter().any(|path| !path.dynamic) {
+            STATIC_PATH_PRIORITY
+        } else {
+            DYNAMIC_PATH_PRIORITY
+        };
+        // A custom rule that overlaps a manifest rule must not rename an
+        // already tracked file and create a second remote identity.
+        let priority = (rule.source != "custom", path_priority);
+        for scanned_path in rule.scanned_paths {
+            let store_user = store_user_identity(
+                shop,
+                scanned_path.store_user_id.as_deref(),
+                store_user_context,
+            );
+            let authority = store_user.authority.clone();
+            let coverage_authority = coverage_authority(&authority);
+            let concrete_user_segment = store_user.concrete_folder_id.clone();
+            let bindings = portable_bindings(shop, object_id, store_user);
+            let variant =
+                build_snapshot_variant(save_namespace_key, &bindings, scanned_path.case_sensitive);
+            let variant_id = variant.variant_id.clone();
+            if let Some(existing) = variants_by_id.insert(variant_id.clone(), variant.clone()) {
+                if existing.kind != variant.kind
+                    || existing.steam_id64 != variant.steam_id64
+                    || existing.concrete_folder_id != variant.concrete_folder_id
+                {
+                    return Err("cloud_save_variant_metadata_mismatch".to_string());
+                }
+            }
+            identity_by_candidate.insert(
+                scanned_path.candidate_id.clone(),
+                (variant_id.clone(), coverage_authority.clone()),
+            );
+            for file in scanned_path.files {
+                let relative_path = normalize_text(&file.relative_path.replace('\\', "/"));
+                let provenance = vec![format!("{}:{}", rule.source, rule.rule_id)];
+                let discovered = DiscoveredLocalSaveFile {
+                    variant_id: variant_id.clone(),
+                    rule_id: rule.rule_id.clone(),
+                    raw_path: rule.raw_path.clone(),
+                    absolute_path: file.absolute_path.clone(),
+                    relative_path,
+                    local_bindings: LocalResolutionBindings {
+                        environment_id: environment_id.to_string(),
+                        root_id: local_id(&[environment_id, &scanned_path.resolved_path]),
+                        prefix_generation_id: None,
+                        concrete_user_segment: concrete_user_segment.clone(),
+                        concrete_path: scanned_path.resolved_path.clone(),
+                    },
+                    confidence: coverage_authority.clone(),
+                    provenance,
+                };
+
+                match discovered_by_path.entry(file.absolute_path) {
+                    Entry::Vacant(entry) => {
+                        entry.insert((priority, discovered));
+                    }
+                    Entry::Occupied(mut entry) => {
+                        let (existing_priority, existing) = entry.get_mut();
+                        let replace = priority > *existing_priority
+                            || (priority == *existing_priority
+                                && (
+                                    &discovered.variant_id,
+                                    &discovered.raw_path,
+                                    &discovered.relative_path,
+                                ) < (
+                                    &existing.variant_id,
+                                    &existing.raw_path,
+                                    &existing.relative_path,
+                                ));
+                        if replace {
+                            let mut replacement = discovered;
+                            replacement
+                                .provenance
+                                .extend(existing.provenance.iter().cloned());
+                            replacement.provenance.sort();
+                            replacement.provenance.dedup();
+                            entry.insert((priority, replacement));
+                        } else {
+                            existing.provenance.extend(discovered.provenance);
+                            existing.provenance.sort();
+                            existing.provenance.dedup();
+                        }
+                    }
+                }
+            }
+        }
+
+        for mut item in rule.coverage {
+            if let Some((variant_id, authority)) = identity_by_candidate.get(&item.candidate_id) {
+                item.variant_id = Some(variant_id.clone());
+                item.authority = authority.clone();
+            }
+            coverage.push(item);
+        }
+    }
+
+    let mut discovered_by_identity = BTreeMap::new();
+    let mut ambiguous = HashSet::new();
+    for (_, discovered) in discovered_by_path.into_values() {
+        let identity = (
+            discovered.variant_id.clone(),
+            discovered.raw_path.clone(),
+            discovered.relative_path.clone(),
+        );
+        match discovered_by_identity.entry(identity.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert(discovered);
+            }
+            Entry::Occupied(entry) if entry.get().absolute_path != discovered.absolute_path => {
+                ambiguous.insert(identity);
+                coverage.push(UserLocationCoverage {
+                    candidate_id: local_id(&[
+                        "ambiguous",
+                        &discovered.variant_id,
+                        &discovered.raw_path,
+                        &discovered.relative_path,
+                    ]),
+                    rule_id: discovered.rule_id.clone(),
+                    variant_id: Some(discovered.variant_id.clone()),
+                    raw_path: Some(discovered.raw_path.clone()),
+                    relative_path: Some(discovered.relative_path.clone()),
+                    selected_root: true,
+                    authority: discovered.confidence.clone(),
+                    outcome: "partial".to_string(),
+                    enumerated_completely: false,
+                    warning_codes: vec!["ambiguous-location".to_string()],
+                });
+            }
+            Entry::Occupied(_) => {}
+        }
+    }
+    for identity in ambiguous {
+        discovered_by_identity.remove(&identity);
+    }
+    coverage.sort_by(|left, right| {
+        left.rule_id
+            .cmp(&right.rule_id)
+            .then_with(|| left.variant_id.cmp(&right.variant_id))
+            .then_with(|| left.candidate_id.cmp(&right.candidate_id))
+    });
+
+    Ok((
+        variants_by_id.into_values().collect(),
+        discovered_by_identity.into_values().collect(),
+        coverage,
+    ))
+}
+
+#[napi]
+pub async fn build_local_game_snapshot_pipeline(
+    input: BuildLocalGameSnapshotPipelineInput,
+) -> napi::Result<LocalGameSnapshotWithHash> {
+    let shop = input.shop;
+    let object_id = input.object_id;
+    let save_namespace_key = format!("{shop}:{object_id}");
+    let save_rules = get_save_rules_for_game(GetSaveRulesForGameInput {
+        shop: shop.clone(),
+        object_id: object_id.clone(),
+        title: input.title,
+        remote_id: input.remote_id,
+        user_data_path: input.user_data_path,
+        source_url: input.source_url,
+    })
+    .await?;
+    let manifest_key = save_rules.manifest_key;
+    let rule_source_revision = save_rules.rule_source_revision;
+    let mut rules = save_rules.rules;
+    rules.extend(input.extra_rules.unwrap_or_default());
+    let resolved_rules = resolve_save_rules(ResolveSaveRulesInput {
+        shop: shop.clone(),
+        object_id: object_id.clone(),
+        platform: input.platform,
+        home_dir: input.home_dir,
+        documents_dir: input.documents_dir,
+        app_data_dir: input.app_data_dir,
+        executable_path: input.executable_path,
+        wine_prefix_path: input.wine_prefix_path,
+        steam_path: input.steam_path,
+        rules,
+    })?;
+    let scanned_rules = scan_resolved_save_rules(resolved_rules).await?;
+    let environment_id = input.environment_id;
+    let store_user_context = input.store_user_context;
+    let namespace_for_collect = save_namespace_key.clone();
+    let shop_for_collect = shop.clone();
+    let object_for_collect = object_id.clone();
+    let (variants, discovered_files, coverage) = tokio::task::spawn_blocking(move || {
+        collect_discovered_files(
+            &shop_for_collect,
+            &object_for_collect,
+            &namespace_for_collect,
+            &environment_id,
+            &store_user_context,
+            scanned_rules,
+        )
+    })
+    .await
+    .map_err(|error| Error::from_reason(error.to_string()))?
+    .map_err(Error::from_reason)?;
+
+    build_local_game_snapshot(BuildLocalGameSnapshotInput {
+        game_id: CloudSaveGameId { shop, object_id },
+        manifest_key,
+        rule_source_revision,
+        discovery_engine_version: DISCOVERY_ENGINE_VERSION,
+        coverage,
+        variants,
+        files: discovered_files,
+        hash_cache: input.hash_cache,
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::cloud_save::path_resolution::ResolvedCloudSavePath;
+    use crate::cloud_save::save_scanner::{ScannedCloudSaveFile, ScannedCloudSavePath};
+
+    fn scanned_rule(
+        raw_path: &str,
+        user: Option<&str>,
+        absolute_path: &str,
+        relative_path: &str,
+    ) -> ScannedCloudSaveRule {
+        ScannedCloudSaveRule {
+            rule_id: format!("rule-{raw_path}"),
+            kind: "dir".into(),
+            raw_path: raw_path.into(),
+            source: "test".into(),
+            tags: vec!["save".into()],
+            when: vec![],
+            resolved_paths: vec![ResolvedCloudSavePath {
+                path: absolute_path.into(),
+                case_sensitive: false,
+                dynamic: user.is_some(),
+                scan_root: None,
+            }],
+            unresolved_tokens: vec![],
+            scanned_paths: vec![ScannedCloudSavePath {
+                candidate_id: format!("candidate-{user:?}"),
+                resolved_path: Path::new(absolute_path)
+                    .parent()
+                    .unwrap()
+                    .display()
+                    .to_string(),
+                store_user_id: user.map(ToString::to_string),
+                case_sensitive: false,
+                files: vec![ScannedCloudSaveFile {
+                    absolute_path: absolute_path.into(),
+                    relative_path: relative_path.into(),
+                }],
+            }],
+            coverage: vec![],
+        }
+    }
+
+    #[test]
+    fn keeps_same_relative_file_for_two_store_users() {
+        let temp = tempdir().unwrap();
+        let first = temp.path().join("111111/S0000.sl2");
+        let second = temp.path().join("222222/S0000.sl2");
+        fs::create_dir_all(first.parent().unwrap()).unwrap();
+        fs::create_dir_all(second.parent().unwrap()).unwrap();
+        fs::write(&first, b"same").unwrap();
+        fs::write(&second, b"same").unwrap();
+
+        let (variants, files, _) = collect_discovered_files(
+            "steam",
+            "814380",
+            "steam:814380",
+            "environment",
+            &StoreUserContext::default(),
+            vec![
+                scanned_rule(
+                    "<winAppData>/Sekiro/<storeUserId>",
+                    Some("111111"),
+                    &first.display().to_string(),
+                    "S0000.sl2",
+                ),
+                scanned_rule(
+                    "<winAppData>/Sekiro/<storeUserId>",
+                    Some("222222"),
+                    &second.display().to_string(),
+                    "S0000.sl2",
+                ),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 2);
+        assert_eq!(variants.len(), 2);
+        assert_ne!(files[0].variant_id, files[1].variant_id);
+    }
+
+    #[test]
+    fn manifest_identity_wins_when_a_custom_rule_finds_the_same_file() {
+        let temp = tempdir().unwrap();
+        let save = temp.path().join("slot.sav");
+        fs::write(&save, b"same").unwrap();
+        let mut custom = scanned_rule(
+            "<custom><windows><winDocuments>/Game",
+            None,
+            &save.display().to_string(),
+            "slot.sav",
+        );
+        custom.source = "custom".into();
+        let mut manifest = scanned_rule(
+            "<winDocuments>/Game",
+            None,
+            &save.display().to_string(),
+            "slot.sav",
+        );
+        manifest.source = "ludusavi".into();
+
+        let (_, files, _) = collect_discovered_files(
+            "steam",
+            "1",
+            "steam:1",
+            "environment",
+            &StoreUserContext::default(),
+            vec![custom, manifest],
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].raw_path, "<winDocuments>/Game");
+    }
+}

--- a/native/hydra-native/src/cloud_save/pipeline/types.rs
+++ b/native/hydra-native/src/cloud_save/pipeline/types.rs
@@ -1,0 +1,26 @@
+use napi_derive::napi;
+
+use crate::cloud_save::hashing::LocalFileHashCacheEntry;
+use crate::cloud_save::identity::StoreUserContext;
+use crate::cloud_save::manifest::types::CloudSaveRule;
+
+#[napi(object)]
+pub struct BuildLocalGameSnapshotPipelineInput {
+    pub shop: String,
+    pub object_id: String,
+    pub title: Option<String>,
+    pub remote_id: Option<String>,
+    pub user_data_path: String,
+    pub source_url: Option<String>,
+    pub platform: String,
+    pub home_dir: String,
+    pub documents_dir: Option<String>,
+    pub app_data_dir: Option<String>,
+    pub executable_path: Option<String>,
+    pub wine_prefix_path: Option<String>,
+    pub steam_path: Option<String>,
+    pub environment_id: String,
+    pub store_user_context: StoreUserContext,
+    pub hash_cache: Vec<LocalFileHashCacheEntry>,
+    pub extra_rules: Option<Vec<CloudSaveRule>>,
+}

--- a/native/hydra-native/src/cloud_save/restore/artifacts.rs
+++ b/native/hydra-native/src/cloud_save/restore/artifacts.rs
@@ -1,0 +1,65 @@
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+const ARTIFACT_PREFIX: &str = ".hydra-restore-";
+
+pub(crate) struct RestoreArtifactPaths {
+    pub stage: PathBuf,
+    pub backup: PathBuf,
+}
+
+pub(crate) fn restore_artifact_paths(
+    target: &Path,
+    target_key: &str,
+) -> Result<RestoreArtifactPaths, String> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| "cloud_save_restore_target_without_parent".to_string())?;
+    let id = format!("{:x}", Sha256::digest(target_key.as_bytes()));
+    Ok(RestoreArtifactPaths {
+        stage: parent.join(format!("{ARTIFACT_PREFIX}{id}-stage")),
+        backup: parent.join(format!("{ARTIFACT_PREFIX}{id}-backup")),
+    })
+}
+
+pub(crate) fn is_restore_artifact_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(value) = name.strip_prefix(ARTIFACT_PREFIX) else {
+        return false;
+    };
+    let Some((id, kind)) = value.rsplit_once('-') else {
+        return false;
+    };
+
+    id.len() == 64
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        && matches!(kind, "stage" | "backup")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_only_exact_internal_artifact_names() {
+        for name in [
+            format!("{ARTIFACT_PREFIX}{}-stage", "a".repeat(64)),
+            format!("{ARTIFACT_PREFIX}{}-backup", "1".repeat(64)),
+        ] {
+            assert!(is_restore_artifact_path(Path::new(&name)));
+        }
+        for name in [
+            ".hydra-restore-save.dat".to_string(),
+            ".hydra-restore-not-a-hash-stage".to_string(),
+            format!("{ARTIFACT_PREFIX}{}-other", "a".repeat(64)),
+            format!("{ARTIFACT_PREFIX}{}-stage", "A".repeat(64)),
+        ] {
+            assert!(!is_restore_artifact_path(Path::new(&name)));
+        }
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/download_blob.rs
+++ b/native/hydra-native/src/cloud_save/restore/download_blob.rs
@@ -1,0 +1,208 @@
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+use tokio::io::AsyncWriteExt;
+
+use super::validation::{validate_hash, validate_path_component};
+
+fn build_paths(temp_root: &str, snapshot_id: &str, hash: &str) -> (PathBuf, PathBuf) {
+    let directory = Path::new(temp_root)
+        .join("hydra-cloud-saves")
+        .join(snapshot_id);
+    (
+        directory.join(format!("{hash}.blob")),
+        directory.join(format!("{hash}.blob.part")),
+    )
+}
+
+async fn remove_if_exists(path: &Path) -> std::io::Result<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn download_error(stage: &str, error: reqwest::Error) -> String {
+    format!("{stage}: {}", error.without_url())
+}
+
+async fn download_blob(
+    download_url: String,
+    final_path: &Path,
+    partial_path: &Path,
+) -> Result<(), String> {
+    let mut response = reqwest::Client::new()
+        .get(download_url)
+        .send()
+        .await
+        .map_err(|error| download_error("Failed to download restore blob", error))?
+        .error_for_status()
+        .map_err(|error| download_error("Failed to download restore blob", error))?;
+    let parent = final_path
+        .parent()
+        .ok_or_else(|| "cloud_save_invalid_restore_temp_path".to_string())?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|error| format!("Failed to create restore temporary directory: {error}"))?;
+    remove_if_exists(partial_path)
+        .await
+        .map_err(|error| format!("Failed to clear partial restore blob: {error}"))?;
+    let mut output = tokio::fs::File::create(partial_path)
+        .await
+        .map_err(|error| format!("Failed to create temporary restore blob: {error}"))?;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| download_error("Failed to read restore blob response", error))?
+    {
+        output
+            .write_all(&chunk)
+            .await
+            .map_err(|error| format!("Failed to write temporary restore blob: {error}"))?;
+    }
+    output
+        .flush()
+        .await
+        .map_err(|error| format!("Failed to flush temporary restore blob: {error}"))?;
+    output
+        .sync_all()
+        .await
+        .map_err(|error| format!("Failed to sync temporary restore blob: {error}"))?;
+    drop(output);
+
+    remove_if_exists(final_path)
+        .await
+        .map_err(|error| format!("Failed to replace temporary restore blob: {error}"))?;
+    tokio::fs::rename(partial_path, final_path)
+        .await
+        .map_err(|error| format!("Failed to finalize temporary restore blob: {error}"))
+}
+
+#[napi]
+pub async fn download_restore_blob_to_temp(
+    snapshot_id: String,
+    hash: String,
+    download_url: String,
+    temp_root: String,
+) -> napi::Result<String> {
+    validate_path_component(&snapshot_id).map_err(Error::from_reason)?;
+    validate_hash(&hash).map_err(Error::from_reason)?;
+    if temp_root.is_empty() {
+        return Err(Error::from_reason("cloud_save_invalid_restore_temp_root"));
+    }
+
+    let (final_path, partial_path) = build_paths(&temp_root, &snapshot_id, &hash);
+    if let Err(error) = download_blob(download_url, &final_path, &partial_path).await {
+        let _ = remove_if_exists(&partial_path).await;
+        return Err(Error::from_reason(error));
+    }
+
+    Ok(final_path.to_string_lossy().to_string())
+}
+
+#[napi]
+pub async fn cleanup_restore_temp_snapshot(
+    snapshot_id: String,
+    temp_root: String,
+) -> napi::Result<()> {
+    validate_path_component(&snapshot_id).map_err(Error::from_reason)?;
+    if temp_root.is_empty() {
+        return Err(Error::from_reason("cloud_save_invalid_restore_temp_root"));
+    }
+    let directory = Path::new(&temp_root)
+        .join("hydra-cloud-saves")
+        .join(snapshot_id);
+    match tokio::fs::remove_dir_all(directory).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::from_reason(format!(
+            "Failed to clean restore temporary directory: {error}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    async fn server(response: &'static [u8]) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await;
+            stream.write_all(response).await.unwrap();
+        });
+        format!("http://{address}/blob?signature=secret")
+    }
+
+    #[tokio::test]
+    async fn downloads_atomically_and_cleans_snapshot() {
+        let url = server(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nsave").await;
+        let directory = tempdir().unwrap();
+        let hash = "a".repeat(64);
+        let result = download_restore_blob_to_temp(
+            "snapshot_1".to_string(),
+            hash.clone(),
+            url,
+            directory.path().display().to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tokio::fs::read(&result).await.unwrap(), b"save");
+        assert!(!PathBuf::from(format!("{result}.part")).exists());
+
+        cleanup_restore_temp_snapshot(
+            "snapshot_1".to_string(),
+            directory.path().display().to_string(),
+        )
+        .await
+        .unwrap();
+        assert!(!Path::new(&result).exists());
+    }
+
+    #[tokio::test]
+    async fn removes_partial_download_and_signed_url_from_errors() {
+        let directory = tempdir().unwrap();
+        let hash = "a".repeat(64);
+        let truncated = server(b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nshort").await;
+        let error = download_restore_blob_to_temp(
+            "snapshot_1".to_string(),
+            hash.clone(),
+            truncated,
+            directory.path().display().to_string(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        let (final_path, partial_path) =
+            build_paths(&directory.path().display().to_string(), "snapshot_1", &hash);
+        assert!(!final_path.exists());
+        assert!(!partial_path.exists());
+        assert!(!error.contains("signature=secret"));
+
+        let rejected = server(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n").await;
+        let error = download_restore_blob_to_temp(
+            "snapshot_1".to_string(),
+            hash,
+            rejected,
+            directory.path().display().to_string(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("403 Forbidden"));
+        assert!(!error.contains("signature=secret"));
+        assert!(!error.contains("http://"));
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/download_blob.rs
+++ b/native/hydra-native/src/cloud_save/restore/download_blob.rs
@@ -5,7 +5,9 @@ use napi::bindgen_prelude::Error;
 use napi_derive::napi;
 use tokio::io::AsyncWriteExt;
 
-use super::validation::{validate_hash, validate_path_component};
+use crate::cloud_save::http::blob_http_client;
+
+use super::validation::{validate_hash, validate_path_component, validate_size};
 
 fn build_paths(temp_root: &str, snapshot_id: &str, hash: &str) -> (PathBuf, PathBuf) {
     let directory = Path::new(temp_root)
@@ -30,17 +32,25 @@ fn download_error(stage: &str, error: reqwest::Error) -> String {
 }
 
 async fn download_blob(
+    client: &reqwest::Client,
     download_url: String,
+    expected_size: u64,
     final_path: &Path,
     partial_path: &Path,
 ) -> Result<(), String> {
-    let mut response = reqwest::Client::new()
+    let mut response = client
         .get(download_url)
         .send()
         .await
         .map_err(|error| download_error("Failed to download restore blob", error))?
         .error_for_status()
         .map_err(|error| download_error("Failed to download restore blob", error))?;
+    if response
+        .content_length()
+        .is_some_and(|content_length| content_length != expected_size)
+    {
+        return Err("cloud_save_restore_download_size_mismatch".to_string());
+    }
     let parent = final_path
         .parent()
         .ok_or_else(|| "cloud_save_invalid_restore_temp_path".to_string())?;
@@ -54,15 +64,25 @@ async fn download_blob(
         .await
         .map_err(|error| format!("Failed to create temporary restore blob: {error}"))?;
 
+    let mut downloaded_size = 0_u64;
     while let Some(chunk) = response
         .chunk()
         .await
         .map_err(|error| download_error("Failed to read restore blob response", error))?
     {
+        downloaded_size = downloaded_size
+            .checked_add(chunk.len() as u64)
+            .ok_or_else(|| "cloud_save_restore_download_size_mismatch".to_string())?;
+        if downloaded_size > expected_size {
+            return Err("cloud_save_restore_download_size_mismatch".to_string());
+        }
         output
             .write_all(&chunk)
             .await
             .map_err(|error| format!("Failed to write temporary restore blob: {error}"))?;
+    }
+    if downloaded_size != expected_size {
+        return Err("cloud_save_restore_download_size_mismatch".to_string());
     }
     output
         .flush()
@@ -86,17 +106,28 @@ async fn download_blob(
 pub async fn download_restore_blob_to_temp(
     snapshot_id: String,
     hash: String,
+    expected_size_bytes: f64,
     download_url: String,
     temp_root: String,
 ) -> napi::Result<String> {
     validate_path_component(&snapshot_id).map_err(Error::from_reason)?;
     validate_hash(&hash).map_err(Error::from_reason)?;
+    validate_size(expected_size_bytes).map_err(Error::from_reason)?;
     if temp_root.is_empty() {
         return Err(Error::from_reason("cloud_save_invalid_restore_temp_root"));
     }
 
     let (final_path, partial_path) = build_paths(&temp_root, &snapshot_id, &hash);
-    if let Err(error) = download_blob(download_url, &final_path, &partial_path).await {
+    let client = blob_http_client().map_err(Error::from_reason)?;
+    if let Err(error) = download_blob(
+        client,
+        download_url,
+        expected_size_bytes as u64,
+        &final_path,
+        &partial_path,
+    )
+    .await
+    {
         let _ = remove_if_exists(&partial_path).await;
         return Err(Error::from_reason(error));
     }
@@ -127,11 +158,14 @@ pub async fn cleanup_restore_temp_snapshot(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     use super::*;
+    use crate::cloud_save::http::build_blob_http_client;
 
     async fn server(response: &'static [u8]) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -145,6 +179,18 @@ mod tests {
         format!("http://{address}/blob?signature=secret")
     }
 
+    async fn stalled_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await;
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        });
+        format!("http://{address}/blob")
+    }
+
     #[tokio::test]
     async fn downloads_atomically_and_cleans_snapshot() {
         let url = server(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nsave").await;
@@ -153,6 +199,7 @@ mod tests {
         let result = download_restore_blob_to_temp(
             "snapshot_1".to_string(),
             hash.clone(),
+            4.0,
             url,
             directory.path().display().to_string(),
         )
@@ -179,6 +226,7 @@ mod tests {
         let error = download_restore_blob_to_temp(
             "snapshot_1".to_string(),
             hash.clone(),
+            10.0,
             truncated,
             directory.path().display().to_string(),
         )
@@ -195,6 +243,7 @@ mod tests {
         let error = download_restore_blob_to_temp(
             "snapshot_1".to_string(),
             hash,
+            0.0,
             rejected,
             directory.path().display().to_string(),
         )
@@ -204,5 +253,72 @@ mod tests {
         assert!(error.contains("403 Forbidden"));
         assert!(!error.contains("signature=secret"));
         assert!(!error.contains("http://"));
+    }
+
+    #[tokio::test]
+    async fn rejects_declared_and_streamed_size_mismatches() {
+        let directory = tempdir().unwrap();
+        let hash = "a".repeat(64);
+        let declared = server(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nsave").await;
+        let error = download_restore_blob_to_temp(
+            "snapshot_1".to_string(),
+            hash.clone(),
+            3.0,
+            declared,
+            directory.path().display().to_string(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("cloud_save_restore_download_size_mismatch"));
+
+        let streamed =
+            server(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nlarge\r\n0\r\n\r\n")
+                .await;
+        let error = download_restore_blob_to_temp(
+            "snapshot_1".to_string(),
+            hash.clone(),
+            4.0,
+            streamed,
+            directory.path().display().to_string(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        let (final_path, partial_path) =
+            build_paths(&directory.path().display().to_string(), "snapshot_1", &hash);
+        assert!(error.contains("cloud_save_restore_download_size_mismatch"));
+        assert!(!final_path.exists());
+        assert!(!partial_path.exists());
+    }
+
+    #[tokio::test]
+    async fn stops_a_stalled_download_on_the_read_timeout() {
+        let directory = tempdir().unwrap();
+        let (final_path, partial_path) = build_paths(
+            &directory.path().display().to_string(),
+            "snapshot_1",
+            &"a".repeat(64),
+        );
+        let client = build_blob_http_client(
+            Duration::from_secs(1),
+            Duration::from_millis(25),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        let error = download_blob(
+            &client,
+            stalled_server().await,
+            4,
+            &final_path,
+            &partial_path,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("Failed to download restore blob"));
+        assert!(!final_path.exists());
+        assert!(!partial_path.exists());
     }
 }

--- a/native/hydra-native/src/cloud_save/restore/metadata.rs
+++ b/native/hydra-native/src/cloud_save/restore/metadata.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+
+use filetime::{set_file_mtime, FileTime};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RestoreTimestamp {
+    unix_seconds: i64,
+    nanoseconds: u32,
+}
+
+impl RestoreTimestamp {
+    pub fn as_file_time(self) -> FileTime {
+        FileTime::from_unix_time(self.unix_seconds, self.nanoseconds)
+    }
+}
+
+pub fn parse_last_modified_at(value: &str) -> Result<RestoreTimestamp, String> {
+    let timestamp = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| "cloud_save_invalid_last_modified_at".to_string())?;
+    Ok(RestoreTimestamp {
+        unix_seconds: timestamp.unix_timestamp(),
+        nanoseconds: timestamp.nanosecond(),
+    })
+}
+
+pub fn read_mtime(path: &Path) -> Result<FileTime, String> {
+    std::fs::metadata(path)
+        .map(|metadata| FileTime::from_last_modification_time(&metadata))
+        .map_err(|_| "cloud_save_restore_read_mtime_failed".to_string())
+}
+
+pub fn write_mtime(path: &Path, timestamp: FileTime) -> Result<(), String> {
+    set_file_mtime(path, timestamp).map_err(|_| "cloud_save_restore_set_mtime_failed".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_utc_and_offset_as_the_same_instant() {
+        assert_eq!(
+            parse_last_modified_at("2026-07-23T10:00:00.123Z").unwrap(),
+            parse_last_modified_at("2026-07-23T07:00:00.123-03:00").unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_timestamp() {
+        assert!(parse_last_modified_at("2026-07-23 10:00:00").is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/mod.rs
+++ b/native/hydra-native/src/cloud_save/restore/mod.rs
@@ -1,0 +1,14 @@
+mod download_blob;
+mod metadata;
+mod replace_targets;
+mod resolve_targets;
+mod should_skip_file;
+mod types;
+mod validation;
+mod verify_file;
+
+pub use download_blob::{cleanup_restore_temp_snapshot, download_restore_blob_to_temp};
+pub use replace_targets::replace_restore_targets;
+pub use resolve_targets::resolve_restore_targets;
+pub use should_skip_file::should_skip_restore_file;
+pub use verify_file::verify_downloaded_restore_file;

--- a/native/hydra-native/src/cloud_save/restore/mod.rs
+++ b/native/hydra-native/src/cloud_save/restore/mod.rs
@@ -1,3 +1,4 @@
+mod artifacts;
 mod download_blob;
 mod metadata;
 mod replace_targets;
@@ -7,6 +8,7 @@ mod types;
 mod validation;
 mod verify_file;
 
+pub(crate) use artifacts::is_restore_artifact_path;
 pub use download_blob::{cleanup_restore_temp_snapshot, download_restore_blob_to_temp};
 pub use replace_targets::replace_restore_targets;
 pub use resolve_targets::resolve_restore_targets;

--- a/native/hydra-native/src/cloud_save/restore/replace_targets.rs
+++ b/native/hydra-native/src/cloud_save/restore/replace_targets.rs
@@ -1,0 +1,911 @@
+use std::collections::{HashMap, HashSet};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use filetime::FileTime;
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+use uuid::Uuid;
+
+use crate::cloud_save::hashing::hash_file;
+
+use super::metadata::{parse_last_modified_at, read_mtime, write_mtime, RestoreTimestamp};
+use super::types::{
+    ReplaceRestoreTarget, ReplaceRestoreTargetsResult, RestoreFailedFile, RestoreMetadataFailure,
+    RestoreResultFile, RestoreSkippedFile, RestoreTargetAction,
+};
+use super::validation::{validate_hash, validate_relative_path};
+
+struct ValidatedTarget {
+    input: ReplaceRestoreTarget,
+    expected_hash: String,
+    desired_mtime: RestoreTimestamp,
+    original_mtime: Option<FileTime>,
+}
+
+struct PreparedTarget {
+    validated: ValidatedTarget,
+    staging_path: PathBuf,
+    backup_path: Option<PathBuf>,
+    installed: bool,
+}
+
+struct DirectoryTimestamp {
+    path: PathBuf,
+    desired: RestoreTimestamp,
+    original: Option<FileTime>,
+    depth: usize,
+}
+
+fn identity(input: &ReplaceRestoreTarget) -> RestoreResultFile {
+    RestoreResultFile {
+        variant_id: input.variant_id.clone(),
+        raw_path: input.raw_path.clone(),
+        relative_path: input.relative_path.clone(),
+        target_path: input.target_path.clone(),
+        restore_root_path: input.restore_root_path.clone(),
+        last_modified_at: input.last_modified_at.clone(),
+    }
+}
+
+fn failure(input: &ReplaceRestoreTarget, reason: &str) -> RestoreFailedFile {
+    RestoreFailedFile {
+        variant_id: input.variant_id.clone(),
+        raw_path: input.raw_path.clone(),
+        relative_path: input.relative_path.clone(),
+        target_path: input.target_path.clone(),
+        restore_root_path: input.restore_root_path.clone(),
+        last_modified_at: input.last_modified_at.clone(),
+        reason: reason.to_string(),
+    }
+}
+
+fn skipped(input: &ReplaceRestoreTarget) -> RestoreSkippedFile {
+    RestoreSkippedFile {
+        variant_id: input.variant_id.clone(),
+        raw_path: input.raw_path.clone(),
+        relative_path: input.relative_path.clone(),
+        target_path: input.target_path.clone(),
+        restore_root_path: input.restore_root_path.clone(),
+        last_modified_at: input.last_modified_at.clone(),
+        reason: "already_matches_expected_state".to_string(),
+    }
+}
+
+fn metadata_failure(path: &Path, kind: &str, reason: &str) -> RestoreMetadataFailure {
+    RestoreMetadataFailure {
+        path: path.display().to_string(),
+        kind: kind.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+fn sibling_path(target: &Path, suffix: &str) -> Result<PathBuf, String> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| "cloud_save_restore_target_without_parent".to_string())?;
+    Ok(parent.join(format!(".hydra-restore-{}-{suffix}", Uuid::new_v4())))
+}
+
+fn canonical_path_with_missing(path: &Path) -> PathBuf {
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name().map(|name| name.to_os_string()) else {
+            break;
+        };
+        missing.push(name);
+        if !existing.pop() {
+            break;
+        }
+    }
+    let mut canonical = std::fs::canonicalize(&existing).unwrap_or(existing);
+    for segment in missing.into_iter().rev() {
+        canonical.push(segment);
+    }
+    canonical
+}
+
+fn path_key(path: &Path) -> String {
+    let normalized = canonical_path_with_missing(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    if cfg!(windows) {
+        normalized.to_ascii_lowercase()
+    } else {
+        normalized
+    }
+}
+
+fn target_is_within_root(target: &Path, root: &Path) -> bool {
+    let target = path_key(target);
+    let root = path_key(root);
+    target == root || target.starts_with(&format!("{}/", root.trim_end_matches('/')))
+}
+
+fn target_is_symlink(path: &Path) -> Result<bool, String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_symlink()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+        Err(_) => Err("cloud_save_restore_target_inspection_failed".to_string()),
+    }
+}
+
+fn validate_target_containment(input: &ReplaceRestoreTarget) -> Result<(), String> {
+    let target = Path::new(&input.target_path);
+    let root = Path::new(&input.restore_root_path);
+    if input.target_path.is_empty()
+        || input.restore_root_path.is_empty()
+        || !target_is_within_root(target, root)
+        || target_is_symlink(target).unwrap_or(true)
+    {
+        Err("cloud_save_restore_target_outside_root".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn desired_directories(
+    target: &Path,
+    root: &Path,
+    desired: RestoreTimestamp,
+    directories: &mut HashMap<String, DirectoryTimestamp>,
+) -> Result<(), String> {
+    if !target_is_within_root(target, root) {
+        return Err("cloud_save_restore_target_outside_root".to_string());
+    }
+    let root_key = path_key(root);
+    let mut current = target
+        .parent()
+        .ok_or_else(|| "cloud_save_restore_target_without_parent".to_string())?
+        .to_path_buf();
+
+    loop {
+        if !target_is_within_root(&current, root) {
+            return Err("cloud_save_restore_target_outside_root".to_string());
+        }
+        let key = path_key(&current);
+        let depth = canonical_path_with_missing(&current).components().count();
+        match directories.get_mut(&key) {
+            Some(directory) if desired > directory.desired => {
+                directory.desired = desired;
+            }
+            Some(_) => {}
+            None => {
+                let original = if current.exists() {
+                    Some(read_mtime(&current)?)
+                } else {
+                    None
+                };
+                directories.insert(
+                    key.clone(),
+                    DirectoryTimestamp {
+                        path: current.clone(),
+                        desired,
+                        original,
+                        depth,
+                    },
+                );
+            }
+        }
+        if key == root_key {
+            return Ok(());
+        }
+        if !current.pop() {
+            return Err("cloud_save_restore_target_outside_root".to_string());
+        }
+    }
+}
+
+async fn remove_if_exists(path: &Path) -> Result<(), String> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+async fn hash_path(path: String, stage: &'static str) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || hash_file(&path))
+        .await
+        .map_err(|_| format!("cloud_save_{stage}_hash_task_failed"))?
+        .map_err(|_| format!("cloud_save_{stage}_hash_failed"))
+}
+
+fn metadata_result(failure: RestoreMetadataFailure) -> ReplaceRestoreTargetsResult {
+    ReplaceRestoreTargetsResult {
+        restored_files: Vec::new(),
+        skipped_files: Vec::new(),
+        failed_files: Vec::new(),
+        metadata_failures: vec![failure],
+        updated_directory_count: 0,
+    }
+}
+
+fn failed_result(
+    inputs: &[ReplaceRestoreTarget],
+    failed_target_key: &str,
+    metadata_failures: Vec<RestoreMetadataFailure>,
+) -> ReplaceRestoreTargetsResult {
+    ReplaceRestoreTargetsResult {
+        restored_files: Vec::new(),
+        skipped_files: Vec::new(),
+        failed_files: inputs
+            .iter()
+            .map(|input| {
+                failure(
+                    input,
+                    if path_key(Path::new(&input.target_path)) == failed_target_key {
+                        "failed_to_replace_target"
+                    } else {
+                        "restore_rolled_back"
+                    },
+                )
+            })
+            .collect(),
+        metadata_failures,
+        updated_directory_count: 0,
+    }
+}
+
+fn validate_target(
+    input: ReplaceRestoreTarget,
+    directories: &mut HashMap<String, DirectoryTimestamp>,
+) -> Result<ValidatedTarget, RestoreMetadataFailure> {
+    if validate_target_containment(&input).is_err() {
+        return Err(metadata_failure(
+            Path::new(&input.target_path),
+            "file",
+            "target-outside-restore-root",
+        ));
+    }
+    let target = Path::new(&input.target_path);
+    let root = Path::new(&input.restore_root_path);
+    let desired_mtime = parse_last_modified_at(&input.last_modified_at)
+        .map_err(|_| metadata_failure(target, "file", "invalid-last-modified-at"))?;
+    let expected_hash = input
+        .expected_hash
+        .clone()
+        .expect("expected hash is validated before target metadata");
+    let original_mtime = if target.exists() {
+        Some(
+            read_mtime(target)
+                .map_err(|_| metadata_failure(target, "file", "failed-to-read-original-mtime"))?,
+        )
+    } else {
+        None
+    };
+    desired_directories(target, root, desired_mtime, directories).map_err(|error| {
+        metadata_failure(
+            target,
+            "file",
+            if error == "cloud_save_restore_read_mtime_failed" {
+                "failed-to-read-original-mtime"
+            } else {
+                "target-outside-restore-root"
+            },
+        )
+    })?;
+
+    Ok(ValidatedTarget {
+        input,
+        expected_hash,
+        desired_mtime,
+        original_mtime,
+    })
+}
+
+async fn prepare_target(validated: ValidatedTarget) -> Result<PreparedTarget, String> {
+    validate_target_containment(&validated.input)?;
+    let temp_path = validated
+        .input
+        .temp_path
+        .as_deref()
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| "cloud_save_restore_temp_path_missing".to_string())?;
+    if hash_path(temp_path.to_string(), "restore_temp").await? != validated.expected_hash {
+        return Err("cloud_save_restore_temp_hash_mismatch".to_string());
+    }
+
+    let target = Path::new(&validated.input.target_path);
+    let parent = target
+        .parent()
+        .ok_or_else(|| "cloud_save_restore_target_without_parent".to_string())?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|_| "cloud_save_restore_target_directory_failed".to_string())?;
+    let staging_path = sibling_path(target, "stage")?;
+    if tokio::fs::copy(temp_path, &staging_path).await.is_err() {
+        let _ = remove_if_exists(&staging_path).await;
+        return Err("cloud_save_restore_staging_copy_failed".to_string());
+    }
+    if hash_path(staging_path.display().to_string(), "restore_staging").await?
+        != validated.expected_hash
+    {
+        let _ = remove_if_exists(&staging_path).await;
+        return Err("cloud_save_restore_staging_hash_mismatch".to_string());
+    }
+
+    Ok(PreparedTarget {
+        validated,
+        staging_path,
+        backup_path: None,
+        installed: false,
+    })
+}
+
+async fn cleanup_staging(prepared: &[PreparedTarget]) -> Result<(), String> {
+    let mut failed = false;
+    for item in prepared {
+        failed |= remove_if_exists(&item.staging_path).await.is_err();
+    }
+    if failed {
+        Err("cloud_save_restore_cleanup_failed".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+async fn commit_target(item: &mut PreparedTarget) -> Result<(), (&'static str, String)> {
+    validate_target_containment(&item.validated.input).map_err(|error| ("content", error))?;
+    let target = Path::new(&item.validated.input.target_path);
+    if target.try_exists().map_err(|_| {
+        (
+            "content",
+            "cloud_save_restore_target_inspection_failed".to_string(),
+        )
+    })? {
+        if !tokio::fs::metadata(target)
+            .await
+            .map_err(|_| {
+                (
+                    "content",
+                    "cloud_save_restore_target_inspection_failed".to_string(),
+                )
+            })?
+            .is_file()
+        {
+            return Err(("content", "cloud_save_restore_target_not_file".to_string()));
+        }
+        let backup = sibling_path(target, "backup").map_err(|error| ("content", error))?;
+        tokio::fs::rename(target, &backup)
+            .await
+            .map_err(|_| ("content", "cloud_save_restore_backup_failed".to_string()))?;
+        item.backup_path = Some(backup);
+    }
+
+    tokio::fs::rename(&item.staging_path, target)
+        .await
+        .map_err(|_| ("content", "cloud_save_restore_install_failed".to_string()))?;
+    item.installed = true;
+
+    if hash_path(item.validated.input.target_path.clone(), "restore_final")
+        .await
+        .map_err(|error| ("content", error))?
+        != item.validated.expected_hash
+    {
+        return Err((
+            "content",
+            "cloud_save_restore_final_hash_mismatch".to_string(),
+        ));
+    }
+    write_mtime(target, item.validated.desired_mtime.as_file_time())
+        .map_err(|error| ("metadata", error))
+}
+
+fn restore_original_directories(
+    directories: &HashMap<String, DirectoryTimestamp>,
+    metadata_failures: &mut Vec<RestoreMetadataFailure>,
+) {
+    let mut originals = directories
+        .values()
+        .filter_map(|directory| {
+            directory
+                .original
+                .map(|original| (directory.depth, &directory.path, original))
+        })
+        .collect::<Vec<_>>();
+    originals.sort_by(|left, right| right.0.cmp(&left.0));
+    for (_, path, original) in originals {
+        if write_mtime(path, original).is_err() {
+            metadata_failures.push(metadata_failure(
+                path,
+                "directory",
+                "failed-to-restore-mtime-during-rollback",
+            ));
+        }
+    }
+}
+
+async fn rollback(
+    prepared: &mut [PreparedTarget],
+    applied_skips: &[ValidatedTarget],
+    directories: &HashMap<String, DirectoryTimestamp>,
+    metadata_failures: &mut Vec<RestoreMetadataFailure>,
+) {
+    for item in prepared.iter_mut().rev() {
+        let target = Path::new(&item.validated.input.target_path);
+        if item.installed {
+            if remove_if_exists(target).await.is_err() {
+                metadata_failures.push(metadata_failure(
+                    target,
+                    "file",
+                    "failed-to-restore-mtime-during-rollback",
+                ));
+            }
+            item.installed = false;
+        }
+        if let Some(backup) = item.backup_path.as_ref() {
+            if tokio::fs::rename(backup, target).await.is_ok() {
+                item.backup_path = None;
+                if let Some(original) = item.validated.original_mtime {
+                    if write_mtime(target, original).is_err() {
+                        metadata_failures.push(metadata_failure(
+                            target,
+                            "file",
+                            "failed-to-restore-mtime-during-rollback",
+                        ));
+                    }
+                }
+            } else {
+                metadata_failures.push(metadata_failure(
+                    target,
+                    "file",
+                    "failed-to-restore-mtime-during-rollback",
+                ));
+            }
+        }
+        let _ = remove_if_exists(&item.staging_path).await;
+    }
+    for skip in applied_skips {
+        if let Some(original) = skip.original_mtime {
+            let target = Path::new(&skip.input.target_path);
+            if write_mtime(target, original).is_err() {
+                metadata_failures.push(metadata_failure(
+                    target,
+                    "file",
+                    "failed-to-restore-mtime-during-rollback",
+                ));
+            }
+        }
+    }
+    restore_original_directories(directories, metadata_failures);
+}
+
+async fn remove_backups(prepared: &mut [PreparedTarget]) -> Result<(), String> {
+    for item in prepared {
+        if let Some(backup) = item.backup_path.as_ref() {
+            remove_if_exists(backup)
+                .await
+                .map_err(|_| "cloud_save_restore_cleanup_failed".to_string())?;
+            item.backup_path = None;
+        }
+    }
+    Ok(())
+}
+
+fn apply_directory_timestamps(
+    directories: &HashMap<String, DirectoryTimestamp>,
+) -> (u32, Vec<RestoreMetadataFailure>) {
+    let mut ordered = directories.values().collect::<Vec<_>>();
+    ordered.sort_by(|left, right| right.depth.cmp(&left.depth));
+    let mut updated = 0u32;
+    let mut failures = Vec::new();
+    for directory in ordered {
+        if write_mtime(&directory.path, directory.desired.as_file_time()).is_ok() {
+            updated += 1;
+        } else {
+            failures.push(metadata_failure(
+                &directory.path,
+                "directory",
+                "failed-to-set-mtime",
+            ));
+        }
+    }
+    (updated, failures)
+}
+
+#[napi]
+pub async fn replace_restore_targets(
+    files: Vec<ReplaceRestoreTarget>,
+) -> napi::Result<ReplaceRestoreTargetsResult> {
+    let all_inputs = files.clone();
+    let mut seen_targets = HashSet::new();
+    let mut directories = HashMap::new();
+    let mut restore_targets = Vec::new();
+    let mut skip_targets = Vec::new();
+
+    for file in files {
+        validate_relative_path(&file.relative_path).map_err(Error::from_reason)?;
+        let expected_hash = file
+            .expected_hash
+            .as_deref()
+            .ok_or_else(|| Error::from_reason("cloud_save_restore_expected_hash_missing"))?;
+        validate_hash(expected_hash).map_err(Error::from_reason)?;
+        if !seen_targets.insert(path_key(Path::new(&file.target_path))) {
+            return Err(Error::from_reason("cloud_save_duplicate_restore_target"));
+        }
+        let validated = match validate_target(file, &mut directories) {
+            Ok(validated) => validated,
+            Err(failure) => return Ok(metadata_result(failure)),
+        };
+        match validated.input.action {
+            RestoreTargetAction::Restore => restore_targets.push(validated),
+            RestoreTargetAction::Skip => skip_targets.push(validated),
+        }
+    }
+
+    let mut prepared = Vec::new();
+    for validated in restore_targets {
+        let failed_key = path_key(Path::new(&validated.input.target_path));
+        match prepare_target(validated).await {
+            Ok(item) => prepared.push(item),
+            Err(_) => {
+                cleanup_staging(&prepared)
+                    .await
+                    .map_err(Error::from_reason)?;
+                let mut metadata_failures = Vec::new();
+                restore_original_directories(&directories, &mut metadata_failures);
+                return Ok(failed_result(&all_inputs, &failed_key, metadata_failures));
+            }
+        }
+    }
+
+    for index in 0..prepared.len() {
+        if let Err((kind, _)) = commit_target(&mut prepared[index]).await {
+            let failed_key = path_key(Path::new(&prepared[index].validated.input.target_path));
+            let mut metadata_failures = if kind == "metadata" {
+                vec![metadata_failure(
+                    Path::new(&prepared[index].validated.input.target_path),
+                    "file",
+                    "failed-to-set-mtime",
+                )]
+            } else {
+                Vec::new()
+            };
+            rollback(&mut prepared, &[], &directories, &mut metadata_failures).await;
+            return Ok(failed_result(&all_inputs, &failed_key, metadata_failures));
+        }
+    }
+
+    let mut applied_skips = Vec::new();
+    for skip in skip_targets {
+        if validate_target_containment(&skip.input).is_err() {
+            let failed_key = path_key(Path::new(&skip.input.target_path));
+            let mut metadata_failures = vec![metadata_failure(
+                Path::new(&skip.input.target_path),
+                "file",
+                "target-outside-restore-root",
+            )];
+            rollback(
+                &mut prepared,
+                &applied_skips,
+                &directories,
+                &mut metadata_failures,
+            )
+            .await;
+            return Ok(failed_result(&all_inputs, &failed_key, metadata_failures));
+        }
+        let target_path = skip.input.target_path.clone();
+        let target = Path::new(&target_path);
+        let hash_matches = target.is_file()
+            && hash_path(target_path.clone(), "restore_skip")
+                .await
+                .is_ok_and(|hash| hash == skip.expected_hash);
+        if !hash_matches {
+            let failed_key = path_key(target);
+            let mut metadata_failures = Vec::new();
+            rollback(
+                &mut prepared,
+                &applied_skips,
+                &directories,
+                &mut metadata_failures,
+            )
+            .await;
+            return Ok(failed_result(&all_inputs, &failed_key, metadata_failures));
+        }
+        applied_skips.push(skip);
+        let current = applied_skips
+            .last()
+            .expect("the current skip target was just appended");
+        if write_mtime(target, current.desired_mtime.as_file_time()).is_err() {
+            let failed_key = path_key(target);
+            let mut metadata_failures =
+                vec![metadata_failure(target, "file", "failed-to-set-mtime")];
+            rollback(
+                &mut prepared,
+                &applied_skips,
+                &directories,
+                &mut metadata_failures,
+            )
+            .await;
+            return Ok(failed_result(&all_inputs, &failed_key, metadata_failures));
+        }
+    }
+
+    remove_backups(&mut prepared)
+        .await
+        .map_err(Error::from_reason)?;
+    let (updated_directory_count, metadata_failures) = apply_directory_timestamps(&directories);
+
+    Ok(ReplaceRestoreTargetsResult {
+        restored_files: prepared
+            .iter()
+            .map(|item| identity(&item.validated.input))
+            .collect(),
+        skipped_files: applied_skips
+            .iter()
+            .map(|item| skipped(&item.input))
+            .collect(),
+        failed_files: Vec::new(),
+        metadata_failures,
+        updated_directory_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const FIRST_TIME: &str = "2026-07-20T10:00:00.123Z";
+    const SECOND_TIME: &str = "2026-07-22T10:05:00.456Z";
+
+    fn restore(
+        temp: &Path,
+        target: &Path,
+        root: &Path,
+        content: &[u8],
+        last_modified_at: &str,
+    ) -> ReplaceRestoreTarget {
+        ReplaceRestoreTarget {
+            variant_id: "variant".to_string(),
+            raw_path: "<home>/Game".to_string(),
+            relative_path: target
+                .strip_prefix(root)
+                .unwrap_or(target)
+                .to_string_lossy()
+                .replace('\\', "/"),
+            target_path: target.display().to_string(),
+            restore_root_path: root.display().to_string(),
+            last_modified_at: last_modified_at.to_string(),
+            action: RestoreTargetAction::Restore,
+            temp_path: Some(temp.display().to_string()),
+            expected_hash: Some(format!("{:x}", Sha256::digest(content))),
+        }
+    }
+
+    fn skip(
+        target: &Path,
+        root: &Path,
+        content: &[u8],
+        last_modified_at: &str,
+    ) -> ReplaceRestoreTarget {
+        ReplaceRestoreTarget {
+            variant_id: "variant".to_string(),
+            raw_path: "<home>/Game".to_string(),
+            relative_path: target
+                .strip_prefix(root)
+                .unwrap_or(target)
+                .to_string_lossy()
+                .replace('\\', "/"),
+            target_path: target.display().to_string(),
+            restore_root_path: root.display().to_string(),
+            last_modified_at: last_modified_at.to_string(),
+            action: RestoreTargetAction::Skip,
+            temp_path: None,
+            expected_hash: Some(format!("{:x}", Sha256::digest(content))),
+        }
+    }
+
+    fn assert_mtime(path: &Path, expected: &str) {
+        let actual = read_mtime(path).unwrap();
+        let expected = parse_last_modified_at(expected).unwrap().as_file_time();
+        let difference = actual.unix_seconds().abs_diff(expected.unix_seconds());
+        assert!(
+            difference <= Duration::from_secs(2).as_secs(),
+            "{} differs by {difference}s",
+            path.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn restores_file_skip_and_directory_mtimes() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        let nested = root.join("slot");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        let first_temp = directory.path().join("first.blob");
+        let first_target = nested.join("existing.sav");
+        let skipped_target = nested.join("skip.sav");
+        tokio::fs::write(&first_temp, b"first-remote")
+            .await
+            .unwrap();
+        tokio::fs::write(&first_target, b"first-local")
+            .await
+            .unwrap();
+        tokio::fs::write(&skipped_target, b"same").await.unwrap();
+
+        let result = replace_restore_targets(vec![
+            restore(
+                &first_temp,
+                &first_target,
+                &root,
+                b"first-remote",
+                FIRST_TIME,
+            ),
+            skip(&skipped_target, &root, b"same", SECOND_TIME),
+        ])
+        .await
+        .unwrap();
+
+        assert_eq!(
+            tokio::fs::read(&first_target).await.unwrap(),
+            b"first-remote"
+        );
+        assert_eq!(tokio::fs::read(&skipped_target).await.unwrap(), b"same");
+        assert_mtime(&first_target, FIRST_TIME);
+        assert_mtime(&skipped_target, SECOND_TIME);
+        assert_mtime(&nested, SECOND_TIME);
+        assert_mtime(&root, SECOND_TIME);
+        assert_eq!(result.restored_files.len(), 1);
+        assert_eq!(result.skipped_files.len(), 1);
+        assert!(result.failed_files.is_empty());
+        assert!(result.metadata_failures.is_empty());
+        assert_eq!(result.updated_directory_count, 2);
+    }
+
+    #[tokio::test]
+    async fn shared_blob_keeps_independent_target_timestamps() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let temp = directory.path().join("shared.blob");
+        let first_target = root.join("first.sav");
+        let second_target = root.join("second.sav");
+        tokio::fs::write(&temp, b"same").await.unwrap();
+
+        replace_restore_targets(vec![
+            restore(&temp, &first_target, &root, b"same", FIRST_TIME),
+            restore(&temp, &second_target, &root, b"same", SECOND_TIME),
+        ])
+        .await
+        .unwrap();
+
+        assert_mtime(&first_target, FIRST_TIME);
+        assert_mtime(&second_target, SECOND_TIME);
+        assert_mtime(&root, SECOND_TIME);
+    }
+
+    #[tokio::test]
+    async fn invalid_timestamp_or_outside_root_does_not_mutate_target() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let temp = directory.path().join("remote.blob");
+        let target = root.join("save.dat");
+        tokio::fs::write(&temp, b"remote").await.unwrap();
+        tokio::fs::write(&target, b"local").await.unwrap();
+
+        let invalid = restore(&temp, &target, &root, b"remote", "invalid");
+        let result = replace_restore_targets(vec![invalid]).await.unwrap();
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"local");
+        assert_eq!(
+            result.metadata_failures[0].reason,
+            "invalid-last-modified-at"
+        );
+
+        let mut outside = restore(&temp, &target, &root.join("other"), b"remote", FIRST_TIME);
+        outside.relative_path = "save.dat".to_string();
+        let result = replace_restore_targets(vec![outside]).await.unwrap();
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"local");
+        assert_eq!(
+            result.metadata_failures[0].reason,
+            "target-outside-restore-root"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_temp_hash_does_not_mutate_target_or_leave_residue() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let temp = directory.path().join("remote.blob");
+        let target = root.join("save.dat");
+        tokio::fs::write(&temp, b"corrupt").await.unwrap();
+        tokio::fs::write(&target, b"local").await.unwrap();
+
+        let result = replace_restore_targets(vec![restore(
+            &temp,
+            &target,
+            &root,
+            b"expected",
+            FIRST_TIME,
+        )])
+        .await
+        .unwrap();
+
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"local");
+        assert_eq!(result.failed_files[0].reason, "failed_to_replace_target");
+        let entries = std::fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert!(!entries
+            .iter()
+            .any(|name| name.starts_with(".hydra-restore-")));
+    }
+
+    #[tokio::test]
+    async fn failure_on_second_target_rolls_back_first_without_residue() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let first_temp = directory.path().join("first.blob");
+        let second_temp = directory.path().join("second.blob");
+        let first_target = root.join("first.sav");
+        let invalid_target = root.join("target-directory");
+        tokio::fs::write(&first_temp, b"first-remote")
+            .await
+            .unwrap();
+        tokio::fs::write(&second_temp, b"second-remote")
+            .await
+            .unwrap();
+        tokio::fs::write(&first_target, b"first-local")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&invalid_target).await.unwrap();
+
+        let result = replace_restore_targets(vec![
+            restore(
+                &first_temp,
+                &first_target,
+                &root,
+                b"first-remote",
+                FIRST_TIME,
+            ),
+            restore(
+                &second_temp,
+                &invalid_target,
+                &root,
+                b"second-remote",
+                SECOND_TIME,
+            ),
+        ])
+        .await
+        .unwrap();
+
+        assert_eq!(
+            tokio::fs::read(&first_target).await.unwrap(),
+            b"first-local"
+        );
+        assert_eq!(result.failed_files[0].reason, "restore_rolled_back");
+        assert_eq!(result.failed_files[1].reason, "failed_to_replace_target");
+        let entries = std::fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert!(!entries
+            .iter()
+            .any(|name| name.starts_with(".hydra-restore-")));
+    }
+
+    #[tokio::test]
+    async fn rejects_duplicate_targets() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let temp = directory.path().join("remote.blob");
+        let target = root.join("save.dat");
+        tokio::fs::write(&temp, b"save").await.unwrap();
+        let first = restore(&temp, &target, &root, b"save", FIRST_TIME);
+
+        assert!(replace_restore_targets(vec![first.clone(), first])
+            .await
+            .is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/replace_targets.rs
+++ b/native/hydra-native/src/cloud_save/restore/replace_targets.rs
@@ -5,16 +5,16 @@ use std::path::{Path, PathBuf};
 use filetime::FileTime;
 use napi::bindgen_prelude::Error;
 use napi_derive::napi;
-use uuid::Uuid;
 
 use crate::cloud_save::hashing::hash_file;
 
+use super::artifacts::restore_artifact_paths;
 use super::metadata::{parse_last_modified_at, read_mtime, write_mtime, RestoreTimestamp};
 use super::types::{
     ReplaceRestoreTarget, ReplaceRestoreTargetsResult, RestoreFailedFile, RestoreMetadataFailure,
     RestoreResultFile, RestoreSkippedFile, RestoreTargetAction,
 };
-use super::validation::{validate_hash, validate_relative_path};
+use super::validation::{validate_hash, validate_relative_path, validate_windows_relative_path};
 
 struct ValidatedTarget {
     input: ReplaceRestoreTarget,
@@ -78,13 +78,6 @@ fn metadata_failure(path: &Path, kind: &str, reason: &str) -> RestoreMetadataFai
         kind: kind.to_string(),
         reason: reason.to_string(),
     }
-}
-
-fn sibling_path(target: &Path, suffix: &str) -> Result<PathBuf, String> {
-    let parent = target
-        .parent()
-        .ok_or_else(|| "cloud_save_restore_target_without_parent".to_string())?;
-    Ok(parent.join(format!(".hydra-restore-{}-{suffix}", Uuid::new_v4())))
 }
 
 fn canonical_path_with_missing(path: &Path) -> PathBuf {
@@ -205,6 +198,79 @@ async fn remove_if_exists(path: &Path) -> Result<(), String> {
     }
 }
 
+async fn sync_file(path: &Path) -> Result<(), String> {
+    tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .await
+        .map_err(|_| "cloud_save_restore_sync_failed".to_string())?
+        .sync_all()
+        .await
+        .map_err(|_| "cloud_save_restore_sync_failed".to_string())
+}
+
+#[cfg(unix)]
+async fn sync_directory(path: &Path) -> Result<(), String> {
+    tokio::fs::File::open(path)
+        .await
+        .map_err(|_| "cloud_save_restore_directory_sync_failed".to_string())?
+        .sync_all()
+        .await
+        .map_err(|_| "cloud_save_restore_directory_sync_failed".to_string())
+}
+
+#[cfg(not(unix))]
+async fn sync_directory(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+async fn sync_parent_directory(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "cloud_save_restore_target_without_parent".to_string())?;
+    sync_directory(parent).await
+}
+
+async fn recover_target_artifacts(target: &Path) -> Result<(), String> {
+    let artifacts = restore_artifact_paths(target, &path_key(target))?;
+    match tokio::fs::symlink_metadata(&artifacts.stage).await {
+        Ok(_) => {
+            remove_if_exists(&artifacts.stage).await?;
+            sync_parent_directory(&artifacts.stage).await?;
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(_) => return Err("cloud_save_restore_artifact_inspection_failed".to_string()),
+    }
+
+    let backup_metadata = match tokio::fs::symlink_metadata(&artifacts.backup).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(_) => return Err("cloud_save_restore_artifact_inspection_failed".to_string()),
+    };
+    if !backup_metadata.is_file() || backup_metadata.file_type().is_symlink() {
+        return Err("cloud_save_restore_invalid_backup_artifact".to_string());
+    }
+
+    match tokio::fs::symlink_metadata(target).await {
+        Ok(metadata) => {
+            if !metadata.is_file() || metadata.file_type().is_symlink() {
+                return Err("cloud_save_restore_target_not_file".to_string());
+            }
+            sync_file(target).await?;
+            remove_if_exists(&artifacts.backup).await?;
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            tokio::fs::rename(&artifacts.backup, target)
+                .await
+                .map_err(|_| "cloud_save_restore_backup_recovery_failed".to_string())?;
+            sync_file(target).await?;
+        }
+        Err(_) => return Err("cloud_save_restore_target_inspection_failed".to_string()),
+    }
+    sync_parent_directory(target).await
+}
+
 async fn hash_path(path: String, stage: &'static str) -> Result<String, String> {
     tokio::task::spawn_blocking(move || hash_file(&path))
         .await
@@ -314,10 +380,14 @@ async fn prepare_target(validated: ValidatedTarget) -> Result<PreparedTarget, St
     tokio::fs::create_dir_all(parent)
         .await
         .map_err(|_| "cloud_save_restore_target_directory_failed".to_string())?;
-    let staging_path = sibling_path(target, "stage")?;
+    let staging_path = restore_artifact_paths(target, &path_key(target))?.stage;
     if tokio::fs::copy(temp_path, &staging_path).await.is_err() {
         let _ = remove_if_exists(&staging_path).await;
         return Err("cloud_save_restore_staging_copy_failed".to_string());
+    }
+    if sync_file(&staging_path).await.is_err() {
+        let _ = remove_if_exists(&staging_path).await;
+        return Err("cloud_save_restore_staging_sync_failed".to_string());
     }
     if hash_path(staging_path.display().to_string(), "restore_staging").await?
         != validated.expected_hash
@@ -337,7 +407,11 @@ async fn prepare_target(validated: ValidatedTarget) -> Result<PreparedTarget, St
 async fn cleanup_staging(prepared: &[PreparedTarget]) -> Result<(), String> {
     let mut failed = false;
     for item in prepared {
-        failed |= remove_if_exists(&item.staging_path).await.is_err();
+        if remove_if_exists(&item.staging_path).await.is_err()
+            || sync_parent_directory(&item.staging_path).await.is_err()
+        {
+            failed = true;
+        }
     }
     if failed {
         Err("cloud_save_restore_cleanup_failed".to_string())
@@ -367,7 +441,9 @@ async fn commit_target(item: &mut PreparedTarget) -> Result<(), (&'static str, S
         {
             return Err(("content", "cloud_save_restore_target_not_file".to_string()));
         }
-        let backup = sibling_path(target, "backup").map_err(|error| ("content", error))?;
+        let backup = restore_artifact_paths(target, &path_key(target))
+            .map_err(|error| ("content", error))?
+            .backup;
         tokio::fs::rename(target, &backup)
             .await
             .map_err(|_| ("content", "cloud_save_restore_backup_failed".to_string()))?;
@@ -378,6 +454,9 @@ async fn commit_target(item: &mut PreparedTarget) -> Result<(), (&'static str, S
         .await
         .map_err(|_| ("content", "cloud_save_restore_install_failed".to_string()))?;
     item.installed = true;
+    sync_parent_directory(target)
+        .await
+        .map_err(|error| ("content", error))?;
 
     if hash_path(item.validated.input.target_path.clone(), "restore_final")
         .await
@@ -390,7 +469,8 @@ async fn commit_target(item: &mut PreparedTarget) -> Result<(), (&'static str, S
         ));
     }
     write_mtime(target, item.validated.desired_mtime.as_file_time())
-        .map_err(|error| ("metadata", error))
+        .map_err(|error| ("metadata", error))?;
+    sync_file(target).await.map_err(|error| ("content", error))
 }
 
 fn restore_original_directories(
@@ -447,6 +527,13 @@ async fn rollback(
                         ));
                     }
                 }
+                if sync_file(target).await.is_err() {
+                    metadata_failures.push(metadata_failure(
+                        target,
+                        "file",
+                        "failed-to-sync-during-rollback",
+                    ));
+                }
             } else {
                 metadata_failures.push(metadata_failure(
                     target,
@@ -456,6 +543,13 @@ async fn rollback(
             }
         }
         let _ = remove_if_exists(&item.staging_path).await;
+        if sync_parent_directory(target).await.is_err() {
+            metadata_failures.push(metadata_failure(
+                target,
+                "directory",
+                "failed-to-sync-during-rollback",
+            ));
+        }
     }
     for skip in applied_skips {
         if let Some(original) = skip.original_mtime {
@@ -465,6 +559,12 @@ async fn rollback(
                     target,
                     "file",
                     "failed-to-restore-mtime-during-rollback",
+                ));
+            } else if sync_file(target).await.is_err() {
+                metadata_failures.push(metadata_failure(
+                    target,
+                    "file",
+                    "failed-to-sync-during-rollback",
                 ));
             }
         }
@@ -476,6 +576,9 @@ async fn remove_backups(prepared: &mut [PreparedTarget]) -> Result<(), String> {
     for item in prepared {
         if let Some(backup) = item.backup_path.as_ref() {
             remove_if_exists(backup)
+                .await
+                .map_err(|_| "cloud_save_restore_cleanup_failed".to_string())?;
+            sync_parent_directory(backup)
                 .await
                 .map_err(|_| "cloud_save_restore_cleanup_failed".to_string())?;
             item.backup_path = None;
@@ -517,6 +620,9 @@ pub async fn replace_restore_targets(
 
     for file in files {
         validate_relative_path(&file.relative_path).map_err(Error::from_reason)?;
+        if cfg!(windows) {
+            validate_windows_relative_path(&file.relative_path).map_err(Error::from_reason)?;
+        }
         let expected_hash = file
             .expected_hash
             .as_deref()
@@ -524,6 +630,23 @@ pub async fn replace_restore_targets(
         validate_hash(expected_hash).map_err(Error::from_reason)?;
         if !seen_targets.insert(path_key(Path::new(&file.target_path))) {
             return Err(Error::from_reason("cloud_save_duplicate_restore_target"));
+        }
+        if validate_target_containment(&file).is_err() {
+            return Ok(metadata_result(metadata_failure(
+                Path::new(&file.target_path),
+                "file",
+                "target-outside-restore-root",
+            )));
+        }
+        if recover_target_artifacts(Path::new(&file.target_path))
+            .await
+            .is_err()
+        {
+            return Ok(metadata_result(metadata_failure(
+                Path::new(&file.target_path),
+                "file",
+                "failed-to-recover-restore-artifacts",
+            )));
         }
         let validated = match validate_target(file, &mut directories) {
             Ok(validated) => validated,
@@ -651,6 +774,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::cloud_save::restore::artifacts::RestoreArtifactPaths;
 
     const FIRST_TIME: &str = "2026-07-20T10:00:00.123Z";
     const SECOND_TIME: &str = "2026-07-22T10:05:00.456Z";
@@ -711,6 +835,10 @@ mod tests {
             "{} differs by {difference}s",
             path.display()
         );
+    }
+
+    fn artifacts(target: &Path) -> RestoreArtifactPaths {
+        restore_artifact_paths(target, &path_key(target)).unwrap()
     }
 
     #[tokio::test]
@@ -907,5 +1035,67 @@ mod tests {
         assert!(replace_restore_targets(vec![first.clone(), first])
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn removes_abandoned_staging_before_a_restore() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let target = root.join("save.dat");
+        tokio::fs::write(&target, b"current").await.unwrap();
+        let artifact_paths = artifacts(&target);
+        tokio::fs::write(&artifact_paths.stage, b"abandoned")
+            .await
+            .unwrap();
+
+        let result = replace_restore_targets(vec![skip(&target, &root, b"current", FIRST_TIME)])
+            .await
+            .unwrap();
+
+        assert_eq!(result.skipped_files.len(), 1);
+        assert!(!artifact_paths.stage.exists());
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"current");
+    }
+
+    #[tokio::test]
+    async fn recovers_backup_when_target_is_missing() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let target = root.join("save.dat");
+        let artifact_paths = artifacts(&target);
+        tokio::fs::write(&artifact_paths.backup, b"original")
+            .await
+            .unwrap();
+
+        let result = replace_restore_targets(vec![skip(&target, &root, b"original", FIRST_TIME)])
+            .await
+            .unwrap();
+
+        assert_eq!(result.skipped_files.len(), 1);
+        assert!(!artifact_paths.backup.exists());
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"original");
+    }
+
+    #[tokio::test]
+    async fn keeps_installed_target_and_removes_old_backup() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("saves");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let target = root.join("save.dat");
+        tokio::fs::write(&target, b"installed").await.unwrap();
+        let artifact_paths = artifacts(&target);
+        tokio::fs::write(&artifact_paths.backup, b"old")
+            .await
+            .unwrap();
+
+        let result = replace_restore_targets(vec![skip(&target, &root, b"installed", FIRST_TIME)])
+            .await
+            .unwrap();
+
+        assert_eq!(result.skipped_files.len(), 1);
+        assert!(!artifact_paths.backup.exists());
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"installed");
     }
 }

--- a/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
+++ b/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
@@ -18,7 +18,9 @@ use super::types::{
     BlockedRestoreFile, ResolveRestoreTargetsInput, ResolveRestoreTargetsResult,
     ResolvedRestoreTarget, RestoreManifestFile,
 };
-use super::validation::{validate_hash, validate_relative_path, validate_size};
+use super::validation::{
+    validate_hash, validate_relative_path, validate_size, validate_windows_relative_path,
+};
 
 const STEAM_INDIVIDUAL_ACCOUNT_BASE: u64 = 76_561_197_960_265_728;
 
@@ -31,7 +33,7 @@ fn join_path(root: &str, relative_path: &str) -> String {
     .replace('\\', "/")
 }
 
-fn validate_file(file: &RestoreManifestFile) -> Result<(), String> {
+fn validate_file(file: &RestoreManifestFile, windows_semantics: bool) -> Result<(), String> {
     if file.variant_id.len() != 64
         || !file.variant_id.bytes().all(|byte| byte.is_ascii_hexdigit())
         || file.raw_path.is_empty()
@@ -40,6 +42,9 @@ fn validate_file(file: &RestoreManifestFile) -> Result<(), String> {
         return Err("cloud_save_invalid_restore_identity".to_string());
     }
     validate_relative_path(&file.relative_path)?;
+    if windows_semantics {
+        validate_windows_relative_path(&file.relative_path)?;
+    }
     validate_hash(&file.hash)?;
     validate_size(file.size_bytes)?;
     parse_last_modified_at(&file.last_modified_at).map(|_| ())
@@ -184,8 +189,7 @@ fn has_glob(raw_rule: &str) -> bool {
         .any(|character| matches!(character, '*' | '?' | '[' | '{'))
 }
 
-#[napi]
-pub fn resolve_restore_targets(
+fn resolve_restore_targets_inner(
     input: ResolveRestoreTargetsInput,
 ) -> napi::Result<ResolveRestoreTargetsResult> {
     let context = build_context(&ResolveSaveRulesInput {
@@ -202,6 +206,7 @@ pub fn resolve_restore_targets(
     })
     .map_err(Error::from_reason)?;
     let case_sensitive = context.platform == "linux" && !context.windows_compatibility;
+    let windows_semantics = context.platform == "windows" || context.windows_compatibility;
 
     let mut variants = HashMap::new();
     for variant in input.variants {
@@ -225,7 +230,7 @@ pub fn resolve_restore_targets(
     let mut used_variants = HashSet::new();
 
     for file in input.files {
-        validate_file(&file).map_err(Error::from_reason)?;
+        validate_file(&file, windows_semantics).map_err(Error::from_reason)?;
         if !identities.insert(identity_key(&file)) {
             return Err(Error::from_reason("cloud_save_duplicate_restore_identity"));
         }
@@ -430,6 +435,15 @@ pub fn resolve_restore_targets(
     })
 }
 
+#[napi]
+pub async fn resolve_restore_targets(
+    input: ResolveRestoreTargetsInput,
+) -> napi::Result<ResolveRestoreTargetsResult> {
+    tokio::task::spawn_blocking(move || resolve_restore_targets_inner(input))
+        .await
+        .map_err(|_| Error::from_reason("cloud_save_restore_plan_task_failed"))?
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -515,7 +529,7 @@ mod tests {
             preferred_path: None,
         }];
 
-        let result = resolve_restore_targets(restore_input).unwrap();
+        let result = resolve_restore_targets_inner(restore_input).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 1);
@@ -556,7 +570,7 @@ mod tests {
             preferred_path: Some(approved_root.display().to_string()),
         }];
 
-        let result = resolve_restore_targets(restore_input).unwrap();
+        let result = resolve_restore_targets_inner(restore_input).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 1);
@@ -597,7 +611,7 @@ mod tests {
             preferred_path: Some(selected.display().to_string()),
         }];
 
-        let result = resolve_restore_targets(restore_input).unwrap();
+        let result = resolve_restore_targets_inner(restore_input).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(
@@ -620,7 +634,7 @@ mod tests {
             .iter()
             .map(|variant| file(variant, "slot.dat"))
             .collect();
-        let result = resolve_restore_targets(input(
+        let result = resolve_restore_targets_inner(input(
             temp.path(),
             StoreUserContext::default(),
             variants,
@@ -637,7 +651,7 @@ mod tests {
         let temp = tempdir().unwrap();
         let variants = vec![variant("opaque-folder", "Unknown")];
         let files = vec![file(&variants[0], "slot.dat")];
-        let result = resolve_restore_targets(input(
+        let result = resolve_restore_targets_inner(input(
             temp.path(),
             StoreUserContext::default(),
             variants,
@@ -664,7 +678,8 @@ mod tests {
         };
         let variants = vec![variant("steam-account", "76561197960278073")];
         let files = vec![file(&variants[0], "slot.dat")];
-        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+        let result =
+            resolve_restore_targets_inner(input(temp.path(), context, variants, files)).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 1);
@@ -706,7 +721,8 @@ mod tests {
             .map(|variant| file(variant, "slot.dat"))
             .collect();
 
-        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+        let result =
+            resolve_restore_targets_inner(input(temp.path(), context, variants, files)).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 3);
@@ -741,7 +757,8 @@ mod tests {
         let variants = vec![variant("steam-account", "76561199800542110")];
         let files = vec![file(&variants[0], "slot.dat")];
 
-        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+        let result =
+            resolve_restore_targets_inner(input(temp.path(), context, variants, files)).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 1);
@@ -769,7 +786,8 @@ mod tests {
         let variants = vec![variant("steam-account", "76561199800542110")];
         let files = vec![file(&variants[0], "slot.dat")];
 
-        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+        let result =
+            resolve_restore_targets_inner(input(temp.path(), context, variants, files)).unwrap();
 
         assert!(result.actions.is_empty());
         assert_eq!(result.blocked.len(), 1);
@@ -781,7 +799,7 @@ mod tests {
         let temp = tempdir().unwrap();
         let variants = vec![variant("steam-account", "76561197960278073")];
         let files = vec![file(&variants[0], "slot.dat")];
-        let result = resolve_restore_targets(input(
+        let result = resolve_restore_targets_inner(input(
             temp.path(),
             StoreUserContext::default(),
             variants,
@@ -825,7 +843,7 @@ mod tests {
                 last_modified_at: LAST_MODIFIED_AT.into(),
             }],
         };
-        let result = resolve_restore_targets(input).unwrap();
+        let result = resolve_restore_targets_inner(input).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 1);
@@ -875,7 +893,7 @@ mod tests {
             }],
         };
 
-        let result = resolve_restore_targets(input).unwrap();
+        let result = resolve_restore_targets_inner(input).unwrap();
 
         assert!(result.blocked.is_empty());
         assert_eq!(result.actions.len(), 1);
@@ -930,7 +948,7 @@ mod tests {
                 last_modified_at: LAST_MODIFIED_AT.into(),
             }],
         };
-        let result = resolve_restore_targets(input).unwrap();
+        let result = resolve_restore_targets_inner(input).unwrap();
 
         assert!(result.actions.is_empty());
         assert_eq!(result.blocked[0].reason, "blocked-target-ambiguous");
@@ -941,12 +959,29 @@ mod tests {
         let temp = tempdir().unwrap();
         let variants = vec![variant("opaque-folder", "Goldberg")];
         let files = vec![file(&variants[0], "../slot.dat")];
-        assert!(resolve_restore_targets(input(
+        assert!(resolve_restore_targets_inner(input(
             temp.path(),
             StoreUserContext::default(),
             variants,
             files
         ))
         .is_err());
+    }
+
+    #[test]
+    fn rejects_windows_unsafe_relative_paths_during_resolution() {
+        for relative_path in ["slot.sav:stream", "CON", "Profile/NUL.txt", "save. "] {
+            let temp = tempdir().unwrap();
+            let variants = vec![variant("opaque-folder", "Goldberg")];
+            let files = vec![file(&variants[0], relative_path)];
+
+            assert!(resolve_restore_targets_inner(input(
+                temp.path(),
+                StoreUserContext::default(),
+                variants,
+                files,
+            ))
+            .is_err());
+        }
     }
 }

--- a/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
+++ b/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
@@ -860,16 +860,14 @@ mod tests {
 
     #[test]
     fn resolves_an_approved_custom_directory_and_can_create_it() {
-        let temp = tempdir().unwrap();
         let default = variant("default", "default");
-        let custom_root = temp.path().join("Custom Saves");
-        let normalized_root = custom_root.display().to_string().replace('\\', "/");
+        let normalized_root = "C:/Users/hydra/AppData/Local/Temp/Custom Saves";
         let raw_path = format!("<custom><windows><absolute>{normalized_root}");
         let input = ResolveRestoreTargetsInput {
             shop: "steam".into(),
             object_id: "1".into(),
             platform: "windows".into(),
-            home_dir: temp.path().display().to_string(),
+            home_dir: "C:/Users/hydra".into(),
             documents_dir: None,
             app_data_dir: None,
             executable_path: None,

--- a/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
+++ b/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
@@ -1,0 +1,952 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+use crate::cloud_save::hashing::hash_file;
+use crate::cloud_save::identity::{
+    is_safe_capture, normalize_rule_path, KnownStoreAccount, SnapshotVariant,
+};
+use crate::cloud_save::manifest::types::CloudSaveRule;
+use crate::cloud_save::path_resolution::{
+    build_context, glob_base_path, resolve_restore_root, ResolveSaveRulesInput,
+};
+
+use super::metadata::parse_last_modified_at;
+use super::types::{
+    BlockedRestoreFile, ResolveRestoreTargetsInput, ResolveRestoreTargetsResult,
+    ResolvedRestoreTarget, RestoreManifestFile,
+};
+use super::validation::{validate_hash, validate_relative_path, validate_size};
+
+const STEAM_INDIVIDUAL_ACCOUNT_BASE: u64 = 76_561_197_960_265_728;
+
+fn join_path(root: &str, relative_path: &str) -> String {
+    format!(
+        "{}/{}",
+        root.trim_end_matches(['/', '\\']),
+        relative_path.trim_start_matches(['/', '\\'])
+    )
+    .replace('\\', "/")
+}
+
+fn validate_file(file: &RestoreManifestFile) -> Result<(), String> {
+    if file.variant_id.len() != 64
+        || !file.variant_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || file.raw_path.is_empty()
+        || normalize_rule_path(&file.raw_path) != file.raw_path
+    {
+        return Err("cloud_save_invalid_restore_identity".to_string());
+    }
+    validate_relative_path(&file.relative_path)?;
+    validate_hash(&file.hash)?;
+    validate_size(file.size_bytes)?;
+    parse_last_modified_at(&file.last_modified_at).map(|_| ())
+}
+
+fn validate_variant(variant: &SnapshotVariant, shop: &str) -> Result<(), String> {
+    if variant.variant_id.len() != 64
+        || !variant
+            .variant_id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("cloud_save_invalid_restore_variant".to_string());
+    }
+    match variant.kind.as_str() {
+        "default" if variant.steam_id64.is_none() && variant.concrete_folder_id.is_none() => Ok(()),
+        "steam-account"
+            if shop == "steam"
+                && variant.concrete_folder_id.is_none()
+                && variant.steam_id64.as_deref().is_some_and(|value| {
+                    value.len() == 17 && value.bytes().all(|byte| byte.is_ascii_digit())
+                }) =>
+        {
+            Ok(())
+        }
+        "opaque-folder"
+            if variant.steam_id64.is_none()
+                && variant
+                    .concrete_folder_id
+                    .as_deref()
+                    .is_some_and(is_safe_capture) =>
+        {
+            Ok(())
+        }
+        _ => Err("cloud_save_invalid_restore_variant".to_string()),
+    }
+}
+
+fn canonical_target_key(path: &str, case_sensitive: bool) -> String {
+    let mut existing = PathBuf::from(path);
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name().map(|name| name.to_os_string()) else {
+            break;
+        };
+        missing.push(name);
+        if !existing.pop() {
+            break;
+        }
+    }
+
+    let mut canonical = std::fs::canonicalize(&existing).unwrap_or(existing);
+    for segment in missing.into_iter().rev() {
+        canonical.push(segment);
+    }
+    let normalized = canonical.to_string_lossy().replace('\\', "/");
+    if case_sensitive {
+        normalized
+    } else {
+        normalized.to_lowercase()
+    }
+}
+
+fn target_is_within_root(target: &str, root: &str, case_sensitive: bool) -> bool {
+    let target = canonical_target_key(target, case_sensitive);
+    let root = canonical_target_key(root, case_sensitive);
+    target == root || target.starts_with(&format!("{}/", root.trim_end_matches('/')))
+}
+
+fn identity_key(file: &RestoreManifestFile) -> String {
+    format!(
+        "{}\0{}\0{}",
+        file.variant_id, file.raw_path, file.relative_path
+    )
+}
+
+fn blocked(file: RestoreManifestFile, reason: &str) -> BlockedRestoreFile {
+    BlockedRestoreFile {
+        variant_id: file.variant_id,
+        raw_path: file.raw_path,
+        relative_path: file.relative_path,
+        hash: file.hash,
+        size_bytes: file.size_bytes,
+        last_modified_at: file.last_modified_at,
+        reason: reason.to_string(),
+    }
+}
+
+fn validated_steam_ids(account: &KnownStoreAccount) -> Option<(String, String)> {
+    if account.store != "steam" {
+        return None;
+    }
+    let steam_id64 = account.steam_id64.as_deref()?.parse::<u64>().ok()?;
+    let account_id32 = steam_id64.checked_sub(STEAM_INDIVIDUAL_ACCOUNT_BASE)?;
+    if account_id32 > u32::MAX as u64 {
+        return None;
+    }
+    let account_id32 = account_id32.to_string();
+    if account.account_id32.as_deref() != Some(account_id32.as_str()) {
+        return None;
+    }
+    Some((steam_id64.to_string(), account_id32))
+}
+
+fn concrete_user_values(
+    variant: &SnapshotVariant,
+    context: &crate::cloud_save::identity::StoreUserContext,
+) -> Result<Vec<String>, &'static str> {
+    match variant.kind.as_str() {
+        "default" => Ok(Vec::new()),
+        "opaque-folder" => Ok(vec![variant
+            .concrete_folder_id
+            .clone()
+            .ok_or("blocked-user-ambiguous")?]),
+        "steam-account" => {
+            let expected = variant
+                .steam_id64
+                .as_deref()
+                .ok_or("blocked-user-ambiguous")?;
+            let account = context
+                .active
+                .iter()
+                .chain(context.known.iter())
+                .find_map(|account| validated_steam_ids(account).filter(|ids| ids.0 == expected))
+                .ok_or("blocked-user-not-found")?;
+            Ok(vec![account.0, account.1])
+        }
+        _ => Err("blocked-user-ambiguous"),
+    }
+}
+
+fn bind_store_user(raw_rule: &str, value: &str) -> String {
+    raw_rule
+        .replace("*<storeUserId>", value)
+        .replace("<storeUserId>*", value)
+        .replace("<storeUserId>", value)
+}
+
+fn has_glob(raw_rule: &str) -> bool {
+    raw_rule
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '[' | '{'))
+}
+
+#[napi]
+pub fn resolve_restore_targets(
+    input: ResolveRestoreTargetsInput,
+) -> napi::Result<ResolveRestoreTargetsResult> {
+    let context = build_context(&ResolveSaveRulesInput {
+        shop: input.shop.clone(),
+        object_id: input.object_id.clone(),
+        platform: input.platform.clone(),
+        home_dir: input.home_dir,
+        documents_dir: input.documents_dir,
+        app_data_dir: input.app_data_dir,
+        executable_path: input.executable_path,
+        wine_prefix_path: input.wine_prefix_path,
+        steam_path: input.steam_path,
+        rules: Vec::<CloudSaveRule>::new(),
+    })
+    .map_err(Error::from_reason)?;
+    let case_sensitive = context.platform == "linux" && !context.windows_compatibility;
+
+    let mut variants = HashMap::new();
+    for variant in input.variants {
+        validate_variant(&variant, &input.shop).map_err(Error::from_reason)?;
+        if variants
+            .insert(variant.variant_id.clone(), variant)
+            .is_some()
+        {
+            return Err(Error::from_reason("cloud_save_duplicate_restore_variant"));
+        }
+    }
+
+    let approved = input
+        .approved_rules
+        .into_iter()
+        .filter(|rule| !rule.kind.is_empty() && !rule.raw_path.is_empty())
+        .collect::<Vec<_>>();
+    let mut candidates = Vec::<(ResolvedRestoreTarget, RestoreManifestFile)>::new();
+    let mut blocked_files = Vec::new();
+    let mut identities = HashSet::new();
+    let mut used_variants = HashSet::new();
+
+    for file in input.files {
+        validate_file(&file).map_err(Error::from_reason)?;
+        if !identities.insert(identity_key(&file)) {
+            return Err(Error::from_reason("cloud_save_duplicate_restore_identity"));
+        }
+        let Some(variant) = variants.get(&file.variant_id) else {
+            return Err(Error::from_reason("cloud_save_restore_variant_not_found"));
+        };
+        used_variants.insert(file.variant_id.clone());
+
+        let rules = approved
+            .iter()
+            .filter(|rule| normalize_rule_path(&rule.raw_path) == file.raw_path)
+            .collect::<Vec<_>>();
+        if rules.is_empty() {
+            blocked_files.push(blocked(file, "blocked-rule-unavailable"));
+            continue;
+        }
+        if variant.kind == "default" && file.raw_path.contains("<storeUserId>") {
+            blocked_files.push(blocked(file, "blocked-user-ambiguous"));
+            continue;
+        }
+        if variant.kind != "default" && !file.raw_path.contains("<storeUserId>") {
+            blocked_files.push(blocked(file, "blocked-user-ambiguous"));
+            continue;
+        }
+
+        let user_values = match concrete_user_values(variant, &input.store_user_context) {
+            Ok(values) => values,
+            Err(reason) => {
+                blocked_files.push(blocked(file, reason));
+                continue;
+            }
+        };
+
+        let mut resolved_targets = Vec::new();
+        for rule in rules {
+            let directory = rule.kind == "dir" || has_glob(&rule.raw_path);
+            let root_rule = if has_glob(&rule.raw_path) {
+                glob_base_path(&rule.raw_path).unwrap_or_else(|| rule.raw_path.clone())
+            } else {
+                rule.raw_path.clone()
+            };
+            let concrete_values = if variant.kind == "default" {
+                vec![None]
+            } else {
+                user_values.iter().map(Some).collect()
+            };
+            let mut resolved_roots = Vec::new();
+            let preferred_path = rule.preferred_path.as_ref().filter(|preferred_path| {
+                variant.kind == "default"
+                    || user_values.iter().any(|value| {
+                        preferred_path
+                            .replace('\\', "/")
+                            .split('/')
+                            .any(|segment| segment == value)
+                    })
+            });
+            if let Some(preferred_path) = preferred_path {
+                resolved_roots.push(preferred_path.replace('\\', "/"));
+            }
+            for user_value in concrete_values {
+                if preferred_path.is_some() {
+                    break;
+                }
+                let concrete_rule = user_value
+                    .map(|value| bind_store_user(&root_rule, value))
+                    .unwrap_or_else(|| root_rule.clone());
+                if let Ok(root) = resolve_restore_root(
+                    &concrete_rule,
+                    &context,
+                    directory,
+                    std::slice::from_ref(&file.relative_path),
+                ) {
+                    if variant.kind == "opaque-folder" && !Path::new(&root).exists() {
+                        continue;
+                    }
+                    resolved_roots.push(root);
+                }
+            }
+
+            if variant.kind == "steam-account" {
+                let existing = resolved_roots
+                    .iter()
+                    .filter(|root| Path::new(root).exists())
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if !existing.is_empty() {
+                    resolved_roots = existing;
+                } else {
+                    resolved_roots.truncate(1);
+                }
+            }
+            for root in resolved_roots {
+                let target_path = if directory {
+                    join_path(&root, &file.relative_path)
+                } else {
+                    root.clone()
+                };
+                let restore_root_path = if directory {
+                    root
+                } else {
+                    Path::new(&target_path)
+                        .parent()
+                        .map(|parent| parent.to_string_lossy().replace('\\', "/"))
+                        .unwrap_or_default()
+                };
+                if !restore_root_path.is_empty()
+                    && target_is_within_root(&target_path, &restore_root_path, case_sensitive)
+                {
+                    resolved_targets.push((target_path, restore_root_path));
+                }
+            }
+        }
+
+        resolved_targets.sort_by(|left, right| {
+            canonical_target_key(&left.0, case_sensitive)
+                .cmp(&canonical_target_key(&right.0, case_sensitive))
+                .then_with(|| {
+                    Path::new(&right.1)
+                        .components()
+                        .count()
+                        .cmp(&Path::new(&left.1).components().count())
+                })
+        });
+        resolved_targets.dedup_by(|left, right| {
+            canonical_target_key(&left.0, case_sensitive)
+                == canonical_target_key(&right.0, case_sensitive)
+        });
+        if resolved_targets.is_empty() {
+            blocked_files.push(blocked(file, "blocked-user-not-found"));
+            continue;
+        }
+        if resolved_targets.len() > 1 {
+            blocked_files.push(blocked(file, "blocked-target-ambiguous"));
+            continue;
+        }
+
+        let (target_path, restore_root_path) = resolved_targets.remove(0);
+        let action = if Path::new(&target_path).is_file()
+            && hash_file(&target_path).is_ok_and(|hash| hash == file.hash)
+        {
+            "skip-identical"
+        } else if Path::new(&target_path).exists() {
+            "replace"
+        } else {
+            "create"
+        };
+        candidates.push((
+            ResolvedRestoreTarget {
+                variant_id: file.variant_id.clone(),
+                raw_path: file.raw_path.clone(),
+                relative_path: file.relative_path.clone(),
+                target_path,
+                restore_root_path,
+                hash: file.hash.clone(),
+                size_bytes: file.size_bytes,
+                last_modified_at: file.last_modified_at.clone(),
+                action: action.to_string(),
+            },
+            file,
+        ));
+    }
+
+    if used_variants.len() != variants.len() {
+        return Err(Error::from_reason("cloud_save_unused_restore_variant"));
+    }
+
+    let mut counts = HashMap::new();
+    for (target, _) in &candidates {
+        *counts
+            .entry(canonical_target_key(&target.target_path, case_sensitive))
+            .or_insert(0usize) += 1;
+    }
+    let mut actions = Vec::new();
+    for (target, file) in candidates {
+        if counts
+            .get(&canonical_target_key(&target.target_path, case_sensitive))
+            .copied()
+            .unwrap_or_default()
+            > 1
+        {
+            blocked_files.push(blocked(file, "blocked-target-ambiguous"));
+        } else {
+            actions.push(target);
+        }
+    }
+    actions.sort_by_key(|file| {
+        format!(
+            "{}\0{}\0{}",
+            file.variant_id, file.raw_path, file.relative_path
+        )
+    });
+    blocked_files.sort_by_key(|file| {
+        format!(
+            "{}\0{}\0{}",
+            file.variant_id, file.raw_path, file.relative_path
+        )
+    });
+
+    Ok(ResolveRestoreTargetsResult {
+        actions,
+        blocked: blocked_files,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::cloud_save::identity::{KnownStoreAccount, StoreUserContext};
+    use crate::cloud_save::restore::types::ApprovedRestoreRule;
+
+    const RAW_RULE: &str = "<home>/Game/<storeUserId>";
+    const LAST_MODIFIED_AT: &str = "2026-07-23T10:00:00.123Z";
+
+    fn variant(kind: &str, user: &str) -> SnapshotVariant {
+        SnapshotVariant {
+            variant_id: format!("{:x}", Sha256::digest(format!("{kind}:{user}"))),
+            kind: kind.into(),
+            steam_id64: (kind == "steam-account").then(|| user.into()),
+            concrete_folder_id: (kind == "opaque-folder").then(|| user.into()),
+        }
+    }
+
+    fn file(variant: &SnapshotVariant, relative_path: &str) -> RestoreManifestFile {
+        RestoreManifestFile {
+            variant_id: variant.variant_id.clone(),
+            raw_path: RAW_RULE.into(),
+            relative_path: relative_path.to_string(),
+            hash: "a".repeat(64),
+            size_bytes: 4.0,
+            last_modified_at: LAST_MODIFIED_AT.into(),
+        }
+    }
+
+    fn input(
+        home: &Path,
+        context: StoreUserContext,
+        variants: Vec<SnapshotVariant>,
+        files: Vec<RestoreManifestFile>,
+    ) -> ResolveRestoreTargetsInput {
+        ResolveRestoreTargetsInput {
+            shop: "steam".into(),
+            object_id: "1".into(),
+            platform: "windows".into(),
+            home_dir: home.display().to_string(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            store_user_context: context,
+            approved_rules: vec![ApprovedRestoreRule {
+                kind: "dir".into(),
+                raw_path: RAW_RULE.into(),
+                source: "test".into(),
+                preferred_path: None,
+            }],
+            variants,
+            files,
+        }
+    }
+
+    #[test]
+    fn keeps_an_absolute_custom_path_exact() {
+        let temp = tempdir().unwrap();
+        let variant = variant("default", "");
+        let mut remote_file = file(&variant, "slot.sav");
+        remote_file.raw_path =
+            "<custom><windows><absolute>C:/Users/Rodrigo/Downloads/Game/Saves".into();
+        let mut restore_input = input(
+            temp.path(),
+            StoreUserContext {
+                active: None,
+                known: Vec::new(),
+            },
+            vec![variant],
+            vec![remote_file],
+        );
+        restore_input.approved_rules = vec![ApprovedRestoreRule {
+            kind: "dir".into(),
+            raw_path: "<custom><windows><absolute>C:/Users/Rodrigo/Downloads/Game/Saves".into(),
+            source: "custom".into(),
+            preferred_path: None,
+        }];
+
+        let result = resolve_restore_targets(restore_input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(
+            Path::new(&result.actions[0].target_path),
+            Path::new("C:/Users/Rodrigo/Downloads/Game/Saves/slot.sav")
+        );
+    }
+
+    #[test]
+    fn restores_a_windows_custom_path_to_the_approved_active_profile() {
+        let temp = tempdir().unwrap();
+        let prefix = temp.path().join("prefix");
+        fs::create_dir_all(prefix.join("drive_c/users/steamuser")).unwrap();
+        fs::create_dir_all(prefix.join("drive_c/users/player-two")).unwrap();
+        let approved_root = prefix.join("drive_c/users/player-two/AppData/Roaming/Game");
+        let variant = variant("default", "");
+        let raw_path = "<custom><windows><winAppData>/Game";
+        let mut remote_file = file(&variant, "slot.sav");
+        remote_file.raw_path = raw_path.into();
+        let mut restore_input = input(
+            temp.path(),
+            StoreUserContext {
+                active: None,
+                known: Vec::new(),
+            },
+            vec![variant],
+            vec![remote_file],
+        );
+        restore_input.platform = "linux".into();
+        restore_input.executable_path =
+            Some(temp.path().join("Game/game.exe").display().to_string());
+        restore_input.wine_prefix_path = Some(prefix.display().to_string());
+        restore_input.approved_rules = vec![ApprovedRestoreRule {
+            kind: "dir".into(),
+            raw_path: raw_path.into(),
+            source: "custom".into(),
+            preferred_path: Some(approved_root.display().to_string()),
+        }];
+
+        let result = resolve_restore_targets(restore_input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(
+            Path::new(&result.actions[0].target_path),
+            approved_root.join("slot.sav")
+        );
+    }
+
+    #[test]
+    fn an_approved_custom_path_restores_to_its_exact_preferred_path() {
+        let temp = tempdir().unwrap();
+        let prefix = temp.path().join("prefix");
+        let selected = prefix.join("drive_c/users/player-two/Documents/Game");
+        fs::create_dir_all(prefix.join("drive_c/users/steamuser/Documents/Game")).unwrap();
+        fs::create_dir_all(&selected).unwrap();
+        let variant = variant("default", "");
+        let raw_path = "<custom><windows><winDocuments>/Game";
+        let mut remote_file = file(&variant, "slot.sav");
+        remote_file.raw_path = raw_path.into();
+        let mut restore_input = input(
+            temp.path(),
+            StoreUserContext {
+                active: None,
+                known: Vec::new(),
+            },
+            vec![variant],
+            vec![remote_file],
+        );
+        restore_input.platform = "linux".into();
+        restore_input.executable_path =
+            Some(temp.path().join("Game/game.exe").display().to_string());
+        restore_input.wine_prefix_path = Some(prefix.display().to_string());
+        restore_input.approved_rules = vec![ApprovedRestoreRule {
+            kind: "dir".into(),
+            raw_path: raw_path.into(),
+            source: "custom".into(),
+            preferred_path: Some(selected.display().to_string()),
+        }];
+
+        let result = resolve_restore_targets(restore_input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(
+            Path::new(&result.actions[0].target_path),
+            selected.join("slot.sav")
+        );
+    }
+
+    #[test]
+    fn maps_two_opaque_folders_independently_even_with_same_hash() {
+        let temp = tempdir().unwrap();
+        for user in ["Goldberg", "Rune"] {
+            fs::create_dir_all(temp.path().join("Game").join(user)).unwrap();
+        }
+        let variants = vec![
+            variant("opaque-folder", "Goldberg"),
+            variant("opaque-folder", "Rune"),
+        ];
+        let files = variants
+            .iter()
+            .map(|variant| file(variant, "slot.dat"))
+            .collect();
+        let result = resolve_restore_targets(input(
+            temp.path(),
+            StoreUserContext::default(),
+            variants,
+            files,
+        ))
+        .unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 2);
+    }
+
+    #[test]
+    fn refuses_to_create_a_missing_opaque_folder() {
+        let temp = tempdir().unwrap();
+        let variants = vec![variant("opaque-folder", "Unknown")];
+        let files = vec![file(&variants[0], "slot.dat")];
+        let result = resolve_restore_targets(input(
+            temp.path(),
+            StoreUserContext::default(),
+            variants,
+            files,
+        ))
+        .unwrap();
+
+        assert!(result.actions.is_empty());
+        assert_eq!(result.blocked[0].reason, "blocked-user-not-found");
+    }
+
+    #[test]
+    fn validated_account_can_create_its_exact_missing_folder() {
+        let temp = tempdir().unwrap();
+        let account = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some("76561197960278073".into()),
+            account_id32: Some("12345".into()),
+            source: "loginusers".into(),
+        };
+        let context = StoreUserContext {
+            active: Some(account.clone()),
+            known: vec![account],
+        };
+        let variants = vec![variant("steam-account", "76561197960278073")];
+        let files = vec![file(&variants[0], "slot.dat")];
+        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(result.actions[0].action, "create");
+    }
+
+    #[test]
+    fn restores_remote_snapshot_accounts_independently_from_the_local_account() {
+        let temp = tempdir().unwrap();
+        let local = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some("76561199208012825".into()),
+            account_id32: Some("1247747097".into()),
+            source: "active-login".into(),
+        };
+        let remote_accounts = [
+            ("76561199800542110", "1840276382"),
+            ("76561199865645641", "1905379913"),
+            ("76561198835007011", "874741283"),
+        ];
+        let mut known = vec![local.clone()];
+        known.extend(
+            remote_accounts.map(|(steam_id64, account_id32)| KnownStoreAccount {
+                store: "steam".into(),
+                steam_id64: Some(steam_id64.into()),
+                account_id32: Some(account_id32.into()),
+                source: "remote-snapshot".into(),
+            }),
+        );
+        let context = StoreUserContext {
+            active: Some(local),
+            known,
+        };
+        let variants = remote_accounts
+            .map(|(steam_id64, _)| variant("steam-account", steam_id64))
+            .to_vec();
+        let files = variants
+            .iter()
+            .map(|variant| file(variant, "slot.dat"))
+            .collect();
+
+        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 3);
+        for (steam_id64, _) in remote_accounts {
+            assert!(result.actions.iter().any(|action| {
+                action
+                    .target_path
+                    .replace('\\', "/")
+                    .ends_with(&format!("/Game/{steam_id64}/slot.dat"))
+            }));
+        }
+        assert!(result
+            .actions
+            .iter()
+            .all(|action| !action.target_path.contains("76561199208012825")));
+    }
+
+    #[test]
+    fn reuses_an_existing_account_id32_folder_for_a_remote_account() {
+        let temp = tempdir().unwrap();
+        fs::create_dir_all(temp.path().join("Game").join("1840276382")).unwrap();
+        let account = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some("76561199800542110".into()),
+            account_id32: Some("1840276382".into()),
+            source: "remote-snapshot".into(),
+        };
+        let context = StoreUserContext {
+            active: None,
+            known: vec![account],
+        };
+        let variants = vec![variant("steam-account", "76561199800542110")];
+        let files = vec![file(&variants[0], "slot.dat")];
+
+        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert!(result.actions[0]
+            .target_path
+            .replace('\\', "/")
+            .ends_with("/Game/1840276382/slot.dat"));
+    }
+
+    #[test]
+    fn blocks_a_remote_account_when_both_steam_folder_formats_exist() {
+        let temp = tempdir().unwrap();
+        fs::create_dir_all(temp.path().join("Game").join("76561199800542110")).unwrap();
+        fs::create_dir_all(temp.path().join("Game").join("1840276382")).unwrap();
+        let account = KnownStoreAccount {
+            store: "steam".into(),
+            steam_id64: Some("76561199800542110".into()),
+            account_id32: Some("1840276382".into()),
+            source: "remote-snapshot".into(),
+        };
+        let context = StoreUserContext {
+            active: None,
+            known: vec![account],
+        };
+        let variants = vec![variant("steam-account", "76561199800542110")];
+        let files = vec![file(&variants[0], "slot.dat")];
+
+        let result = resolve_restore_targets(input(temp.path(), context, variants, files)).unwrap();
+
+        assert!(result.actions.is_empty());
+        assert_eq!(result.blocked.len(), 1);
+        assert_eq!(result.blocked[0].reason, "blocked-target-ambiguous");
+    }
+
+    #[test]
+    fn blocks_a_steam_variant_when_the_account_is_not_known() {
+        let temp = tempdir().unwrap();
+        let variants = vec![variant("steam-account", "76561197960278073")];
+        let files = vec![file(&variants[0], "slot.dat")];
+        let result = resolve_restore_targets(input(
+            temp.path(),
+            StoreUserContext::default(),
+            variants,
+            files,
+        ))
+        .unwrap();
+
+        assert!(result.actions.is_empty());
+        assert_eq!(result.blocked[0].reason, "blocked-user-not-found");
+    }
+
+    #[test]
+    fn resolves_a_default_variant_without_a_store_user() {
+        let temp = tempdir().unwrap();
+        let default = variant("default", "default");
+        let raw_path = "<home>/Game/save.dat";
+        let input = ResolveRestoreTargetsInput {
+            shop: "steam".into(),
+            object_id: "1".into(),
+            platform: "windows".into(),
+            home_dir: temp.path().display().to_string(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            store_user_context: StoreUserContext::default(),
+            approved_rules: vec![ApprovedRestoreRule {
+                kind: "file".into(),
+                raw_path: raw_path.into(),
+                source: "test".into(),
+                preferred_path: None,
+            }],
+            variants: vec![default.clone()],
+            files: vec![RestoreManifestFile {
+                variant_id: default.variant_id,
+                raw_path: raw_path.into(),
+                relative_path: "save.dat".into(),
+                hash: "a".repeat(64),
+                size_bytes: 4.0,
+                last_modified_at: LAST_MODIFIED_AT.into(),
+            }],
+        };
+        let result = resolve_restore_targets(input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert!(result.actions[0]
+            .target_path
+            .replace('\\', "/")
+            .ends_with("/Game/save.dat"));
+        assert!(result.actions[0]
+            .restore_root_path
+            .replace('\\', "/")
+            .ends_with("/Game"));
+        assert_eq!(result.actions[0].last_modified_at, LAST_MODIFIED_AT);
+    }
+
+    #[test]
+    fn resolves_an_approved_custom_directory_and_can_create_it() {
+        let temp = tempdir().unwrap();
+        let default = variant("default", "default");
+        let custom_root = temp.path().join("Custom Saves");
+        let normalized_root = custom_root.display().to_string().replace('\\', "/");
+        let raw_path = format!("<custom><windows><absolute>{normalized_root}");
+        let input = ResolveRestoreTargetsInput {
+            shop: "steam".into(),
+            object_id: "1".into(),
+            platform: "windows".into(),
+            home_dir: temp.path().display().to_string(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            store_user_context: StoreUserContext::default(),
+            approved_rules: vec![ApprovedRestoreRule {
+                kind: "dir".into(),
+                raw_path: raw_path.clone(),
+                source: "custom".into(),
+                preferred_path: None,
+            }],
+            variants: vec![default.clone()],
+            files: vec![RestoreManifestFile {
+                variant_id: default.variant_id,
+                raw_path,
+                relative_path: "Profile/slot.sav".into(),
+                hash: "a".repeat(64),
+                size_bytes: 4.0,
+                last_modified_at: LAST_MODIFIED_AT.into(),
+            }],
+        };
+
+        let result = resolve_restore_targets(input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(result.actions[0].action, "create");
+        assert_eq!(
+            result.actions[0].restore_root_path.replace('\\', "/"),
+            normalized_root
+        );
+        assert!(result.actions[0]
+            .target_path
+            .replace('\\', "/")
+            .ends_with("/Custom Saves/Profile/slot.sav"));
+    }
+
+    #[test]
+    fn blocks_rules_that_resolve_the_same_entry_to_different_targets() {
+        let temp = tempdir().unwrap();
+        let default = variant("default", "default");
+        let raw_path = "<home>/Game";
+        let input = ResolveRestoreTargetsInput {
+            shop: "steam".into(),
+            object_id: "1".into(),
+            platform: "windows".into(),
+            home_dir: temp.path().display().to_string(),
+            documents_dir: None,
+            app_data_dir: None,
+            executable_path: None,
+            wine_prefix_path: None,
+            steam_path: None,
+            store_user_context: StoreUserContext::default(),
+            approved_rules: vec![
+                ApprovedRestoreRule {
+                    kind: "file".into(),
+                    raw_path: raw_path.into(),
+                    source: "first".into(),
+                    preferred_path: None,
+                },
+                ApprovedRestoreRule {
+                    kind: "dir".into(),
+                    raw_path: raw_path.into(),
+                    source: "second".into(),
+                    preferred_path: None,
+                },
+            ],
+            variants: vec![default.clone()],
+            files: vec![RestoreManifestFile {
+                variant_id: default.variant_id,
+                raw_path: raw_path.into(),
+                relative_path: "slot.dat".into(),
+                hash: "a".repeat(64),
+                size_bytes: 4.0,
+                last_modified_at: LAST_MODIFIED_AT.into(),
+            }],
+        };
+        let result = resolve_restore_targets(input).unwrap();
+
+        assert!(result.actions.is_empty());
+        assert_eq!(result.blocked[0].reason, "blocked-target-ambiguous");
+    }
+
+    #[test]
+    fn rejects_traversal() {
+        let temp = tempdir().unwrap();
+        let variants = vec![variant("opaque-folder", "Goldberg")];
+        let files = vec![file(&variants[0], "../slot.dat")];
+        assert!(resolve_restore_targets(input(
+            temp.path(),
+            StoreUserContext::default(),
+            variants,
+            files
+        ))
+        .is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/should_skip_file.rs
+++ b/native/hydra-native/src/cloud_save/restore/should_skip_file.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+use crate::cloud_save::hashing::hash_file;
+
+use super::validation::validate_hash;
+
+fn should_skip(local_path: &str, expected_hash: &str) -> Result<bool, String> {
+    let path = Path::new(local_path);
+    if !path
+        .try_exists()
+        .map_err(|error| format!("Failed to inspect local restore file: {error}"))?
+    {
+        return Ok(false);
+    }
+
+    hash_file(local_path)
+        .map(|actual_hash| actual_hash == expected_hash)
+        .map_err(|error| format!("Failed to hash local restore file: {error}"))
+}
+
+#[napi]
+pub async fn should_skip_restore_file(
+    local_path: String,
+    expected_hash: String,
+) -> napi::Result<bool> {
+    validate_hash(&expected_hash).map_err(Error::from_reason)?;
+    tokio::task::spawn_blocking(move || should_skip(&local_path, &expected_hash))
+        .await
+        .map_err(|error| Error::from_reason(error.to_string()))?
+        .map_err(Error::from_reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn skips_only_matching_existing_files() {
+        let directory = tempdir().unwrap();
+        let regular = directory.path().join("save.blob");
+        let empty = directory.path().join("empty.blob");
+        tokio::fs::write(&regular, b"save").await.unwrap();
+        tokio::fs::write(&empty, []).await.unwrap();
+
+        assert!(should_skip_restore_file(
+            regular.display().to_string(),
+            format!("{:x}", Sha256::digest(b"save")),
+        )
+        .await
+        .unwrap());
+        assert!(should_skip_restore_file(
+            empty.display().to_string(),
+            format!("{:x}", Sha256::digest(b"")),
+        )
+        .await
+        .unwrap());
+        assert!(!should_skip_restore_file(
+            regular.display().to_string(),
+            format!("{:x}", Sha256::digest(b"other")),
+        )
+        .await
+        .unwrap());
+        assert!(!should_skip_restore_file(
+            directory.path().join("missing").display().to_string(),
+            format!("{:x}", Sha256::digest(b"")),
+        )
+        .await
+        .unwrap());
+        assert!(should_skip_restore_file(
+            directory.path().display().to_string(),
+            format!("{:x}", Sha256::digest(b"")),
+        )
+        .await
+        .is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/types.rs
+++ b/native/hydra-native/src/cloud_save/restore/types.rs
@@ -1,0 +1,145 @@
+use napi_derive::napi;
+
+use crate::cloud_save::identity::{SnapshotVariant, StoreUserContext};
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct RestoreManifestFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct ApprovedRestoreRule {
+    pub kind: String,
+    pub raw_path: String,
+    pub source: String,
+    pub preferred_path: Option<String>,
+}
+
+#[napi(object)]
+pub struct ResolveRestoreTargetsInput {
+    pub shop: String,
+    pub object_id: String,
+    pub platform: String,
+    pub home_dir: String,
+    pub documents_dir: Option<String>,
+    pub app_data_dir: Option<String>,
+    pub executable_path: Option<String>,
+    pub wine_prefix_path: Option<String>,
+    pub steam_path: Option<String>,
+    pub store_user_context: StoreUserContext,
+    pub approved_rules: Vec<ApprovedRestoreRule>,
+    pub variants: Vec<SnapshotVariant>,
+    pub files: Vec<RestoreManifestFile>,
+}
+
+#[napi(object)]
+pub struct ResolvedRestoreTarget {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub target_path: String,
+    pub restore_root_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+    pub action: String,
+}
+
+#[napi(object)]
+pub struct BlockedRestoreFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub hash: String,
+    pub size_bytes: f64,
+    pub last_modified_at: String,
+    pub reason: String,
+}
+
+#[napi(object)]
+pub struct ResolveRestoreTargetsResult {
+    pub actions: Vec<ResolvedRestoreTarget>,
+    pub blocked: Vec<BlockedRestoreFile>,
+}
+
+#[napi(object)]
+pub struct VerifyDownloadedRestoreFileResult {
+    pub ok: bool,
+    pub reason: Option<String>,
+}
+
+#[napi(string_enum = "lowercase")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RestoreTargetAction {
+    Restore,
+    Skip,
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct ReplaceRestoreTarget {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub target_path: String,
+    pub restore_root_path: String,
+    pub last_modified_at: String,
+    pub action: RestoreTargetAction,
+    pub temp_path: Option<String>,
+    pub expected_hash: Option<String>,
+}
+
+#[napi(object)]
+pub struct RestoreResultFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub target_path: String,
+    pub restore_root_path: String,
+    pub last_modified_at: String,
+}
+
+#[napi(object)]
+pub struct RestoreSkippedFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub target_path: String,
+    pub restore_root_path: String,
+    pub last_modified_at: String,
+    pub reason: String,
+}
+
+#[napi(object)]
+pub struct RestoreFailedFile {
+    pub variant_id: String,
+    pub raw_path: String,
+    pub relative_path: String,
+    pub target_path: String,
+    pub restore_root_path: String,
+    pub last_modified_at: String,
+    pub reason: String,
+}
+
+#[napi(object)]
+pub struct RestoreMetadataFailure {
+    pub path: String,
+    pub kind: String,
+    pub reason: String,
+}
+
+#[napi(object)]
+pub struct ReplaceRestoreTargetsResult {
+    pub restored_files: Vec<RestoreResultFile>,
+    pub skipped_files: Vec<RestoreSkippedFile>,
+    pub failed_files: Vec<RestoreFailedFile>,
+    pub metadata_failures: Vec<RestoreMetadataFailure>,
+    pub updated_directory_count: u32,
+}

--- a/native/hydra-native/src/cloud_save/restore/validation.rs
+++ b/native/hydra-native/src/cloud_save/restore/validation.rs
@@ -1,0 +1,56 @@
+use std::path::{Component, Path};
+
+pub fn validate_hash(hash: &str) -> Result<(), String> {
+    if hash.len() == 64
+        && hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err("cloud_save_invalid_blob_hash".to_string())
+    }
+}
+
+pub fn validate_size(size_bytes: f64) -> Result<(), String> {
+    if size_bytes.is_finite()
+        && size_bytes >= 0.0
+        && size_bytes.fract() == 0.0
+        && size_bytes <= u64::MAX as f64
+    {
+        Ok(())
+    } else {
+        Err("cloud_save_invalid_file_size".to_string())
+    }
+}
+
+pub fn validate_relative_path(value: &str) -> Result<(), String> {
+    let normalized = value.replace('\\', "/");
+    let path = Path::new(&normalized);
+    if normalized.is_empty()
+        || path.is_absolute()
+        || normalized.len() > 1 && normalized.as_bytes()[1] == b':'
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        Err("cloud_save_invalid_restore_relative_path".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn validate_path_component(value: &str) -> Result<(), String> {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        Ok(())
+    } else {
+        Err("cloud_save_invalid_restore_path_component".to_string())
+    }
+}

--- a/native/hydra-native/src/cloud_save/restore/validation.rs
+++ b/native/hydra-native/src/cloud_save/restore/validation.rs
@@ -28,6 +28,7 @@ pub fn validate_relative_path(value: &str) -> Result<(), String> {
     let normalized = value.replace('\\', "/");
     let path = Path::new(&normalized);
     if normalized.is_empty()
+        || normalized.contains('\0')
         || path.is_absolute()
         || normalized.len() > 1 && normalized.as_bytes()[1] == b':'
         || path.components().any(|component| {
@@ -43,6 +44,41 @@ pub fn validate_relative_path(value: &str) -> Result<(), String> {
     }
 }
 
+pub fn validate_windows_relative_path(value: &str) -> Result<(), String> {
+    validate_relative_path(value)?;
+    let normalized = value.replace('\\', "/");
+
+    for segment in normalized.split('/') {
+        if segment.is_empty()
+            || segment.ends_with(['.', ' '])
+            || segment.chars().any(|character| {
+                character.is_control()
+                    || matches!(character, '<' | '>' | ':' | '"' | '|' | '?' | '*')
+            })
+        {
+            return Err("cloud_save_invalid_windows_restore_path".to_string());
+        }
+
+        let stem = segment
+            .split('.')
+            .next()
+            .unwrap_or_default()
+            .to_ascii_uppercase();
+        let reserved = matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+            || stem.strip_prefix("COM").is_some_and(|suffix| {
+                matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+            })
+            || stem.strip_prefix("LPT").is_some_and(|suffix| {
+                matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+            });
+        if reserved {
+            return Err("cloud_save_invalid_windows_restore_path".to_string());
+        }
+    }
+
+    Ok(())
+}
+
 pub fn validate_path_component(value: &str) -> Result<(), String> {
     if !value.is_empty()
         && value
@@ -52,5 +88,35 @@ pub fn validate_path_component(value: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err("cloud_save_invalid_restore_path_component".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_windows_restore_paths() {
+        for path in ["Profile/slot.sav", "COM10/save.dat", "console/save.dat"] {
+            assert!(validate_windows_relative_path(path).is_ok(), "{path}");
+        }
+
+        for path in [
+            "Profile/slot.sav:stream",
+            "Profile/slot?.sav",
+            "Profile/slot. ",
+            "CON",
+            "nul.txt",
+            "COM1/save.dat",
+            "LPT9.txt",
+            "Profile/slot\0.sav",
+        ] {
+            assert!(validate_windows_relative_path(path).is_err(), "{path}");
+        }
+    }
+
+    #[test]
+    fn keeps_windows_only_rules_out_of_structural_validation() {
+        assert!(validate_relative_path("Profile/slot.sav:stream").is_ok());
     }
 }

--- a/native/hydra-native/src/cloud_save/restore/verify_file.rs
+++ b/native/hydra-native/src/cloud_save/restore/verify_file.rs
@@ -1,0 +1,78 @@
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+
+use crate::cloud_save::hashing::hash_file;
+
+use super::types::VerifyDownloadedRestoreFileResult;
+use super::validation::validate_hash;
+
+#[napi]
+pub async fn verify_downloaded_restore_file(
+    temp_path: String,
+    expected_hash: String,
+) -> napi::Result<VerifyDownloadedRestoreFileResult> {
+    validate_hash(&expected_hash).map_err(Error::from_reason)?;
+    let actual_hash = tokio::task::spawn_blocking(move || hash_file(&temp_path))
+        .await
+        .map_err(|error| Error::from_reason(error.to_string()))?
+        .map_err(|error| Error::from_reason(format!("Failed to hash restore file: {error}")))?;
+    let ok = actual_hash == expected_hash;
+
+    Ok(VerifyDownloadedRestoreFileResult {
+        ok,
+        reason: (!ok).then(|| "hash_mismatch".to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn verifies_regular_empty_mismatched_and_missing_files() {
+        let directory = tempdir().unwrap();
+        let regular = directory.path().join("regular.blob");
+        let empty = directory.path().join("empty.blob");
+        tokio::fs::write(&regular, b"save").await.unwrap();
+        tokio::fs::write(&empty, []).await.unwrap();
+
+        assert!(
+            verify_downloaded_restore_file(
+                regular.display().to_string(),
+                format!("{:x}", Sha256::digest(b"save")),
+            )
+            .await
+            .unwrap()
+            .ok
+        );
+        assert!(
+            verify_downloaded_restore_file(
+                empty.display().to_string(),
+                format!("{:x}", Sha256::digest(b"")),
+            )
+            .await
+            .unwrap()
+            .ok
+        );
+        assert_eq!(
+            verify_downloaded_restore_file(
+                regular.display().to_string(),
+                format!("{:x}", Sha256::digest(b"other")),
+            )
+            .await
+            .unwrap()
+            .reason
+            .as_deref(),
+            Some("hash_mismatch")
+        );
+        assert!(verify_downloaded_restore_file(
+            directory.path().join("missing").display().to_string(),
+            format!("{:x}", Sha256::digest(b"")),
+        )
+        .await
+        .is_err());
+    }
+}

--- a/native/hydra-native/src/cloud_save/save_scanner/mod.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/mod.rs
@@ -8,7 +8,10 @@ use napi_derive::napi;
 
 use crate::cloud_save::path_resolution::ResolvedCloudSaveRule;
 
+pub(crate) use scan_path::scan_resolved_path;
 pub use types::ScannedCloudSaveRule;
+#[cfg(test)]
+pub(crate) use types::{ScannedCloudSaveFile, ScannedCloudSavePath};
 
 #[napi]
 pub async fn scan_resolved_save_rules(

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -10,6 +10,7 @@ use super::glob::{expand_braces, has_glob_pattern, normalize_path};
 use super::types::{ScannedCloudSaveFile, ScannedCloudSavePath};
 use crate::cloud_save::identity::local_id;
 use crate::cloud_save::path_resolution::capture_store_user;
+use crate::cloud_save::restore::is_restore_artifact_path;
 
 const MAX_SCAN_DEPTH: usize = 100;
 
@@ -260,7 +261,7 @@ fn scan_directory(root: &Path, follow_links: bool) -> Result<ScannedCloudSavePat
         .follow_links(follow_links)
     {
         let entry = entry.map_err(|error| format!("cloud_save_filesystem_error: {error}"))?;
-        if !entry.file_type().is_file() {
+        if !entry.file_type().is_file() || is_restore_artifact_path(entry.path()) {
             continue;
         }
 
@@ -294,6 +295,9 @@ fn add_file(
     root: &Path,
     file: &Path,
 ) -> Result<(), String> {
+    if is_restore_artifact_path(file) {
+        return Ok(());
+    }
     let resolved_root = canonical_path(root)?;
     let relative_path = relative_path(root, file)
         .or_else(|| {
@@ -340,6 +344,9 @@ pub fn scan_resolved_path_with_capture(
     let mut scanned_by_root = BTreeMap::<String, ScannedCloudSavePath>::new();
 
     for matched in matches {
+        if is_restore_artifact_path(&matched) {
+            continue;
+        }
         let concrete = normalize_path(&matched.to_string_lossy());
         let captured = match capture_template {
             Some(template) => match capture_store_user(template, &concrete, case_sensitive) {
@@ -533,6 +540,26 @@ mod tests {
 
         assert_eq!(scanned[0].files.len(), 1);
         assert_eq!(scanned[0].files[0].relative_path, "{Deluxe}/save.dat");
+    }
+
+    #[test]
+    fn ignores_only_exact_restore_artifact_names() {
+        let temp = tempdir().unwrap();
+        let artifact = format!(".hydra-restore-{}-stage", "a".repeat(64));
+        fs::write(temp.path().join(&artifact), b"temporary").unwrap();
+        fs::write(temp.path().join(".hydra-restore-save.dat"), b"user").unwrap();
+        fs::write(temp.path().join("save.dat"), b"save").unwrap();
+
+        let scanned = scan_resolved_path(&temp.path().display().to_string(), true, None).unwrap();
+        let relative_paths = scanned[0]
+            .files
+            .iter()
+            .map(|file| file.relative_path.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(!relative_paths.contains(&artifact.as_str()));
+        assert!(relative_paths.contains(&".hydra-restore-save.dat"));
+        assert!(relative_paths.contains(&"save.dat"));
     }
 
     #[cfg(unix)]

--- a/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
+++ b/native/hydra-native/src/cloud_save/save_scanner/scan_path.rs
@@ -409,7 +409,6 @@ pub fn scan_resolved_path_with_capture(
     Ok(scanned_by_root.into_values().collect())
 }
 
-#[cfg(test)]
 pub fn scan_resolved_path(
     resolved_path: &str,
     case_sensitive: bool,

--- a/native/hydra-native/src/cloud_save/upload/mod.rs
+++ b/native/hydra-native/src/cloud_save/upload/mod.rs
@@ -1,0 +1,3 @@
+mod upload_blob;
+
+pub use upload_blob::upload_local_save_blob;

--- a/native/hydra-native/src/cloud_save/upload/upload_blob.rs
+++ b/native/hydra-native/src/cloud_save/upload/upload_blob.rs
@@ -1,0 +1,177 @@
+use napi::bindgen_prelude::Error;
+use napi_derive::napi;
+use reqwest::header::{HeaderValue, CONTENT_LENGTH};
+
+fn upload_error(error: reqwest::Error) -> Error {
+    Error::from_reason(format!(
+        "Failed to upload local save file: {}",
+        error.without_url()
+    ))
+}
+
+#[napi]
+pub async fn upload_local_save_blob(
+    absolute_path: String,
+    upload_url: String,
+    content_length: String,
+    checksum_sha256: String,
+) -> napi::Result<()> {
+    let expected_size = content_length
+        .parse::<u64>()
+        .map_err(|_| Error::from_reason("Invalid upload Content-Length"))?;
+    let content_length_header = HeaderValue::from_str(&content_length)
+        .map_err(|_| Error::from_reason("Invalid upload Content-Length"))?;
+    let checksum_header = HeaderValue::from_str(&checksum_sha256)
+        .map_err(|_| Error::from_reason("Invalid upload SHA-256 checksum"))?;
+    if checksum_sha256.is_empty() {
+        return Err(Error::from_reason("Invalid upload SHA-256 checksum"));
+    }
+
+    let file = tokio::fs::File::open(&absolute_path)
+        .await
+        .map_err(|error| Error::from_reason(format!("Failed to open local save file: {error}")))?;
+    let metadata = file.metadata().await.map_err(|error| {
+        Error::from_reason(format!("Failed to inspect local save file: {error}"))
+    })?;
+    if !metadata.is_file() {
+        return Err(Error::from_reason("Local save path is not a file"));
+    }
+    if metadata.len() != expected_size {
+        return Err(Error::from_reason("cloud_save_upload_source_size_changed"));
+    }
+
+    let response = reqwest::Client::new()
+        .put(upload_url)
+        .header(CONTENT_LENGTH, content_length_header)
+        .header("x-amz-checksum-sha256", checksum_header)
+        .body(file)
+        .send()
+        .await
+        .map_err(upload_error)?;
+    if matches!(response.status().as_u16(), 401 | 403) {
+        return Err(Error::from_reason("cloud_save_upload_url_expired"));
+    }
+    response.error_for_status().map_err(upload_error)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    async fn server(response: &'static [u8]) -> (String, oneshot::Receiver<Vec<u8>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (sender, receiver) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+
+            loop {
+                let read = stream.read(&mut buffer).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let length = headers.lines().find_map(|line| {
+                    line.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                });
+                if length.is_some_and(|length| request.len() >= header_end + 4 + length) {
+                    break;
+                }
+            }
+
+            let _ = sender.send(request);
+            stream.write_all(response).await.unwrap();
+        });
+        (format!("http://{address}/blob?signature=secret"), receiver)
+    }
+
+    async fn upload_and_capture(content: &[u8]) -> Vec<u8> {
+        let (url, request) = server(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").await;
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("save.dat");
+        tokio::fs::write(&path, content).await.unwrap();
+
+        upload_local_save_blob(
+            path.display().to_string(),
+            url,
+            content.len().to_string(),
+            "checksum==".to_string(),
+        )
+        .await
+        .unwrap();
+        request.await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn streams_empty_and_non_empty_files_with_content_length() {
+        for content in [b"".as_slice(), b"save".as_slice()] {
+            let request = upload_and_capture(content).await;
+            let header_end = request
+                .windows(4)
+                .position(|part| part == b"\r\n\r\n")
+                .unwrap();
+            let headers = String::from_utf8_lossy(&request[..header_end]).to_ascii_lowercase();
+
+            assert!(headers.contains(&format!("content-length: {}", content.len())));
+            assert!(headers.contains("x-amz-checksum-sha256: checksum=="));
+            assert_eq!(&request[header_end + 4..], content);
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_a_file_that_changed_size_after_prepare() {
+        let (url, _) = server(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").await;
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("save.dat");
+        tokio::fs::write(&path, b"changed").await.unwrap();
+
+        let error = upload_local_save_blob(
+            path.display().to_string(),
+            url,
+            "1".to_string(),
+            "checksum==".to_string(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("cloud_save_upload_source_size_changed"));
+    }
+
+    #[tokio::test]
+    async fn removes_signed_url_from_http_errors() {
+        let (url, _) = server(b"HTTP/1.1 411 Length Required\r\nContent-Length: 0\r\n\r\n").await;
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("save.dat");
+        tokio::fs::write(&path, []).await.unwrap();
+
+        let error = upload_local_save_blob(
+            path.display().to_string(),
+            url,
+            "0".to_string(),
+            "checksum==".to_string(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("411 Length Required"));
+        assert!(!error.contains("signature=secret"));
+        assert!(!error.contains("http://"));
+    }
+}

--- a/native/hydra-native/src/cloud_save/upload/upload_blob.rs
+++ b/native/hydra-native/src/cloud_save/upload/upload_blob.rs
@@ -2,6 +2,8 @@ use napi::bindgen_prelude::Error;
 use napi_derive::napi;
 use reqwest::header::{HeaderValue, CONTENT_LENGTH};
 
+use crate::cloud_save::http::blob_http_client;
+
 fn upload_error(error: reqwest::Error) -> Error {
     Error::from_reason(format!(
         "Failed to upload local save file: {}",
@@ -40,7 +42,8 @@ pub async fn upload_local_save_blob(
         return Err(Error::from_reason("cloud_save_upload_source_size_changed"));
     }
 
-    let response = reqwest::Client::new()
+    let response = blob_http_client()
+        .map_err(Error::from_reason)?
         .put(upload_url)
         .header(CONTENT_LENGTH, content_length_header)
         .header("x-amz-checksum-sha256", checksum_header)

--- a/native/hydra-native/src/lib.rs
+++ b/native/hydra-native/src/lib.rs
@@ -5,7 +5,13 @@ pub use cloud_save::hashing::{build_snapshot_aggregate_hash, hash_local_save_fil
 pub use cloud_save::local_snapshot::build_local_game_snapshot;
 pub use cloud_save::manifest::get_save_rules_for_game;
 pub use cloud_save::path_resolution::resolve_save_rules;
+pub use cloud_save::pipeline::build_local_game_snapshot_pipeline;
+pub use cloud_save::restore::{
+    cleanup_restore_temp_snapshot, download_restore_blob_to_temp, replace_restore_targets,
+    resolve_restore_targets, should_skip_restore_file, verify_downloaded_restore_file,
+};
 pub use cloud_save::save_scanner::scan_resolved_save_rules;
+pub use cloud_save::upload::upload_local_save_blob;
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter};


### PR DESCRIPTION
## Summary

- compose manifest lookup, path discovery, scanning, identity, and snapshot building in one native pipeline
- upload local save blobs through the native addon
- resolve, download, verify, and replace restore targets with path validation and metadata preservation

## Context

This PR is stacked on #2607 and replaces #2537 and #2538 using the final Cloud Saves V2 implementation. Local cloud-save deletion is intentionally excluded and will remain a separate later cut.

## Validation

- `cargo check`
- `git diff --check`

**When submitting this pull request, I confirm the following:**

- [ ] I have read the Hydra documentation.
- [ ] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
