### PR TITLE
chore(ci): cache rust/pip/ludusavi and trim linux targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js
+        if: matrix.os != 'windows-2022'
         uses: actions/setup-node@v4
         with:
           node-version: 22.21.0
           cache: "yarn"
+
+      # The Yarn cache is ~1.2GB, and extracting it on Windows takes ~90s --
+      # slower than just refetching from the registry. So no cache here.
+      - name: Install Node.js (Windows)
+        if: matrix.os == 'windows-2022'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.21.0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -134,10 +143,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js
+        if: matrix.os != 'windows-2022'
         uses: actions/setup-node@v4
         with:
           node-version: 22.21.0
           cache: "yarn"
+
+      # The Yarn cache is ~1.2GB, and extracting it on Windows takes ~90s --
+      # slower than just refetching from the registry. So no cache here.
+      - name: Install Node.js (Windows)
+        if: matrix.os == 'windows-2022'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.21.0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,19 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Must run before `yarn`, since postinstall builds the Rust addon.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native/hydra-native
+
+      # Must run before `yarn`, since postinstall downloads Ludusavi.
+      - name: Cache Ludusavi
+        uses: actions/cache@v4
+        with:
+          path: ludusavi
+          key: ${{ runner.os }}-ludusavi-${{ hashFiles('scripts/postinstall.cjs') }}
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
@@ -39,17 +52,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: "pip"
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
-      - name: Build Python RPC with cx_Freeze
-        run: python python_rpc/setup.py build
-
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          yarn build:linux
+          yarn build:linux:ci
         env:
           MAIN_VITE_API_URL: ${{ vars.MAIN_VITE_STAGING_API_URL }}
           MAIN_VITE_AUTH_URL: ${{ vars.MAIN_VITE_STAGING_AUTH_URL }}
@@ -102,7 +114,6 @@ jobs:
             dist/*.zip
             dist/*.dmg
             dist/*.deb
-            dist/*.rpm
             dist/*.tar.gz
             dist/*.yml
             dist/*.blockmap
@@ -131,6 +142,19 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Must run before `yarn`, since postinstall builds the Rust addon.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native/hydra-native
+
+      # Must run before `yarn`, since postinstall downloads Ludusavi.
+      - name: Cache Ludusavi
+        uses: actions/cache@v4
+        with:
+          path: ludusavi
+          key: ${{ runner.os }}-ludusavi-${{ hashFiles('scripts/postinstall.cjs') }}
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
@@ -138,17 +162,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: "pip"
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
-      - name: Build Python RPC with cx_Freeze
-        run: python python_rpc/setup.py build
-
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          yarn build:linux
+          yarn build:linux:ci
         env:
           MAIN_VITE_API_URL: ${{ vars.MAIN_VITE_API_URL }}
           MAIN_VITE_AUTH_URL: ${{ vars.MAIN_VITE_AUTH_URL }}
@@ -201,7 +224,6 @@ jobs:
             dist/*.zip
             dist/*.dmg
             dist/*.deb
-            dist/*.rpm
             dist/*.tar.gz
             dist/*.yml
             dist/*.blockmap

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.21.0
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,19 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Must run before `yarn`, since postinstall builds the Rust addon.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native/hydra-native
+
+      # Must run before `yarn`, since postinstall downloads Ludusavi.
+      - name: Cache Ludusavi
+        uses: actions/cache@v4
+        with:
+          path: ludusavi
+          key: ${{ runner.os }}-ludusavi-${{ hashFiles('scripts/postinstall.cjs') }}
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
@@ -37,12 +50,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: "pip"
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt
-
-      - name: Build Python RPC with cx_Freeze
-        run: python python_rpc/setup.py build
 
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:win": "npm run build:native && npm run build:python-rpc && electron-vite build && electron-builder --win",
     "build:mac": "npm run build:native && npm run build:python-rpc && electron-vite build && electron-builder --mac",
     "build:linux": "npm run build:native && npm run build:python-rpc && electron-vite build && electron-builder --linux",
+    "build:linux:ci": "npm run build:native && npm run build:python-rpc && electron-vite build && electron-builder --linux AppImage deb",
     "dev:big-picture": "vite dev src/big-picture",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Why

Measured baseline (run `30608924577`, PR build):

| Job | Total |
|---|---|
| `build (windows-2022)` | 10m47s |
| `build (ubuntu-latest)` | 8m27s |

Two clear sources of waste:

**1. Nothing caches Cargo.** `postinstall` runs `cargo build --release` over 119 crates from scratch on every run.

**2. Snap and rpm are built on every PR and thrown away.** From the Linux logs: `deb` 2m02s, `rpm` **1m51s**, `AppImage`+`snap` 58s. But `snap` isn't in the `upload-artifact` path list at all, and `upload-build.cjs` only ships `.deb`, `.exe`, `.AppImage`. Neither reaches anyone.

## What changed

- `Swatinem/rust-cache` on `build.yml` + `release.yml`, scoped to `native/hydra-native`, placed before `yarn` since `postinstall` triggers the Rust build.
- Cache the Ludusavi download, keyed on `scripts/postinstall.cjs` (which pins the version). The script already no-ops when the binary exists.
- `cache: pip` on `setup-python`.
- New `build:linux:ci` targeting `AppImage deb` only, used by PR/staging builds. **`release.yml` still builds all four targets**, so shipped releases are unchanged. Dropped `dist/*.rpm` from the staging/production artifact lists to match.
- Removed the standalone `Build Python RPC with cx_Freeze` step — `build:win`/`build:linux` already run `build:python-rpc`.
- No Yarn cache on Windows. Restoring it costs 12s of download plus **89s of tar extraction** for a 1.2GB archive; refetching from the registry is slightly cheaper, and it stops a single branch from eating 1.2GB of the repo's 10GB Actions cache quota.
- Added the missing `cache: "yarn"` to `lint.yml`.

## Measured result

| Job | Before | After | Delta |
|---|---|---|---|
| `build (windows-2022)` | 10m47s | **9m44s** | −1m03s |
| `build (ubuntu-latest)` | 8m27s | **6m23s** | −2m04s |
| **Wall clock** | **10m47s** | **9m44s** | **−9.7%** |

Wall clock is gated by Windows, so the larger Linux saving doesn't show up in it.

Step-level on Windows:

| Step | Before | After |
|---|---|---|
| Install Node.js | 112s | 8s |
| Install dependencies | 225s | 225s |
| Build Windows | 238s | 258s |

Cargo caching cut the install step by ~90s, but dropping the Yarn cache added roughly that back to the same step while removing 105s from `setup-node`. Net is what the table above shows.

## What's left, for a follow-up

Windows is now the critical path at 9m44s. Remaining costs, measured:

- `Build Windows` (vite + electron-builder nsis/portable): **258s**
- yarn fetch + link: **~120s**
- `electron-builder install-app-deps`: **74s**
- `setup-python`: **39s**
- `cargo build` final crate link: **27s** (rust-cache intentionally doesn't cache the workspace crate itself)

Migrating yarn → pnpm was left out of this PR, but the numbers make a better case for it than they first appeared: on Windows the package manager accounts for ~120s of the critical path. It would need `node-linker=hoisted` to avoid breaking the literal `node_modules/...` paths in `electron-builder.yml` (`asarUnpack` for sharp, `extraResources` for create-desktop-shortcuts).
