### PR TITLE
fix: render custom games in big picture instead of hanging on load

### DIFF
--- a/src/big-picture/src/components/pages/game/controller-support/index.tsx
+++ b/src/big-picture/src/components/pages/game/controller-support/index.tsx
@@ -11,7 +11,7 @@ import PlayStationLogo from "@renderer/assets/PlayStation Logo Wordmark.svg?reac
 
 export interface ControllerSupportBoxProps {
   shop?: GameShop;
-  shopDetails: ShopDetails;
+  shopDetails: ShopDetails | null;
   focusId?: string;
   focusNavigationOverrides?: FocusOverrides;
   focusNavigationOrder?: number;
@@ -26,7 +26,7 @@ export function ControllerSupportBox({
 }: Readonly<ControllerSupportBoxProps>) {
   const { t } = useTranslation("game_details");
 
-  if (shop !== "steam") return null;
+  if (shop !== "steam" || !shopDetails) return null;
 
   const controllerSupport = resolveControllerSupport(shopDetails);
 

--- a/src/big-picture/src/components/pages/game/hero/index.tsx
+++ b/src/big-picture/src/components/pages/game/hero/index.tsx
@@ -36,7 +36,7 @@ import { useHeroBackgroundLayers } from "../../library/hero/use-hero-background-
 import cn from "classnames";
 
 export interface HeroProps {
-  shopDetails: ShopDetailsWithAssets;
+  shopDetails: ShopDetailsWithAssets | null;
   game: LibraryGame | null;
   isGameRunning: boolean;
   isFavorite: boolean;
@@ -95,8 +95,8 @@ export function Hero({
 }: Readonly<HeroProps>) {
   const { t } = useTranslation("game_details");
   const preferredAssets = useMemo(
-    () => resolvePreferredGameAssets(game, shopDetails.assets),
-    [game, shopDetails.assets]
+    () => resolvePreferredGameAssets(game, shopDetails?.assets),
+    [game, shopDetails?.assets]
   );
   const dominantColor = useDominantColor(preferredAssets.heroSrc || null);
   const { backgroundLayers, getLayerEventHandlers } = useHeroBackgroundLayers(
@@ -388,7 +388,7 @@ export function Hero({
         <Typography
           className="game-page__hero-description"
           dangerouslySetInnerHTML={{
-            __html: shopDetails.short_description || "",
+            __html: shopDetails?.short_description || "",
           }}
         />
 

--- a/src/big-picture/src/components/pages/game/requirements-to-play/index.tsx
+++ b/src/big-picture/src/components/pages/game/requirements-to-play/index.tsx
@@ -8,7 +8,7 @@ import { useNavigationIsFocused } from "../../../../stores";
 import { FocusItem, Typography } from "../../../common";
 
 export interface RequirementsToPlayProps {
-  shopDetails: ShopDetails;
+  shopDetails: ShopDetails | null;
   focusId?: string;
   focusNavigationOverrides?: FocusOverrides;
   focusNavigationOrder?: number;
@@ -74,11 +74,11 @@ export function RequirementsToPlay({
   const normalizedHtml = useMemo(() => {
     const raw =
       activeRequirement === "minimum"
-        ? shopDetails.pc_requirements.minimum
-        : shopDetails.pc_requirements.recommended;
+        ? shopDetails?.pc_requirements?.minimum
+        : shopDetails?.pc_requirements?.recommended;
 
-    return normalizeRequirementsHtml(raw);
-  }, [activeRequirement, shopDetails.pc_requirements]);
+    return normalizeRequirementsHtml(raw ?? "");
+  }, [activeRequirement, shopDetails?.pc_requirements]);
 
   const requirementRows = useMemo(
     () => parseRequirementRows(normalizedHtml),
@@ -127,6 +127,8 @@ export function RequirementsToPlay({
     selectRequirementByIndex,
     selectedTabIndex,
   ]);
+
+  if (!shopDetails) return null;
 
   return (
     <FocusItem

--- a/src/big-picture/src/components/pages/game/supported-languages/index.tsx
+++ b/src/big-picture/src/components/pages/game/supported-languages/index.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon, XIcon } from "@phosphor-icons/react";
 import { ShopDetails } from "@types";
+import { parseSupportedLanguages } from "@shared";
 import { useMemo } from "react";
 import type { FocusOverrides } from "../../../../services";
 import { FocusItem, Typography } from "../../../common";
@@ -17,18 +18,10 @@ export function SupportedLanguages({
   focusNavigationOverrides,
   focusNavigationOrder,
 }: Readonly<SupportedLanguagesProps>) {
-  const languages = useMemo(() => {
-    const supportedLanguages = shopDetails?.supported_languages;
-    if (!supportedLanguages) return [];
-
-    const languagesString = supportedLanguages.split("<br>")[0];
-    const languageArray = languagesString?.split(",") || [];
-
-    return languageArray.map((lang) => ({
-      language: lang.replace("<strong>*</strong>", "").trim(),
-      hasAudio: lang.includes("*"),
-    }));
-  }, [shopDetails?.supported_languages]);
+  const languages = useMemo(
+    () => parseSupportedLanguages(shopDetails?.supported_languages),
+    [shopDetails?.supported_languages]
+  );
 
   if (languages.length === 0) {
     return null;

--- a/src/big-picture/src/components/pages/game/supported-languages/index.tsx
+++ b/src/big-picture/src/components/pages/game/supported-languages/index.tsx
@@ -5,7 +5,7 @@ import type { FocusOverrides } from "../../../../services";
 import { FocusItem, Typography } from "../../../common";
 
 export interface SupportedLanguagesProps {
-  shopDetails: ShopDetails;
+  shopDetails: ShopDetails | null;
   focusId?: string;
   focusNavigationOverrides?: FocusOverrides;
   focusNavigationOrder?: number;
@@ -18,7 +18,7 @@ export function SupportedLanguages({
   focusNavigationOrder,
 }: Readonly<SupportedLanguagesProps>) {
   const languages = useMemo(() => {
-    const supportedLanguages = shopDetails.supported_languages;
+    const supportedLanguages = shopDetails?.supported_languages;
     if (!supportedLanguages) return [];
 
     const languagesString = supportedLanguages.split("<br>")[0];
@@ -28,7 +28,7 @@ export function SupportedLanguages({
       language: lang.replace("<strong>*</strong>", "").trim(),
       hasAudio: lang.includes("*"),
     }));
-  }, [shopDetails.supported_languages]);
+  }, [shopDetails?.supported_languages]);
 
   if (languages.length === 0) {
     return null;

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -1246,7 +1246,7 @@ export default function Game() {
     };
   }, [descriptionBlocks]);
 
-  if (isLoading || !shopDetails) {
+  if (isLoading || (shop !== "custom" && !shopDetails)) {
     return (
       <VerticalFocusGroup regionId={GAME_PAGE_REGION_ID} asChild>
         <div className="game-page">
@@ -1305,8 +1305,8 @@ export default function Game() {
           <div className="game-page__main-layout">
             <div className="game-page__main-column">
               <ScreenshotCarousel
-                videos={shopDetails.movies ?? []}
-                screenshots={shopDetails.screenshots ?? []}
+                videos={shopDetails?.movies ?? []}
+                screenshots={shopDetails?.screenshots ?? []}
                 onActiveItemChange={setActiveMediaItemId}
                 nextContentEntryTarget={
                   descriptionEntryTarget ?? commentsEntryTarget
@@ -1487,7 +1487,7 @@ export default function Game() {
                     className="game-page__sidebar-section game-page__metadata"
                     aria-label="Game info"
                   >
-                    {isLaunchboxGame && shopDetails.platform ? (
+                    {isLaunchboxGame && shopDetails?.platform ? (
                       <div className="game-page__metadata-row">
                         <Typography className="game-page__metadata-label">
                           Platform

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -614,10 +614,11 @@ export default function Game() {
     };
   }, [activeMediaItemId, hasMedia]);
   const sidebarStatsEntryTarget = useMemo(
-    () => getItemFocusTarget(GAME_SIDEBAR_STATS_ID),
-    []
+    () =>
+      shop === "custom" ? undefined : getItemFocusTarget(GAME_SIDEBAR_STATS_ID),
+    [shop]
   );
-  const bodyRightNavigationTarget = useMemo<FocusOverrideTarget>(
+  const bodyRightNavigationTarget = useMemo<FocusOverrideTarget | undefined>(
     () => sidebarStatsEntryTarget,
     [sidebarStatsEntryTarget]
   );
@@ -1373,215 +1374,233 @@ export default function Game() {
                 </VerticalFocusGroup>
               )}
 
-              <Divider />
+              {shop !== "custom" && (
+                <>
+                  <Divider />
 
-              <GameReviews
-                shop={shop!}
-                objectId={objectId!}
-                topNavigationTarget={commentsTopNavigationTarget}
-                onHasNavigableActionsChange={setHasNavigableComments}
-              />
+                  <GameReviews
+                    shop={shop!}
+                    objectId={objectId!}
+                    topNavigationTarget={commentsTopNavigationTarget}
+                    onHasNavigableActionsChange={setHasNavigableComments}
+                  />
+                </>
+              )}
             </div>
 
-            <VerticalFocusGroup regionId={GAME_SIDEBAR_REGION_ID} asChild>
-              <div className="game-page__sidebar">
-                <FocusItem
-                  id={GAME_SIDEBAR_STATS_ID}
-                  navigationOrder={0}
-                  navigationOverrides={sidebarStatsNavigationOverrides}
-                  asChild
-                >
-                  <section
-                    className="game-page__sidebar-section game-page__stats"
-                    aria-label="Game stats"
+            {shop !== "custom" && (
+              <VerticalFocusGroup regionId={GAME_SIDEBAR_REGION_ID} asChild>
+                <div className="game-page__sidebar">
+                  <FocusItem
+                    id={GAME_SIDEBAR_STATS_ID}
+                    navigationOrder={0}
+                    navigationOverrides={sidebarStatsNavigationOverrides}
+                    asChild
                   >
-                    <div className="game-page__stats-title">
-                      <Typography>Game Stats</Typography>
-                    </div>
-
-                    <div className="game-page__stats-row">
-                      <Typography className="game-page__stats-label">
-                        Rating
-                      </Typography>
-                      <div className="game-page__stats-rating-value">
-                        <StarIcon
-                          size={16}
-                          weight="fill"
-                          aria-hidden="true"
-                          className="game-page__stats-rating-icon"
-                        />
-                        <Typography className="game-page__stats-value">
-                          {formatNumber(stats?.averageScore ?? 0)}
-                        </Typography>
+                    <section
+                      className="game-page__sidebar-section game-page__stats"
+                      aria-label="Game stats"
+                    >
+                      <div className="game-page__stats-title">
+                        <Typography>Game Stats</Typography>
                       </div>
-                    </div>
 
-                    <div className="game-page__stats-row">
-                      <Typography className="game-page__stats-label">
-                        Downloads
-                      </Typography>
-                      <Typography className="game-page__stats-value">
-                        {formatNumber(stats?.downloadCount ?? 0)}
-                      </Typography>
-                    </div>
-
-                    <div className="game-page__stats-row">
-                      <Typography className="game-page__stats-label">
-                        Playing now
-                      </Typography>
-                      <Typography className="game-page__stats-value">
-                        {formatNumber(stats?.playerCount ?? 0)}
-                      </Typography>
-                    </div>
-                  </section>
-                </FocusItem>
-
-                {(howLongToBeat?.length ?? 0) > 0 && (
-                  <HowLongToBeatBox
-                    howLongToBeat={howLongToBeat ?? []}
-                    focusId={GAME_SIDEBAR_HLTB_ID}
-                    focusNavigationOrder={1}
-                    focusNavigationOverrides={
-                      sidebarCarouselNavigationOverrides
-                    }
-                  />
-                )}
-
-                {shouldShowProtonSection && (
-                  <ProtonDBSection
-                    protonDBData={protonDBData}
-                    focusId={GAME_SIDEBAR_PROTONDB_ID}
-                    focusNavigationOrder={2}
-                    focusNavigationOverrides={
-                      sidebarCarouselNavigationOverrides
-                    }
-                  />
-                )}
-
-                <ControllerSupportBox
-                  shop={shop}
-                  shopDetails={shopDetails}
-                  focusId={GAME_SIDEBAR_CONTROLLER_SUPPORT_ID}
-                  focusNavigationOrder={3}
-                  focusNavigationOverrides={sidebarCarouselNavigationOverrides}
-                />
-
-                {achievements.length > 0 && (
-                  <AchievementsBox
-                    achievements={achievements ?? []}
-                    focusId={GAME_SIDEBAR_ACHIEVEMENTS_ID}
-                    focusNavigationOrder={4}
-                    focusNavigationOverrides={
-                      sidebarCarouselNavigationOverrides
-                    }
-                  />
-                )}
-
-                <FocusItem
-                  id={GAME_SIDEBAR_METADATA_ID}
-                  navigationOrder={5}
-                  navigationOverrides={sidebarCarouselNavigationOverrides}
-                  asChild
-                >
-                  <section
-                    className="game-page__sidebar-section game-page__metadata"
-                    aria-label="Game info"
-                  >
-                    {isLaunchboxGame && shopDetails?.platform ? (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Platform
+                      <div className="game-page__stats-row">
+                        <Typography className="game-page__stats-label">
+                          Rating
                         </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {shopDetails.platform}
-                        </Typography>
-                      </div>
-                    ) : null}
-
-                    {isLaunchboxGame && launchboxGenres.length > 0 ? (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Genres
-                        </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {launchboxGenres.join(", ")}
-                        </Typography>
-                      </div>
-                    ) : null}
-
-                    {isLaunchboxGame && launchboxRegions.length > 0 ? (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Regions
-                        </Typography>
-                        <div className="game-page__metadata-flags">
-                          {launchboxRegions.map((region) => (
-                            <img
-                              key={region}
-                              src={getSkuRegionFlag(region)}
-                              alt={REGION_LABELS[region]}
-                              title={REGION_LABELS[region]}
-                              className="game-page__metadata-flag"
-                            />
-                          ))}
+                        <div className="game-page__stats-rating-value">
+                          <StarIcon
+                            size={16}
+                            weight="fill"
+                            aria-hidden="true"
+                            className="game-page__stats-rating-icon"
+                          />
+                          <Typography className="game-page__stats-value">
+                            {formatNumber(stats?.averageScore ?? 0)}
+                          </Typography>
                         </div>
                       </div>
-                    ) : null}
 
-                    {developer && (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Developed by
+                      <div className="game-page__stats-row">
+                        <Typography className="game-page__stats-label">
+                          Downloads
                         </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {developer}
+                        <Typography className="game-page__stats-value">
+                          {formatNumber(stats?.downloadCount ?? 0)}
                         </Typography>
                       </div>
-                    )}
 
-                    {publisher && (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Published by
+                      <div className="game-page__stats-row">
+                        <Typography className="game-page__stats-label">
+                          Playing now
                         </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {publisher}
+                        <Typography className="game-page__stats-value">
+                          {formatNumber(stats?.playerCount ?? 0)}
                         </Typography>
                       </div>
-                    )}
+                    </section>
+                  </FocusItem>
 
-                    {releaseDate && (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Release Date
-                        </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {releaseDate}
-                        </Typography>
-                      </div>
-                    )}
-                  </section>
-                </FocusItem>
+                  {(howLongToBeat?.length ?? 0) > 0 && (
+                    <HowLongToBeatBox
+                      howLongToBeat={howLongToBeat ?? []}
+                      focusId={GAME_SIDEBAR_HLTB_ID}
+                      focusNavigationOrder={1}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  )}
 
-                {!isLaunchboxGame ? ( // NOSONAR
-                  <RequirementsToPlay
+                  {shouldShowProtonSection && (
+                    <ProtonDBSection
+                      protonDBData={protonDBData}
+                      focusId={GAME_SIDEBAR_PROTONDB_ID}
+                      focusNavigationOrder={2}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  )}
+
+                  <ControllerSupportBox
+                    shop={shop}
                     shopDetails={shopDetails}
-                    focusId={GAME_SIDEBAR_REQUIREMENTS_ID}
-                    focusNavigationOrder={6}
+                    focusId={GAME_SIDEBAR_CONTROLLER_SUPPORT_ID}
+                    focusNavigationOrder={3}
                     focusNavigationOverrides={
                       sidebarCarouselNavigationOverrides
                     }
                   />
-                ) : null}
 
-                <SupportedLanguages
-                  shopDetails={shopDetails}
-                  focusId={GAME_SIDEBAR_LANGUAGES_ID}
-                  focusNavigationOrder={7}
-                  focusNavigationOverrides={sidebarLanguagesNavigationOverrides}
-                />
-              </div>
-            </VerticalFocusGroup>
+                  {achievements.length > 0 && (
+                    <AchievementsBox
+                      achievements={achievements ?? []}
+                      focusId={GAME_SIDEBAR_ACHIEVEMENTS_ID}
+                      focusNavigationOrder={4}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  )}
+
+                  {(developer ||
+                    publisher ||
+                    releaseDate ||
+                    (isLaunchboxGame &&
+                      (shopDetails?.platform ||
+                        launchboxGenres.length > 0 ||
+                        launchboxRegions.length > 0))) && (
+                    <FocusItem
+                      id={GAME_SIDEBAR_METADATA_ID}
+                      navigationOrder={5}
+                      navigationOverrides={sidebarCarouselNavigationOverrides}
+                      asChild
+                    >
+                      <section
+                        className="game-page__sidebar-section game-page__metadata"
+                        aria-label="Game info"
+                      >
+                        {isLaunchboxGame && shopDetails?.platform ? (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Platform
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {shopDetails.platform}
+                            </Typography>
+                          </div>
+                        ) : null}
+
+                        {isLaunchboxGame && launchboxGenres.length > 0 ? (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Genres
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {launchboxGenres.join(", ")}
+                            </Typography>
+                          </div>
+                        ) : null}
+
+                        {isLaunchboxGame && launchboxRegions.length > 0 ? (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Regions
+                            </Typography>
+                            <div className="game-page__metadata-flags">
+                              {launchboxRegions.map((region) => (
+                                <img
+                                  key={region}
+                                  src={getSkuRegionFlag(region)}
+                                  alt={REGION_LABELS[region]}
+                                  title={REGION_LABELS[region]}
+                                  className="game-page__metadata-flag"
+                                />
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+
+                        {developer && (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Developed by
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {developer}
+                            </Typography>
+                          </div>
+                        )}
+
+                        {publisher && (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Published by
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {publisher}
+                            </Typography>
+                          </div>
+                        )}
+
+                        {releaseDate && (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Release Date
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {releaseDate}
+                            </Typography>
+                          </div>
+                        )}
+                      </section>
+                    </FocusItem>
+                  )}
+
+                  {!isLaunchboxGame ? ( // NOSONAR
+                    <RequirementsToPlay
+                      shopDetails={shopDetails}
+                      focusId={GAME_SIDEBAR_REQUIREMENTS_ID}
+                      focusNavigationOrder={6}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  ) : null}
+
+                  <SupportedLanguages
+                    shopDetails={shopDetails}
+                    focusId={GAME_SIDEBAR_LANGUAGES_ID}
+                    focusNavigationOrder={7}
+                    focusNavigationOverrides={
+                      sidebarLanguagesNavigationOverrides
+                    }
+                  />
+                </div>
+              </VerticalFocusGroup>
+            )}
           </div>
         </section>
 

--- a/src/renderer/src/pages/game-details/sidebar/game-language-section.tsx
+++ b/src/renderer/src/pages/game-details/sidebar/game-language-section.tsx
@@ -1,6 +1,7 @@
 import { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CheckIcon, XIcon } from "@primer/octicons-react";
+import { parseSupportedLanguages } from "@shared";
 import { gameDetailsContext } from "@renderer/context/game-details/game-details.context";
 import { SidebarSection } from "../sidebar-section/sidebar-section";
 import "./game-language-section.scss";
@@ -9,18 +10,10 @@ export function GameLanguageSection() {
   const { t } = useTranslation("game_details");
   const { shopDetails } = useContext(gameDetailsContext);
 
-  const languages = useMemo(() => {
-    const supportedLanguages = shopDetails?.supported_languages;
-    if (!supportedLanguages) return [];
-
-    const languagesString = supportedLanguages.split("<br>")[0];
-    const languageArray = languagesString?.split(",") || [];
-
-    return languageArray.map((lang) => ({
-      language: lang.replace("<strong>*</strong>", "").trim(),
-      hasAudio: lang.includes("*"),
-    }));
-  }, [shopDetails?.supported_languages]);
+  const languages = useMemo(
+    () => parseSupportedLanguages(shopDetails?.supported_languages),
+    [shopDetails?.supported_languages]
+  );
 
   if (languages.length === 0) {
     return null;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -31,6 +31,7 @@ export * from "./artwork-resolver";
 export * from "./download-directories";
 export * from "./html-sanitizer";
 export * from "./language-flags";
+export * from "./supported-languages";
 export * from "./use-hls-video";
 export * from "./retroarch-platform";
 export * from "./tracker-list";

--- a/src/shared/supported-languages.ts
+++ b/src/shared/supported-languages.ts
@@ -1,0 +1,18 @@
+export interface SupportedLanguage {
+  language: string;
+  hasAudio: boolean;
+}
+
+export function parseSupportedLanguages(
+  supportedLanguages: string | null | undefined
+): SupportedLanguage[] {
+  if (!supportedLanguages) return [];
+
+  const languagesString = supportedLanguages.split("<br>")[0];
+  const languageArray = languagesString?.split(",") || [];
+
+  return languageArray.map((lang) => ({
+    language: lang.replace("<strong>*</strong>", "").trim(),
+    hasAudio: lang.includes("*"),
+  }));
+}


### PR DESCRIPTION
## What

In Big Picture, opening a **custom game** (one added manually, `shop === "custom"`) hangs on the `Loading...` screen forever and can never be played. Normal catalogue games (steam/epic/etc.) load fine.

This PR unblocks that (commit 1) and cleans up the now-visible empty sidebar shells (commit 2).

## Repro

1. Add a custom game to the library (a game not in the catalogue, e.g. Minecraft, with a local executable).
2. Open Big Picture and navigate to that game.
3. The page stays on `Loading...` indefinitely — no hero, no Launch button.

## Why it hangs

The whole page is gated behind a single early return in `src/big-picture/src/pages/game/game.tsx`:

```tsx
if (isLoading || !shopDetails) {
  return (/* Loading... */);
}
```

For a custom game, `shopDetails` is **deliberately never fetched**: the main handler returns `null` for custom, and `useGameDetails` sets `shopDetailsPromise = Promise.resolve(null)` for `shop === "custom"`, then `setShopDetails(null)`. `isLoading` **does** resolve to `false` — so this isn't a stuck promise; the sole reason for the hang is the `!shopDetails` half of the gate, which is `true` forever for custom. `false || !null` → `true`, permanently.

The Play button already handles custom games — the Hero renders `Launch Game` off `game?.executablePath` (populated for custom via `getGameByObjectId`), independent of `shopDetails`. It just never gets the chance because the page never leaves the loading branch. This is the same situation the **desktop** game-details already handles gracefully (it keeps `shopDetails` null for custom and each section guards on `shop !== "custom"` / `!shopDetails`); Big Picture was missing that treatment.

## Fix (commit 1)

- Make the gate custom-aware: `if (isLoading || (shop !== "custom" && !shopDetails))`. Custom games leave the loading branch once `isLoading` is false; normal games are unchanged.
- Null-safe the consumers that read `shopDetails` after the gate: optional-chain in `Hero` (`assets`, `short_description`) and the screenshot carousel (`movies`/`screenshots`), and widen the props of `RequirementsToPlay` / `SupportedLanguages` / `ControllerSupportBox` to `| null`. Sections with no data collapse via their own existing empty-guards.

No new IPC, no synthesized fake shop details — a custom game renders with its hero + Launch button.

## Cleanup (commit 2)

Once rendering, a custom game still showed two empty sidebar shells: a **Game Stats** box (rating/downloads/players all `0`) and an empty **Metadata** section. Commit 2 hides the Stats box for custom games and gates the Metadata section on actual content (developer/publisher/release date, or a launchbox game) — so it also stops rendering empty for non-custom games missing that data.

The Stats box is the sidebar's focus-navigation entry point, so its entry target is made `undefined` for custom too. The Hero and screenshot carousel already treat an undefined target as a no-op block, so gamepad navigation stays correct with an empty sidebar (verified against the focus resolver: an override targeting an unmounted item null-checks and falls back to tree navigation, never crashing or trapping focus).

## Testing

- Big Picture, custom game: renders, shows **Launch Game**, launches the executable; no empty Stats/Metadata shells; gamepad right-nav from the hero is a no-op (nothing to enter); no console errors.
- Big Picture, normal game (steam): unchanged — hero, description, screenshots, stats, metadata, requirements, languages all render.
- `tsc` green.
