### PR TITLE
chore(i18n): fill Brazilian Portuguese (pt-BR) translation gaps

### DIFF
--- a/src/big-picture/src/locales/pt-BR/translation.json
+++ b/src/big-picture/src/locales/pt-BR/translation.json
@@ -712,7 +712,13 @@
     "steamgriddb_sign_in_required": "Entre na sua conta Hydra para explorar as artes do SteamGridDB.",
     "steamgriddb_fetch_failed": "Falha ao carregar recursos do SteamGridDB",
     "steamgriddb_artwork_updated": "Arte atualizada",
-    "steamgriddb_artwork_reset": "Arte redefinida para o padrão"
+    "steamgriddb_artwork_reset": "Arte redefinida para o padrão",
+    "Main Story": "História Principal",
+    "Main + Sides": "Principal + Secundárias",
+    "Completionist": "Completista",
+    "Try adjusting your search terms or filters.": "Tente ajustar os termos de busca ou os filtros.",
+    "Empty collection": "Coleção vazia",
+    "Add games to this collection to see them here.": "Adicione jogos a esta coleção para vê-los aqui."
   },
   "format": {
     "playtime_hours_one": "{{count}} hora",
@@ -765,6 +771,32 @@
     "file_explorer_select_this_directory": "Selecionar esta pasta",
     "file_explorer_select_download_directory": "Selecionar diretório de download",
     "steamgriddb_artwork_updated": "Arte atualizada",
-    "steamgriddb_artwork_reset": "Arte redefinida para o padrão"
+    "steamgriddb_artwork_reset": "Arte redefinida para o padrão",
+    "download_options_count_one": "{{formattedCount}} opção de download",
+    "download_options_count_other": "{{formattedCount}} opções de download",
+    "download_sources_count_one": "{{count}} fonte de download",
+    "download_sources_count_other": "{{count}} fontes de download",
+    "game_review_played_for": "após jogar por {{time}}",
+    "game_review_rating_only": "avaliação",
+    "remove_from_library": "Remover da Biblioteca",
+    "remove_from_library_description": "Isso removerá {{game}} da sua biblioteca",
+    "reset_achievements": "Redefinir conquistas",
+    "reset_achievements_description": "Suas conquistas de {{game}} serão excluídas localmente e na nuvem",
+    "remove_game_files": "Remover arquivos do jogo",
+    "remove_game_files_description": "Os arquivos baixados de {{game}} serão excluídos",
+    "downloads_finished_at": "Concluído às {{time}}",
+    "library_tab_all": "Todos ({{count}})",
+    "library_tab_moderns": "Modernos ({{count}})",
+    "library_tab_classics": "Clássicos ({{count}})",
+    "library_tab_favorites": "Favoritos ({{count}})",
+    "library_tab_completed": "Concluídos ({{count}})",
+    "recently_played_fallback": "recentemente",
+    "select_executable_path": "Selecionar caminho",
+    "clear_executable_path": "Limpar caminho",
+    "clear_launch_args": "Limpar argumentos",
+    "additional_options_description": "Configure ajustes por jogo para GameMode e MangoHud",
+    "never_played": "Nunca jogado",
+    "compact_hours": "{{count}}h",
+    "compact_minutes": "{{count}}min"
   }
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -194,7 +194,7 @@
     "downloading_metadata": "Baixando metadados de {{title}}…",
     "downloading": "Baixando {{title}}… ({{percentage}} concluído) - Conclusão {{eta}} - {{speed}}",
     "calculating_eta": "Baixando {{title}}… ({{percentage}} concluído) - Calculando tempo restante…",
-    "checking_files": "Verificando arquivos de {{title}}…",
+    "checking_files": "Verificando arquivos de {{title}}… ({{percentage}} concluído)",
     "extracting": "Extraindo {{title}}… ({{percentage}} concluído)",
     "installing_common_redist": "{{log}}…",
     "installation_complete": "Instalação concluída",
@@ -685,7 +685,12 @@
     "controller_support_partial_description": "Alguns menus podem exigir teclado e mouse.",
     "controller_support_none_label": "Sem suporte oficial",
     "controller_support_xbox_label": "Controle Xbox",
