### PR TITLE
feat: check hoster file availability on game page load

### DIFF
--- a/src/big-picture/src/hooks/queries/use-game-download-options.hook.ts
+++ b/src/big-picture/src/hooks/queries/use-game-download-options.hook.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { IS_DESKTOP } from "../../constants";
 import type { DownloadSource, Game, GameRepack } from "@types";
 import { orderBy } from "lodash-es";
+import { applyHosterAvailability, getCheckableHosterUris } from "@shared";
 
 export type DownloadOptionsEmptyStateReason =
   | "no-configured-sources"
@@ -19,7 +20,7 @@ function getKnownGameSourcesEmptyStateReason(
 }
 
 interface DownloadStateSetters {
-  setDownloadOptions: (v: GameRepack[]) => void;
+  setDownloadOptions: React.Dispatch<React.SetStateAction<GameRepack[]>>;
   setLocalDownloadSources: (v: DownloadSource[]) => void;
   setIsCheckingSources: (v: boolean) => void;
   setIsLoading: (v: boolean) => void;
@@ -111,6 +112,33 @@ function setNoDownloadOptionsState(
   });
 }
 
+async function refreshHosterAvailability(
+  downloadOptions: GameRepack[],
+  signal: { cancelled: boolean },
+  setters: DownloadStateSetters
+) {
+  const uris = getCheckableHosterUris(
+    downloadOptions.flatMap((option) =>
+      Array.isArray(option.uris) ? option.uris : []
+    )
+  );
+
+  if (uris.length === 0) return;
+
+  try {
+    const availability =
+      await globalThis.window.electron.checkHostersAvailability(uris);
+
+    applyIfNotCancelled(signal, () => {
+      setters.setDownloadOptions((prev) =>
+        applyHosterAvailability(prev, availability)
+      );
+    });
+  } catch (error) {
+    console.error("Failed to check hosters availability:", error);
+  }
+}
+
 async function fetchDownloadOptions(
   game: Pick<Game, "objectId" | "shop">,
   signal: { cancelled: boolean },
@@ -163,6 +191,10 @@ async function fetchDownloadOptions(
     );
 
     setDownloadOptionsSuccessState(signal, setters, options);
+
+    if (Array.isArray(options) && options.length > 0) {
+      await refreshHosterAvailability(options, signal, setters);
+    }
   } catch {
     setNoDownloadOptionsState(signal, setters);
   }

--- a/src/main/events/misc/check-hosters-availability.ts
+++ b/src/main/events/misc/check-hosters-availability.ts
@@ -1,0 +1,13 @@
+import { registerEvent } from "../register-event";
+import { HosterAvailabilityApi } from "@main/services/hosters";
+
+const checkHostersAvailability = async (
+  _event: Electron.IpcMainInvokeEvent,
+  uris: string[]
+): Promise<Record<string, boolean>> => {
+  if (!Array.isArray(uris) || uris.length === 0) return {};
+
+  return HosterAvailabilityApi.check(uris);
+};
+
+registerEvent("checkHostersAvailability", checkHostersAvailability);

--- a/src/main/events/misc/index.ts
+++ b/src/main/events/misc/index.ts
@@ -1,5 +1,6 @@
 import "./can-install-common-redist";
 import "./check-homebrew-folder-exists";
+import "./check-hosters-availability";
 import "./clipboard-write-text";
 import "./close-game-launcher-window";
 import "./delete-temp-file";

--- a/src/main/services/hosters/availability.ts
+++ b/src/main/services/hosters/availability.ts
@@ -1,0 +1,98 @@
+import axios from "axios";
+import { logger } from "../logger";
+import {
+  getCheckableHosterUris,
+  HOSTER_AVAILABILITY_MAX_URIS_PER_REQUEST,
+} from "@shared";
+
+interface AvailabilityResult {
+  url: string;
+  available: boolean;
+}
+
+interface AvailabilityResponse {
+  results: AvailabilityResult[];
+}
+
+const CACHE_TTL_IN_MS = 5 * 60 * 1000;
+
+export class HosterAvailabilityApi {
+  private static readonly cache = new Map<
+    string,
+    { available: boolean; checkedAt: number }
+  >();
+
+  private static getCached(uri: string) {
+    const entry = this.cache.get(uri);
+
+    if (!entry) return null;
+
+    if (Date.now() - entry.checkedAt > CACHE_TTL_IN_MS) {
+      this.cache.delete(uri);
+      return null;
+    }
+
+    return entry.available;
+  }
+
+  public static async check(uris: string[]): Promise<Record<string, boolean>> {
+    const checkableUris = getCheckableHosterUris(uris);
+
+    if (checkableUris.length === 0) return {};
+
+    const availability: Record<string, boolean> = {};
+    const urisToCheck: string[] = [];
+
+    for (const uri of checkableUris) {
+      const cached = this.getCached(uri);
+
+      if (cached === null) {
+        urisToCheck.push(uri);
+      } else {
+        availability[uri] = cached;
+      }
+    }
+
+    for (
+      let index = 0;
+      index < urisToCheck.length;
+      index += HOSTER_AVAILABILITY_MAX_URIS_PER_REQUEST
+    ) {
+      const batch = urisToCheck.slice(
+        index,
+        index + HOSTER_AVAILABILITY_MAX_URIS_PER_REQUEST
+      );
+
+      try {
+        const response = await axios.post<AvailabilityResponse>(
+          `${import.meta.env.MAIN_VITE_NIMBUS_API_URL}/hosters/availability`,
+          { urls: batch },
+          { timeout: 15_000 }
+        );
+
+        for (const result of response.data?.results ?? []) {
+          if (
+            typeof result?.url !== "string" ||
+            typeof result?.available !== "boolean"
+          ) {
+            continue;
+          }
+
+          availability[result.url] = result.available;
+          this.cache.set(result.url, {
+            available: result.available,
+            checkedAt: Date.now(),
+          });
+        }
+      } catch (error) {
+        logger.error("[HosterAvailability] Failed to check batch:", error);
+
+        if (axios.isAxiosError(error) && error.response?.status === 429) {
+          break;
+        }
+      }
+    }
+
+    return availability;
+  }
+}

