### PR TITLE
Fix add download source button opening the wrong settings tab

### DIFF
--- a/src/renderer/src/pages/game-details/modals/real-debrid-info-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/real-debrid-info-modal.tsx
@@ -47,7 +47,7 @@ export function RealDebridInfoModal({
         <Button
           onClick={() => {
             onClose();
-            navigate("/settings?tab=4");
+            navigate("/settings?tab=integrations");
           }}
         >
           {t("go_to_settings")}

--- a/src/renderer/src/pages/game-details/modals/repacks-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/repacks-modal.tsx
@@ -326,7 +326,7 @@ export function RepacksModal({
                     theme="primary"
                     onClick={() => {
                       onClose();
-                      navigate("/settings?tab=2");
+                      navigate("/settings?tab=download_sources");
                     }}
                   >
                     <PlusCircleIcon />


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

When a game has no sources, the download options modal shows an "Add download source" button. It was navigating to `/settings?tab=2`, which lands on Downloads instead of Download sources, so the button never got you where its label says.

`tab=2` is a legacy numeric index. `legacyTabMap` in `settings.context.tsx` maps it to `downloads`, which was correct back when sources lived inside that tab. Once Download sources became its own category it got a string id and no numeric index, so there was no number the button could have used. Changed it to `?tab=download_sources`.

While checking the other call sites I found one more numeric caller: the Real-Debrid info modal used `?tab=4`. That one resolves to `integrations`, which is right, so nothing was broken, but it was the last numeric link in the codebase and it would break the same way if the categories shift again. Switched it to `?tab=integrations`.

Everything else already pointed at the right place. `<Link to="/settings" />` in the download settings modal is the "change the default folder" hint and the folder setting is on General, which is what a tab-less `/settings` opens. Big Picture already used `?tab=downloads&section=sources` and was unaffected.

`legacyTabMap` stays, since old external links may still carry numeric tabs.
