### PR TITLE
fix: skip password toggle button in tab navigation

### DIFF
--- a/src/renderer/src/components/text-field/text-field.tsx
+++ b/src/renderer/src/components/text-field/text-field.tsx
@@ -94,6 +94,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
                 className="text-field-container__toggle-password-button"
                 onClick={() => setIsPasswordVisible(!isPasswordVisible)}
                 aria-label={t("toggle_password_visibility")}
+                tabIndex={-1}
               >
                 {isPasswordVisible ? (
                   <EyeClosedIcon size={16} />


### PR DESCRIPTION
- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

### What does this PR do?

On password fields, the show/hide password toggle button is part of the natural tab order. Pressing `Tab` from a password input moves focus to the toggle button instead of the next field (e.g. from "Password" to "Confirm password"), which interrupts the expected flow when filling out forms like account creation.

### Fix

Added `tabIndex={-1}` to the toggle button in the shared `TextField` component, so keyboard `Tab` navigation skips it and goes straight to the next field. The button stays mouse-clickable and keeps its `aria-label`. Since this is the shared component, it applies to every password form in the app.

### Trade-off

This removes the toggle from keyboard tab order, so keyboard-only users can no longer focus it. I opted for `tabIndex={-1}` because visibility toggling is a convenience and the field remains fully usable without it — this matches common form UX (GitHub, Google, etc.). Happy to adjust if maintainers would rather keep the toggle keyboard-accessible.

### How to reproduce (before the fix)

1. Open a form with a password field (e.g. the account creation screen).
2. Focus the password input and press `Tab`.
3. Focus lands on the eye/toggle button instead of moving to the next field.
