### PR TITLE
fix: drop unfinished download when transferring a game

### DIFF
--- a/src/main/events/library/transfer-game-files.ts
+++ b/src/main/events/library/transfer-game-files.ts
@@ -7,7 +7,7 @@ import { updateGameExecutablePath } from "@main/helpers/update-executable-path";
 import { findGameRootFromExe } from "../helpers/find-game-root";
 import { getDirectorySize } from "../helpers/get-directory-size";
 import { WindowManager } from "@main/services/window-manager";
-import { DownloadOrchestrator } from "@main/services";
+import { DownloadOrchestrator, logger } from "@main/services";
 import type { GameShop, LibraryGame } from "@types";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -310,10 +310,25 @@ async function updateDatabaseAfterTransfer(
   // resurface as a resumable "paused" download for an already-playable game,
   // so drop it instead (cancels the handle and marks it removed, no files
   // deleted).
-  await DownloadOrchestrator.cancelDownloadById(
-    game.shop,
-    game.objectId
-  ).catch(() => {});
+  try {
+    await DownloadOrchestrator.cancelDownloadById(game.shop, game.objectId);
+  } catch (error) {
+    // Don't fail the (already completed) transfer, but make sure the stale
+    // record can't resurface as a resumable download if the full cancel path
+    // failed partway through.
+    logger.warn(
+      "Failed to cancel stale download after transfer; marking it removed",
+      error
+    );
+    await downloadsSublevel
+      .put(gameKey, {
+        ...download,
+        status: "removed",
+        queued: false,
+        shouldSeed: false,
+      })
+      .catch(() => {});
+  }
 }
 
 async function cleanupOnError(id: string, targetRoot: string) {

--- a/src/main/events/library/transfer-game-files.ts
+++ b/src/main/events/library/transfer-game-files.ts
@@ -7,6 +7,7 @@ import { updateGameExecutablePath } from "@main/helpers/update-executable-path";
 import { findGameRootFromExe } from "../helpers/find-game-root";
 import { getDirectorySize } from "../helpers/get-directory-size";
 import { WindowManager } from "@main/services/window-manager";
+import { DownloadOrchestrator } from "@main/services";
 import type { GameShop, LibraryGame } from "@types";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -284,7 +285,16 @@ async function updateDatabaseAfterTransfer(
   });
 
   const download = await downloadsSublevel.get(gameKey).catch(() => null);
-  if (download) {
+  if (!download) return;
+
+  const isFinishedDownload =
+    download.status === "complete" ||
+    download.status === "seeding" ||
+    download.progress >= 1;
+
+  if (isFinishedDownload) {
+    // A completed/seeding download is still valid after the move — just point
+    // it at the new location so seeding keeps working.
     await downloadsSublevel
       .put(gameKey, {
         ...download,
@@ -292,7 +302,18 @@ async function updateDatabaseAfterTransfer(
         folderName: path.basename(targetRoot),
       })
       .catch(() => {});
+    return;
   }
+
+  // The game is now fully present on disk. An unfinished download left over
+  // from before would otherwise be re-pointed at the installed folder and
+  // resurface as a resumable "paused" download for an already-playable game,
+  // so drop it instead (cancels the handle and marks it removed, no files
+  // deleted).
+  await DownloadOrchestrator.cancelDownloadById(
+    game.shop,
+    game.objectId
+  ).catch(() => {});
 }
 
 async function cleanupOnError(id: string, targetRoot: string) {


### PR DESCRIPTION
## What

After transferring a game to another folder, an already-playable game could show a resumable "paused" download, making a fully-installed game look downloadable again.

## Why

`transferGameFiles` re-points the game's download record to the new install folder unconditionally. If the game still had an **unfinished** download left over (e.g. a paused partial from an earlier attempt), that partial record got re-pointed at the freshly-installed folder and resurfaced in the UI as a resumable download for a game the user can already play.

## Fix

In `updateDatabaseAfterTransfer`, only re-point downloads that are actually finished (`complete` / `seeding` / `progress >= 1`) — those should keep seeding from the new location. For unfinished downloads, cancel via `DownloadOrchestrator.cancelDownloadById`, which marks the record `removed` and stops the handle **without deleting any files** (the game is fully present on disk after the transfer).

## Notes

- No file deletion; only the stale download record is dropped.
- Completed/seeding transfers behave exactly as before.