--- a/src/main/services/hosters/availability.ts
+++ b/src/main/services/hosters/availability.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { logger } from "../logger";
+import { HydraApi } from "../hydra-api";
 import {
   getCheckableHosterUris,
   HOSTER_AVAILABILITY_MAX_URIS_PER_REQUEST,
@@ -64,13 +65,13 @@ export class HosterAvailabilityApi {
       );
 
       try {
-        const response = await axios.post<AvailabilityResponse>(
-          `${import.meta.env.MAIN_VITE_NIMBUS_API_URL}/hosters/availability`,
+        const response = await HydraApi.post<AvailabilityResponse>(
+          "/hosters/availability",
           { urls: batch },
-          { timeout: 15_000 }
+          { needsAuth: false }
         );
 
-        for (const result of response.data?.results ?? []) {
+        for (const result of response?.results ?? []) {
           if (
             typeof result?.url !== "string" ||
             typeof result?.available !== "boolean"

--- a/src/main/services/hosters/index.ts
+++ b/src/main/services/hosters/index.ts
@@ -1,3 +1,4 @@
+export * from "./availability";
 export * from "./gofile";
 export * from "./datanodes";
 export * from "./mediafire";

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1030,6 +1030,8 @@ contextBridge.exposeInMainWorld("electron", {
         },
       }),
   },
+  checkHostersAvailability: (uris: string[]) =>
+    ipcRenderer.invoke("checkHostersAvailability", uris),
   canInstallCommonRedist: () => ipcRenderer.invoke("canInstallCommonRedist"),
   installCommonRedist: () => ipcRenderer.invoke("installCommonRedist"),
   installHydraDeckyPlugin: () => ipcRenderer.invoke("installHydraDeckyPlugin"),

--- a/src/renderer/src/context/game-details/game-details.context.tsx
+++ b/src/renderer/src/context/game-details/game-details.context.tsx
@@ -27,7 +27,12 @@ import {
   GameDetailsContext,
   GameOptionsCategoryId,
 } from "./game-details.context.types";
-import { getGameExecutableFilters, SteamContentDescriptor } from "@shared";
+import {
+  applyHosterAvailability,
+  getCheckableHosterUris,
+  getGameExecutableFilters,
+  SteamContentDescriptor,
+} from "@shared";
 
 export const gameDetailsContext = createContext<GameDetailsContext>({
   game: null,
@@ -275,6 +280,7 @@ export function GameDetailsContextProvider({
   useEffect(() => {
     setShopDetails(null);
     setGame(null);
+    setRepacks([]);
     setIsLoading(true);
     setIsGameRunning(false);
     setAchievements(null);
@@ -404,6 +410,29 @@ export function GameDetailsContextProvider({
   useEffect(() => {
     if (shop === "custom") return;
 
+    let cancelled = false;
+
+    const refreshHosterAvailability = async (downloads: GameRepack[]) => {
+      const uris = getCheckableHosterUris(
+        downloads.flatMap((download) =>
+          Array.isArray(download.uris) ? download.uris : []
+        )
+      );
+
+      if (uris.length === 0) return;
+
+      try {
+        const availability =
+          await window.electron.checkHostersAvailability(uris);
+
+        if (cancelled) return;
+
+        setRepacks((prev) => applyHosterAvailability(prev, availability));
+      } catch (error) {
+        console.error("Failed to check hosters availability:", error);
+      }
+    };
+
     const fetchDownloadSources = async () => {
       try {
         const sourcesRaw = (await levelDBService.values(
@@ -425,18 +454,26 @@ export function GameDetailsContextProvider({
           }
         );
 
-        setRepacks(
-          ensureArray<GameRepack>(
-            downloads,
-            `/games/${shop}/${objectId}/download-sources`
-          )
+        if (cancelled) return;
+
+        const repacks = ensureArray<GameRepack>(
+          downloads,
+          `/games/${shop}/${objectId}/download-sources`
         );
+
+        setRepacks(repacks);
+
+        await refreshHosterAvailability(repacks);
       } catch (error) {
         console.error("Failed to fetch download sources:", error);
       }
     };
 
     fetchDownloadSources();
+
+    return () => {
+      cancelled = true;
+    };
   }, [shop, objectId]);
 
   const getDownloadsPath = async () => {

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -779,6 +779,9 @@ declare global {
         }
       ) => Promise<T>;
     };
+    checkHostersAvailability: (
+      uris: string[]
+    ) => Promise<Record<string, boolean>>;
     canInstallCommonRedist: () => Promise<boolean>;
     installCommonRedist: () => Promise<void>;
     installHydraDeckyPlugin: () => Promise<{

--- a/src/shared/hoster-availability.ts
+++ b/src/shared/hoster-availability.ts
@@ -1,0 +1,45 @@
+export const VIKINGFILE_URI_PREFIXES = [
+  "https://vikingfile.com",
+  "https://vik1ngfile.site",
+];
+
+export const HOSTER_AVAILABILITY_MAX_URIS_PER_REQUEST = 50;
+
+export const supportsHosterAvailabilityCheck = (uri: string) =>
+  VIKINGFILE_URI_PREFIXES.some((prefix) => uri.startsWith(prefix));
+
+export const getCheckableHosterUris = (uris: string[]) =>
+  Array.from(new Set(uris.filter(supportsHosterAvailabilityCheck)));
+
+export interface HosterAvailabilityCheckable {
+  uris: string[];
+  unavailableUris: string[];
+}
+
+export const applyHosterAvailability = <T extends HosterAvailabilityCheckable>(
+  repacks: T[],
+  availability: Record<string, boolean>
+): T[] => {
+  if (Object.keys(availability).length === 0) return repacks;
+
+  return repacks.map((repack) => {
+    const uris = Array.isArray(repack.uris) ? repack.uris : [];
+    const checkedUris = uris.filter((uri) => uri in availability);
+
+    if (checkedUris.length === 0) return repack;
+
+    const unavailableUris = new Set(
+      Array.isArray(repack.unavailableUris) ? repack.unavailableUris : []
+    );
+
+    for (const uri of checkedUris) {
+      if (availability[uri]) {
+        unavailableUris.delete(uri);
+      } else {
+        unavailableUris.add(uri);
+      }
+    }
+
+    return { ...repack, unavailableUris: Array.from(unavailableUris) };
+  });
+};

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -16,6 +16,7 @@ import {
 import { isArchiveOrgFileUri } from "./archive-org";
 import { charMap } from "./char-map";
 import { Downloader } from "./constants";
+import { VIKINGFILE_URI_PREFIXES } from "./hoster-availability";
 import { format } from "date-fns";
 import { AchievementNotificationInfo } from "@types";
 
@@ -24,6 +25,7 @@ export * from "./constants";
 export * from "./controller-support";
 export * from "./artwork-resolver";
 export * from "./download-directories";
+export * from "./hoster-availability";
 export * from "./html-sanitizer";
 export * from "./language-flags";
 export * from "./use-hls-video";
@@ -143,10 +145,7 @@ export const getDownloadersForUri = (uri: string) => {
   if (uri.startsWith("https://fuckingfast.co")) {
     return [Downloader.FuckingFast];
   }
-  if (
-    uri.startsWith("https://vikingfile.com") ||
-    uri.startsWith("https://vik1ngfile.site")
-  ) {
+  if (VIKINGFILE_URI_PREFIXES.some((prefix) => uri.startsWith(prefix))) {
     return [Downloader.VikingFile];
   }
   if (uri.startsWith("https://www.rootz.so")) {


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Wires up the new `POST /hosters/availability` endpoint so we can tell the user upfront when a download option is dead instead of letting them find out after picking it.

The endpoint only supports VikingFile right now, so that's the only hoster we send. Adding more later is a one-line change to `VIKINGFILE_URI_PREFIXES` / `supportsHosterAvailabilityCheck` in `src/shared/hoster-availability.ts`.

### How it works

The call goes through `HydraApi` like the rest of the API, and lives in the main process (`HosterAvailabilityApi`), reached from the renderer through a new `checkHostersAvailability` IPC event. Keeping it in main means the batching and the cache are shared between the main window and Big Picture instead of being duplicated per renderer.

- URLs are deduped and batched in groups of 50, matching the documented `1...50` limit
- Results are cached for 5 minutes, so bouncing between game pages doesn't spam the endpoint
- On a 429 we stop sending the remaining batches instead of pushing through the rate limit
- Sent with `needsAuth: false`, since the endpoint doesn't require authentication

### Where it runs

Right after the download options are fetched, on both the regular game details page and the Big Picture download modal. Results get merged into `unavailableUris`, which means the availability orbs in the repacks modal and the per-downloader availability in the download settings modal pick it up without any changes to those components. A live check overrides whatever the download sources API said for that specific URL, since it's the more recent answer.

If the request fails for any reason, the options are left exactly as the download sources API returned them.

### Notes

Response parsing follows the documented `{ results: [{ url, available }] }` contract and ignores any entry that doesn't match that shape, so a contract drift degrades to "no availability info" rather than marking everything offline.