-    "controller_support_playstation_label": "Controle PlayStation"
+    "controller_support_playstation_label": "Controle PlayStation",
+    "video": "Vídeo {{number}}",
+    "view_fullscreen": "Ver em tela cheia",
+    "previous_media": "Anterior",
+    "next_media": "Próximo",
+    "not_enough_space_on_disk": "Espaço insuficiente neste disco. Necessário {{required}}, disponível {{available}}."
   },
   "activation": {
     "title": "Ativação",
@@ -739,9 +744,11 @@
     "peak": "PICO",
     "move_up": "Mover para cima",
     "move_down": "Mover para baixo",
-    "files": "FILES",
+    "files": "ARQUIVOS",
     "extraction_failed_title": "Extração falhou",
-    "extraction_failed_description": "O Hydra não conseguiu extrair este arquivo. Verifique a integridade do arquivo/espaço em disco e tente extrair novamente."
+    "extraction_failed_description": "O Hydra não conseguiu extrair este arquivo. Verifique a integridade do arquivo/espaço em disco e tente extrair novamente.",
+    "download_halted_title": "Download interrompido",
+    "download_halted_description": "{{title}} foi interrompido porque a pasta de download ficou sem espaço. Libere espaço e retome o download."
   },
   "settings": {
     "setup_official_website": "Site oficial",
@@ -1297,7 +1304,9 @@
     "scan_games_complete_title": "Escaneamento de jogos finalizado com sucesso",
     "scan_games_complete_description": "Encontrados {{count}} jogos sem caminho executável definido",
     "scan_games_no_results_title": "Escaneamento de jogos finalizado",
-    "scan_games_no_results_description": "Nenhum jogo instalado foi encontrado"
+    "scan_games_no_results_description": "Nenhum jogo instalado foi encontrado",
+    "download_halted": "Download interrompido",
+    "download_halted_no_disk_space": "{{title}} foi interrompido porque você ficou sem espaço de armazenamento"
   },
   "system_tray": {
     "open": "Abrir Hydra",
@@ -1437,8 +1446,8 @@
     "your_friend_code": "Seu código de amigo:",
     "copy_friend_code": "Copiar código de amigo",
     "copied": "Copiado!",
-    "change_profile_picture": "Change profile picture",
-    "crop_profile_image_stage": "Profile image crop area. Use the arrow keys to move the image.",
+    "change_profile_picture": "Alterar foto de perfil",
+    "crop_profile_image_stage": "Área de recorte da foto de perfil. Use as setas do teclado para mover a imagem.",
     "crop_profile_picture": "Ajustar foto de perfil",
     "crop_profile_banner": "Ajustar banner",
     "crop_profile_image_description": "Arraste a imagem para reposicioná-la e use o zoom para redimensioná-la.",


### PR DESCRIPTION
- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

### What does this PR do?

Fills gaps in the Brazilian Portuguese (`pt-BR`) translation, in both the main app and Big Picture locales. Several strings were falling back to English for pt-BR users.

**Main app (`src/locales/pt-BR`)**
- Game details: media viewer controls (`video`, `view_fullscreen`, `previous_media`, `next_media`) and the out-of-space message (`not_enough_space_on_disk`).
- Downloads / notifications: the "download halted / out of disk space" strings.
- Remaining English values: `files` header, `change_profile_picture` and `crop_profile_image_stage`.
- Bug fix: `bottom_panel.checking_files` was missing the `{{percentage}}` placeholder, so download progress was never shown — restored it.

**Big Picture (`src/big-picture/src/locales/pt-BR`)**
- Empty-collection / no-results states, HowLongToBeat labels (Main Story / Main + Sides / Completionist), library tabs, remove-from-library / reset-achievements / remove-files dialogs, download options & sources counts, executable path controls, and misc labels.

All interpolation placeholders (`{{...}}`) were kept identical to the source, and files use LF line endings.

### Note on #2425

I checked #2425 ("i18n: add missing pt-BR translation keys"). It does not touch the main app `pt-BR/translation.json` at all, and none of the keys added here (e.g. `download_halted_title`, `not_enough_space_on_disk`, `view_fullscreen`, `library_tab_moderns`, `Completionist`) appear in it — so there is no overlap. This PR is intentionally small and focused.
