### PR TITLE
fix(cloud-save): polish background operations and restore resolution

### DIFF
--- a/native/hydra-native/src/cloud_save/path_resolution/mod.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use capture::{
 };
 pub(crate) use context::build_context;
 pub(crate) use resolve_path::{glob_base_path, resolve_path};
-pub(crate) use restore_root::resolve_restore_root;
+pub(crate) use restore_root::{resolve_restore_root, target_matches_rule};
 pub use types::{ResolveSaveRulesInput, ResolvedCloudSavePath, ResolvedCloudSaveRule};
 
 #[napi]

--- a/native/hydra-native/src/cloud_save/path_resolution/restore_root.rs
+++ b/native/hydra-native/src/cloud_save/path_resolution/restore_root.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use globetter::MatchOptions;
+use globset::GlobBuilder;
 
 use super::context::normalize_separators;
 use super::resolve_path::resolve_path;
@@ -164,6 +165,71 @@ fn first_sorted(mut paths: Vec<String>) -> Option<String> {
     paths.into_iter().next()
 }
 
+pub(crate) fn target_matches_rule(
+    candidates: &[ResolvedCloudSavePath],
+    target: &str,
+    directory: bool,
+) -> bool {
+    let target = normalize_separators(target);
+    candidates.iter().any(|candidate| {
+        let Ok(pattern) = GlobBuilder::new(&candidate.path)
+            .case_insensitive(!candidate.case_sensitive)
+            .literal_separator(true)
+            .build()
+        else {
+            return false;
+        };
+        let matcher = pattern.compile_matcher();
+        if !directory {
+            return matcher.is_match(&target);
+        }
+
+        Path::new(&target).parent().is_some_and(|parent| {
+            parent
+                .ancestors()
+                .any(|ancestor| matcher.is_match(normalize_separators(&ancestor.to_string_lossy())))
+        })
+    })
+}
+
+fn root_matches_rule(
+    root: &str,
+    relative_paths: &[String],
+    candidates: &[ResolvedCloudSavePath],
+    directory: bool,
+) -> bool {
+    !relative_paths.is_empty()
+        && relative_paths.iter().all(|relative_path| {
+            let target = Path::new(root).join(relative_path.replace('\\', "/"));
+            target_matches_rule(
+                candidates,
+                &normalize_separators(&target.to_string_lossy()),
+                directory,
+            )
+        })
+}
+
+fn first_compatible_root(
+    paths: Vec<String>,
+    relative_paths: &[String],
+    candidates: &[ResolvedCloudSavePath],
+    directory: bool,
+    rejected_incompatible_root: &mut bool,
+) -> Option<String> {
+    if candidates.is_empty() {
+        return first_sorted(paths);
+    }
+    let mut paths = paths;
+    paths.sort();
+    paths.dedup();
+    let had_paths = !paths.is_empty();
+    let compatible = paths
+        .into_iter()
+        .find(|root| root_matches_rule(root, relative_paths, candidates, directory));
+    *rejected_incompatible_root |= had_paths && compatible.is_none();
+    compatible
+}
+
 fn valid_store_user_id(value: &str) -> bool {
     (5..=20).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit())
 }
@@ -268,8 +334,10 @@ fn restore_root_not_found(
 
 pub fn resolve_restore_root(
     raw_path: &str,
+    target_raw_path: &str,
     context: &PathResolutionContext,
     directory: bool,
+    target_directory: bool,
     relative_paths: &[String],
 ) -> Result<String, String> {
     let resolved = resolve_path(raw_path, context);
@@ -280,6 +348,19 @@ pub fn resolve_restore_root(
         ));
     }
     let candidates = authoritative_candidates(raw_path, context, resolved.paths)?;
+    let target_candidates = if directory {
+        let resolved = resolve_path(target_raw_path, context);
+        if resolved.paths.is_empty() {
+            return Err(format!(
+                "cloud_save_unresolved_restore_tokens: {}",
+                resolved.unresolved_tokens.join(", ")
+            ));
+        }
+        authoritative_candidates(target_raw_path, context, resolved.paths)?
+    } else {
+        Vec::new()
+    };
+    let mut rejected_incompatible_root = false;
     let mut complete_by_candidate = Vec::with_capacity(candidates.len());
     for candidate in &candidates {
         let mut complete = complete_matches(candidate, directory)?;
@@ -287,11 +368,12 @@ pub fn resolve_restore_root(
         complete.dedup();
         if directory {
             let requested_target = complete.iter().find(|root| {
-                relative_paths.iter().any(|relative_path| {
-                    Path::new(root)
-                        .join(relative_path.replace('\\', "/"))
-                        .is_file()
-                })
+                root_matches_rule(root, relative_paths, &target_candidates, target_directory)
+                    && relative_paths.iter().any(|relative_path| {
+                        Path::new(root)
+                            .join(relative_path.replace('\\', "/"))
+                            .is_file()
+                    })
             });
             if let Some(root) = requested_target {
                 return Ok(root.clone());
@@ -309,24 +391,43 @@ pub fn resolve_restore_root(
                 candidate.case_sensitive,
                 candidate.scan_root.as_deref(),
             )?;
-            if let Some(scanned) = scanned_paths
-                .into_iter()
-                .find(|scanned| !scanned.files.is_empty())
-            {
-                return Ok(scanned.resolved_path);
+            if let Some(scanned) = first_compatible_root(
+                scanned_paths
+                    .into_iter()
+                    .filter(|scanned| !scanned.files.is_empty())
+                    .map(|scanned| scanned.resolved_path)
+                    .collect(),
+                relative_paths,
+                &target_candidates,
+                target_directory,
+                &mut rejected_incompatible_root,
+            ) {
+                return Ok(scanned);
             }
         }
     }
 
     for complete in complete_by_candidate {
-        if let Some(existing) = first_sorted(complete) {
+        if let Some(existing) = first_compatible_root(
+            complete,
+            relative_paths,
+            &target_candidates,
+            target_directory,
+            &mut rejected_incompatible_root,
+        ) {
             return Ok(existing);
         }
     }
 
     if raw_path.contains("<storeUserId>") {
         for candidate in &candidates {
-            if let Some(materialized) = first_sorted(materialize_candidate(candidate, directory)) {
+            if let Some(materialized) = first_compatible_root(
+                materialize_candidate(candidate, directory),
+                relative_paths,
+                &target_candidates,
+                target_directory,
+                &mut rejected_incompatible_root,
+            ) {
                 return Ok(materialized);
             }
         }
@@ -340,7 +441,13 @@ pub fn resolve_restore_root(
         let resolved = resolve_path(&concrete, context);
         let candidates = authoritative_candidates(raw_path, context, resolved.paths)?;
         for candidate in &candidates {
-            if let Some(materialized) = first_sorted(materialize_candidate(candidate, directory)) {
+            if let Some(materialized) = first_compatible_root(
+                materialize_candidate(candidate, directory),
+                relative_paths,
+                &target_candidates,
+                target_directory,
+                &mut rejected_incompatible_root,
+            ) {
                 return Ok(materialized);
             }
         }
@@ -351,7 +458,13 @@ pub fn resolve_restore_root(
     }
 
     for candidate in &candidates {
-        if let Some(materialized) = first_sorted(materialize_candidate(candidate, directory)) {
+        if let Some(materialized) = first_compatible_root(
+            materialize_candidate(candidate, directory),
+            relative_paths,
+            &target_candidates,
+            target_directory,
+            &mut rejected_incompatible_root,
+        ) {
             return Ok(materialized);
         }
     }
@@ -361,6 +474,10 @@ pub fn resolve_restore_root(
         && existing_wine_profiles(context).is_empty()
     {
         return Err(profile_unresolved(raw_path, context));
+    }
+
+    if rejected_incompatible_root {
+        return Err("cloud_save_restore_relative_path_incomplete".to_string());
     }
 
     Err(restore_root_not_found(raw_path, context, &candidates))

--- a/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
+++ b/native/hydra-native/src/cloud_save/restore/resolve_targets.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use globset::GlobBuilder;
 use napi::bindgen_prelude::Error;
 use napi_derive::napi;
 
@@ -10,7 +9,7 @@ use crate::cloud_save::identity::{is_safe_capture, normalize_rule_path, Snapshot
 use crate::cloud_save::manifest::types::CloudSaveRule;
 use crate::cloud_save::path_resolution::{
     build_context, glob_base_path, path_is_foreign_environment, resolve_path, resolve_restore_root,
-    rule_is_applicable, ResolveSaveRulesInput, ResolvedCloudSavePath,
+    rule_is_applicable, target_matches_rule, ResolveSaveRulesInput,
 };
 
 use super::metadata::parse_last_modified_at;
@@ -159,33 +158,6 @@ fn has_glob(raw_rule: &str) -> bool {
         .any(|character| matches!(character, '*' | '?' | '[' | '{'))
 }
 
-fn target_matches_rule(
-    candidates: &[ResolvedCloudSavePath],
-    target: &str,
-    directory: bool,
-) -> bool {
-    let target = target.replace('\\', "/");
-    candidates.iter().any(|candidate| {
-        let Ok(pattern) = GlobBuilder::new(&candidate.path)
-            .case_insensitive(!candidate.case_sensitive)
-            .literal_separator(true)
-            .build()
-        else {
-            return false;
-        };
-        let matcher = pattern.compile_matcher();
-        if !directory {
-            return matcher.is_match(&target);
-        }
-
-        Path::new(&target).parent().is_some_and(|parent| {
-            parent
-                .ancestors()
-                .any(|ancestor| matcher.is_match(ancestor.to_string_lossy().replace('\\', "/")))
-        })
-    })
-}
-
 fn resolve_restore_targets_inner(
     input: ResolveRestoreTargetsInput,
 ) -> napi::Result<ResolveRestoreTargetsResult> {
@@ -307,18 +279,26 @@ fn resolve_restore_targets_inner(
                 let concrete_rule = user_value
                     .map(|value| bind_store_user(&root_rule, value))
                     .unwrap_or_else(|| root_rule.clone());
-                if let Ok(root) = resolve_restore_root(
+                let concrete_target_rule = user_value
+                    .map(|value| bind_store_user(&rule.raw_path, value))
+                    .unwrap_or_else(|| rule.raw_path.clone());
+                let resolved_root = resolve_restore_root(
                     &concrete_rule,
+                    &concrete_target_rule,
                     &context,
                     directory,
+                    rule.kind == "dir",
                     std::slice::from_ref(&file.relative_path),
-                ) {
-                    let concrete_rule = has_glob(&rule.raw_path).then(|| {
-                        let raw_rule = user_value
-                            .map(|value| bind_store_user(&rule.raw_path, value))
-                            .unwrap_or_else(|| rule.raw_path.clone());
-                        resolve_path(&raw_rule, &context).paths
-                    });
+                );
+                if resolved_root
+                    .as_ref()
+                    .is_err_and(|error| error == "cloud_save_restore_relative_path_incomplete")
+                {
+                    rejected_incomplete_relative_path = true;
+                }
+                if let Ok(root) = resolved_root {
+                    let concrete_rule = has_glob(&rule.raw_path)
+                        .then(|| resolve_path(&concrete_target_rule, &context).paths);
                     resolved_roots.push((root, concrete_rule));
                 }
             }
@@ -756,6 +736,95 @@ mod tests {
             .target_path
             .replace('\\', "/")
             .ends_with("/76561197960267366/Slots/Slot_1/Data.sav"));
+    }
+
+    #[test]
+    fn ignores_a_legacy_layout_when_resolving_intermediate_glob_segments() {
+        let temp = tempdir().unwrap();
+        let legacy = temp
+            .path()
+            .join("Hk_project/Saved/SaveGames/76561197960267366/Slots/Data.sav");
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(&legacy, b"legacy save").unwrap();
+
+        let result = resolve_restore_targets_inner(intermediate_glob_restore_input(
+            temp.path(),
+            "Slot_1/Data.sav",
+        ))
+        .unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert!(result.actions[0]
+            .target_path
+            .replace('\\', "/")
+            .ends_with("/76561197960267366/Slots/Slot_1/Data.sav"));
+        assert_eq!(fs::read(&legacy).unwrap(), b"legacy save");
+    }
+
+    #[test]
+    fn ignores_a_legacy_layout_inside_the_active_wine_prefix() {
+        let temp = tempdir().unwrap();
+        let prefix = temp.path().join("prefix");
+        let save_root = prefix.join(
+            "drive_c/users/steamuser/AppData/Local/Hk_project/Saved/SaveGames/76561197960267366/Slots",
+        );
+        fs::create_dir_all(&save_root).unwrap();
+        let legacy = save_root.join("Data.sav");
+        fs::write(&legacy, b"legacy save").unwrap();
+
+        let raw_path =
+            "<winLocalAppData>/Hk_project/Saved/SaveGames/<storeUserId>/Slots/Slot_*/Data.sav";
+        let mut restore_input = intermediate_glob_restore_input(temp.path(), "Slot_1/Data.sav");
+        restore_input.platform = "linux".into();
+        restore_input.executable_path = Some(temp.path().join("Stray.exe").display().to_string());
+        restore_input.wine_prefix_path = Some(prefix.display().to_string());
+        restore_input.approved_rules[0].raw_path = raw_path.into();
+        restore_input.files[0].raw_path = raw_path.into();
+
+        let result = resolve_restore_targets_inner(restore_input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(
+            Path::new(&result.actions[0].target_path),
+            save_root.join("Slot_1/Data.sav")
+        );
+        assert_eq!(fs::read(&legacy).unwrap(), b"legacy save");
+    }
+
+    #[test]
+    fn resolves_each_profile_independently_when_legacy_layouts_exist() {
+        let temp = tempdir().unwrap();
+        let second_profile = variant("opaque-folder", "76561199873967367");
+        let mut restore_input = intermediate_glob_restore_input(temp.path(), "Slot_1/Data.sav");
+        let mut second_file = restore_input.files[0].clone();
+        second_file.variant_id = second_profile.variant_id.clone();
+        restore_input.variants.push(second_profile);
+        restore_input.files.push(second_file);
+
+        for profile in ["76561197960267366", "76561199873967367"] {
+            let legacy = temp
+                .path()
+                .join("Hk_project/Saved/SaveGames")
+                .join(profile)
+                .join("Slots/Data.sav");
+            fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+            fs::write(legacy, b"legacy save").unwrap();
+        }
+
+        let result = resolve_restore_targets_inner(restore_input).unwrap();
+
+        assert!(result.blocked.is_empty());
+        assert_eq!(result.actions.len(), 2);
+        for profile in ["76561197960267366", "76561199873967367"] {
+            assert!(result.actions.iter().any(|action| {
+                action
+                    .target_path
+                    .replace('\\', "/")
+                    .ends_with(&format!("/{profile}/Slots/Slot_1/Data.sav"))
+            }));
+        }
     }
 
     #[test]

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -514,6 +514,8 @@
     "cloud_save_v2_subscription_required_description": "Cloud saves require an active Hydra Cloud subscription.",
     "cloud_save_v2_modal_title": "Cloud Save V2 (BETA)",
     "cloud_save_v2_modal_description": "Review cloud save status and synchronize this game.",
+    "cloud_save_v2_feedback_prompt": "Facing issues?",
+    "cloud_save_v2_feedback_action": "Give us feedback.",
     "cloud_save_v2_toggle_title": "Automatic sync is {{status}}",
     "cloud_save_v2_toggle_enabled": "enabled",
     "cloud_save_v2_toggle_disabled": "disabled",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -367,6 +367,8 @@
     "cloud_save_v2_subscription_required_description": "O salvamento na nuvem requer uma assinatura ativa do Hydra Cloud.",
     "cloud_save_v2_modal_title": "Salvamento na nuvem V2 (BETA)",
     "cloud_save_v2_modal_description": "Veja o estado dos saves e sincronize este jogo.",
+    "cloud_save_v2_feedback_prompt": "Está com problemas?",
+    "cloud_save_v2_feedback_action": "Fale com a gente.",
     "cloud_save_v2_toggle_title": "A sincronização automática está {{status}}",
     "cloud_save_v2_toggle_enabled": "ativado",
     "cloud_save_v2_toggle_disabled": "desativado",

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-modal.tsx
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-modal.tsx
@@ -21,6 +21,7 @@ import { Button, Modal } from "@renderer/components";
 import { useDate } from "@renderer/hooks";
 import {
   getCloudSavePanelAction,
+  getCloudSaveOperationPresentation,
   getCloudSavePartialDescriptionKey,
   getCloudSavePresentation,
   getCloudSaveSnapshotPanelMode,
@@ -113,22 +114,15 @@ function CloudSaveSyncAction({
   const { t } = useTranslation("game_details");
 
   if (isSyncing) {
-    const progressLabel = progress
-      ? t(`cloud_save_v2_progress_${progress.stage}`)
-      : t("cloud_save_v2_syncing");
-    const progressFileCount =
-      progress && progress.totalFiles > 0
-        ? t("cloud_save_v2_progress_file_count", {
-            count: progress.totalFiles,
-            processed: progress.processedFiles,
-            total: progress.totalFiles,
-          })
-        : null;
+    const operation = getCloudSaveOperationPresentation(progress);
+    const progressFileCount = operation.fileCount
+      ? t("cloud_save_v2_progress_file_count", operation.fileCount)
+      : null;
 
     return (
       <Button className="cloud-save-v2__sync-button" disabled>
         <CircleNotchIcon className="cloud-save-v2__spinner" size={20} />
-        <span>{progressLabel}</span>
+        <span>{t(operation.labelKey)}</span>
         {progressFileCount && (
           <span className="cloud-save-v2__sync-file-count">
             · {progressFileCount}

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-modal.tsx
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-modal.tsx
@@ -17,7 +17,7 @@ import type {
   CloudSaveSyncProgressPayload,
 } from "@types";
 import { formatBytes } from "@shared";
-import { Button, Modal } from "@renderer/components";
+import { Button, Link, Modal } from "@renderer/components";
 import { useDate } from "@renderer/hooks";
 import {
   getCloudSavePanelAction,
@@ -495,7 +495,18 @@ export function CloudSaveModal({
       description={t("cloud_save_v2_modal_description")}
       onClose={onClose}
     >
-      <CloudSavePanel {...panelProps} active={visible} />
+      <div className="cloud-save-v2__dialog-content">
+        <CloudSavePanel {...panelProps} active={visible} />
+        <p className="cloud-save-v2__feedback">
+          {t("cloud_save_v2_feedback_prompt")}
+          <Link
+            className="cloud-save-v2__feedback-link"
+            to="https://hydra.workwonders.app/feedback"
+          >
+            {t("cloud_save_v2_feedback_action")}
+          </Link>
+        </p>
+      </div>
     </Modal>
   );
 }

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-presentation.test.ts
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-presentation.test.ts
@@ -7,6 +7,7 @@ import * as presentationModule from "./cloud-save-presentation.ts";
 
 const {
   canOpenCloudSaveFileBrowser,
+  getCloudSaveOperationPresentation,
   getCloudSavePanelAction,
   getCloudSavePartialDescriptionKey,
   getCloudSavePresentation,
@@ -17,6 +18,49 @@ const {
   shouldShowCloudSaveEmptySnapshot,
   shouldSyncCloudSaveOnGamePage,
 } = presentationModule;
+
+describe("cloud save operation presentation", () => {
+  it("shares progress labels and file counts between surfaces", () => {
+    assert.deepEqual(getCloudSaveOperationPresentation(null), {
+      labelKey: "cloud_save_v2_syncing",
+      fileCount: null,
+    });
+    assert.deepEqual(
+      getCloudSaveOperationPresentation({
+        gameId: { shop: "steam", objectId: "game" },
+        stage: "uploading",
+        processedFiles: 2,
+        totalFiles: 5,
+      }),
+      {
+        labelKey: "cloud_save_v2_progress_uploading",
+        fileCount: { count: 5, processed: 2, total: 5 },
+      }
+    );
+  });
+
+  it("supports operations without transfer progress", () => {
+    assert.deepEqual(
+      getCloudSaveOperationPresentation(null, "cloud_save_v2_deleting"),
+      {
+        labelKey: "cloud_save_v2_deleting",
+        fileCount: null,
+      }
+    );
+    assert.deepEqual(
+      getCloudSaveOperationPresentation({
+        gameId: { shop: "steam", objectId: "game" },
+        stage: "completed",
+        processedFiles: 0,
+        totalFiles: 0,
+      }),
+      {
+        labelKey: "cloud_save_v2_progress_completed",
+        fileCount: null,
+      }
+    );
+  });
+});
 
 const fileDetails = (
   overrides: Partial<CloudSaveV2FileDetails> = {}

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-presentation.ts
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-presentation.ts
@@ -2,6 +2,7 @@ import type {
   CloudSaveOverview,
   CloudSaveState,
   CloudSaveSyncAction,
+  CloudSaveSyncProgressPayload,
   CloudSaveSyncProgressStage,
   CloudSaveV2FileDetails,
   GameShop,
@@ -109,6 +110,32 @@ export const getCloudSaveSyncErrorKind = (
   }
   return "generic";
 };
+
+export interface CloudSaveOperationPresentation {
+  labelKey: string;
+  fileCount: {
+    count: number;
+    processed: number;
+    total: number;
+  } | null;
+}
+
+export const getCloudSaveOperationPresentation = (
+  progress: CloudSaveSyncProgressPayload | null,
+  fallbackLabelKey = "cloud_save_v2_syncing"
+): CloudSaveOperationPresentation => ({
+  labelKey: progress
+    ? `cloud_save_v2_progress_${progress.stage}`
+    : fallbackLabelKey,
+  fileCount:
+    progress && progress.totalFiles > 0
+      ? {
+          count: progress.totalFiles,
+          processed: progress.processedFiles,
+          total: progress.totalFiles,
+        }
+      : null,
+});
 
 export const getCloudSavePartialDescriptionKey = (
   overview: CloudSaveOverview | null

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-context.tsx
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-context.tsx
@@ -949,6 +949,7 @@ export function CloudSaveV2Provider({
         hasError={hasFileDetailsError}
         isGameRunning={isGameRunning}
         isSyncing={isSyncing}
+        progress={progress}
         onRetry={async () => {
           await refreshFileDetails();
           await refresh();

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-context.tsx
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-context.tsx
@@ -479,6 +479,57 @@ export function CloudSaveV2Provider({
     [showKnownCloudSaveSyncError]
   );
 
+  const runFileBrowserCloudSaveOperation = useCallback(
+    async <T,>(
+      operation: (
+        onProgress: (progress: CloudSaveSyncProgressPayload) => void
+      ) => Promise<T>
+    ): Promise<T> => {
+      const requestedGame = gameKey;
+      setIsSyncing(true);
+      setHasSyncError(false);
+      setProgress(null);
+
+      try {
+        return await operation((nextProgress) => {
+          if (activeGameKey.current === requestedGame) {
+            setProgress(nextProgress);
+          }
+        });
+      } catch (error) {
+        handleCloudSaveOperationError(error, requestedGame);
+        throw error;
+      } finally {
+        if (activeGameKey.current === requestedGame) {
+          await refresh();
+          await refreshFileDetails();
+          setIsSyncing(false);
+        }
+      }
+    },
+    [gameKey, handleCloudSaveOperationError, refresh, refreshFileDetails]
+  );
+
+  const syncAfterCustomPathAdded = useCallback(
+    () =>
+      runFileBrowserCloudSaveOperation((onProgress) =>
+        window.electron.syncGameCloudSave(objectId, shop, onProgress)
+      ),
+    [objectId, runFileBrowserCloudSaveOperation, shop]
+  );
+
+  const removeTrackedCustomPath = useCallback(
+    (rawPath: string) =>
+      runFileBrowserCloudSaveOperation(async () => {
+        await window.electron.removeCloudSaveCustomPath(
+          objectId,
+          shop,
+          rawPath
+        );
+      }),
+    [objectId, runFileBrowserCloudSaveOperation, shop]
+  );
+
   const runCloudSaveOperation = useCallback(
     async (resolution?: CloudSaveConflictResolution) => {
       if (isGameRunning || !hasExecutablePath || shop !== "steam") return;
@@ -902,6 +953,8 @@ export function CloudSaveV2Provider({
           await refreshFileDetails();
           await refresh();
         }}
+        onSyncAfterCustomPathAdded={syncAfterCustomPathAdded}
+        onRemoveTrackedCustomPath={removeTrackedCustomPath}
         onRequestCustomPathRebind={handleRequestCustomPathRebind}
         onClose={() => setIsFileBrowserVisible(false)}
       />

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-modal.tsx
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-modal.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 
 import type {
   CloudSaveState,
+  CloudSaveSyncProgressPayload,
   CloudSaveV2FileDetails,
   GameShop,
   SyncGameCloudSaveResult,
@@ -33,7 +34,10 @@ import {
 } from "./cloud-save-v2-file-tree";
 import { getCloudSaveFileBrowserOperationPolicy } from "./cloud-save-v2-file-browser-policy";
 import { CloudSaveV2FileTreeView } from "./cloud-save-v2-file-tree-view";
-import { hasCloudSaveDataToDelete } from "./cloud-save-presentation";
+import {
+  getCloudSaveOperationPresentation,
+  hasCloudSaveDataToDelete,
+} from "./cloud-save-presentation";
 
 const getCustomPathSelectionError = (error: unknown) => {
   const message = error instanceof Error ? error.message : "";
@@ -131,6 +135,7 @@ interface CloudSaveV2FileBrowserModalProps {
   hasError: boolean;
   isGameRunning: boolean;
   isSyncing: boolean;
+  progress: CloudSaveSyncProgressPayload | null;
   onRetry: () => void | Promise<void>;
   onSyncAfterCustomPathAdded: () => Promise<SyncGameCloudSaveResult>;
   onRemoveTrackedCustomPath: (rawPath: string) => Promise<void>;
@@ -290,6 +295,7 @@ export function CloudSaveV2FileBrowserModal({
   hasError,
   isGameRunning,
   isSyncing,
+  progress,
   onRetry,
   onSyncAfterCustomPathAdded,
   onRemoveTrackedCustomPath,
@@ -500,6 +506,14 @@ export function CloudSaveV2FileBrowserModal({
       isGameRunning,
       isSyncing,
     });
+  const activeOperation = isDeletingCloudSave
+    ? getCloudSaveOperationPresentation(null, "cloud_save_v2_deleting")
+    : isSyncing
+      ? getCloudSaveOperationPresentation(progress)
+      : null;
+  const activeOperationFileCount = activeOperation?.fileCount
+    ? t("cloud_save_v2_progress_file_count", activeOperation.fileCount)
+    : null;
   const hasSaveData = hasCloudSaveDataToDelete(details);
   const addCustomPathButton = (
     <Button
@@ -567,9 +581,34 @@ export function CloudSaveV2FileBrowserModal({
 
           {details && (
             <>
-              {(isConflict || localRoots.length > 0 || hasSaveData) && (
+              {(activeOperation ||
+                isConflict ||
+                localRoots.length > 0 ||
+                hasSaveData) && (
                 <div className="cloud-save-v2__browser-toolbar">
-                  {!isConflict && (
+                  {activeOperation ? (
+                    <div
+                      className="cloud-save-v2__browser-source-summary"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <span>
+                        <CircleNotchIcon
+                          className="cloud-save-v2__spinner"
+                          size={20}
+                        />
+                        <strong>{t(activeOperation.labelKey)}</strong>
+                        {activeOperationFileCount && (
+                          <span aria-hidden="true">·</span>
+                        )}
+                        {activeOperationFileCount && (
+                          <span className="cloud-save-v2__browser-operation-count">
+                            {activeOperationFileCount}
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  ) : !isConflict ? (
                     <div className="cloud-save-v2__browser-source-summary">
                       <span>
                         <MonitorIcon
@@ -583,7 +622,7 @@ export function CloudSaveV2FileBrowserModal({
                         })}
                       </span>
                     </div>
-                  )}
+                  ) : null}
 
                   {!isConflict && (
                     <div className="cloud-save-v2__browser-toolbar-actions">
@@ -592,7 +631,7 @@ export function CloudSaveV2FileBrowserModal({
                     </div>
                   )}
 
-                  {isConflict && (
+                  {isConflict && !activeOperation && (
                     <div className="cloud-save-v2__browser-diff-summary">
                       <span>
                         {t("cloud_save_v2_diff_modified", {

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-modal.tsx
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-modal.tsx
@@ -10,7 +10,12 @@ import {
 import { TrashIcon } from "@primer/octicons-react";
 import { useTranslation } from "react-i18next";
 
-import type { CloudSaveState, CloudSaveV2FileDetails, GameShop } from "@types";
+import type {
+  CloudSaveState,
+  CloudSaveV2FileDetails,
+  GameShop,
+  SyncGameCloudSaveResult,
+} from "@types";
 import { formatBytes } from "@shared";
 import {
   Button,
@@ -26,6 +31,7 @@ import {
   filterCloudSaveV2Comparisons,
   type CloudSaveV2FileTreeRoot,
 } from "./cloud-save-v2-file-tree";
+import { getCloudSaveFileBrowserOperationPolicy } from "./cloud-save-v2-file-browser-policy";
 import { CloudSaveV2FileTreeView } from "./cloud-save-v2-file-tree-view";
 import { hasCloudSaveDataToDelete } from "./cloud-save-presentation";
 
@@ -126,6 +132,8 @@ interface CloudSaveV2FileBrowserModalProps {
   isGameRunning: boolean;
   isSyncing: boolean;
   onRetry: () => void | Promise<void>;
+  onSyncAfterCustomPathAdded: () => Promise<SyncGameCloudSaveResult>;
+  onRemoveTrackedCustomPath: (rawPath: string) => Promise<void>;
   onRequestCustomPathRebind: (rawPath: string) => Promise<void>;
   onClose: () => void;
 }
@@ -283,6 +291,8 @@ export function CloudSaveV2FileBrowserModal({
   isGameRunning,
   isSyncing,
   onRetry,
+  onSyncAfterCustomPathAdded,
+  onRemoveTrackedCustomPath,
   onRequestCustomPathRebind,
   onClose,
 }: Readonly<CloudSaveV2FileBrowserModalProps>) {
@@ -388,18 +398,13 @@ export function CloudSaveV2FileBrowserModal({
       );
       if (!result.canceled && result.customPath) {
         wasAdded = true;
-        const syncResult = await window.electron.syncGameCloudSave(
-          objectId,
-          shop
-        );
+        const syncResult = await onSyncAfterCustomPathAdded();
         if (syncResult.finalState === "conflict") {
           throw new Error("cloud_save_custom_path_sync_conflict");
         }
-        await onRetry();
         showSuccessToast(t("cloud_save_v2_custom_path_added"));
       }
     } catch (error) {
-      if (wasAdded) await onRetry();
       const selectionError = !wasAdded
         ? getCustomPathSelectionError(error)
         : null;
@@ -414,17 +419,13 @@ export function CloudSaveV2FileBrowserModal({
   };
 
   const handleRemoveCustomPath = async () => {
-    if (!pendingCustomPathRemoval) return;
+    const rawPath = pendingCustomPathRemoval;
+    if (!rawPath) return;
 
-    setRemovingCustomPath(pendingCustomPathRemoval);
+    setRemovingCustomPath(rawPath);
+    setPendingCustomPathRemoval(null);
     try {
-      await window.electron.removeCloudSaveCustomPath(
-        objectId,
-        shop,
-        pendingCustomPathRemoval
-      );
-      setPendingCustomPathRemoval(null);
-      await onRetry();
+      await onRemoveTrackedCustomPath(rawPath);
       showSuccessToast(t("cloud_save_v2_custom_path_removed"));
     } catch (error) {
       const localCleanupFailed =
@@ -489,16 +490,16 @@ export function CloudSaveV2FileBrowserModal({
 
   const loadingState = !details && isLoading;
   const errorState = !details && hasError;
-  const isChangingCustomPaths =
-    isAddingCustomPath ||
-    rebindingCustomPath !== null ||
-    removingCustomPath !== null;
-  const actionsAreDisabled =
-    isChangingCustomPaths ||
-    isDeletingCloudSave ||
-    isLoading ||
-    isGameRunning ||
-    isSyncing;
+  const { actionsAreDisabled, closeIsBlocked } =
+    getCloudSaveFileBrowserOperationPolicy({
+      isAddingCustomPath,
+      isRebindingCustomPath: rebindingCustomPath !== null,
+      isRemovingCustomPath: removingCustomPath !== null,
+      isDeletingCloudSave,
+      isLoading,
+      isGameRunning,
+      isSyncing,
+    });
   const hasSaveData = hasCloudSaveDataToDelete(details);
   const addCustomPathButton = (
     <Button
@@ -543,7 +544,7 @@ export function CloudSaveV2FileBrowserModal({
         }
         className={`cloud-save-v2__file-browser-modal ${titleIsConflict ? "cloud-save-v2__file-browser-modal--comparison" : ""}`}
         onClose={() => {
-          if (!isChangingCustomPaths && !isDeletingCloudSave) onClose();
+          if (!closeIsBlocked) onClose();
         }}
       >
         <div className="cloud-save-v2__file-browser">

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-policy.test.ts
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-policy.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// @ts-ignore The Node ESM test runner requires the source extension.
+import { getCloudSaveFileBrowserOperationPolicy } from "./cloud-save-v2-file-browser-policy.ts";
+
+const operationState = (
+  overrides: Partial<
+    Parameters<typeof getCloudSaveFileBrowserOperationPolicy>[0]
+  > = {}
+) => ({
+  isAddingCustomPath: false,
+  isRebindingCustomPath: false,
+  isRemovingCustomPath: false,
+  isDeletingCloudSave: false,
+  isLoading: false,
+  isGameRunning: false,
+  isSyncing: false,
+  ...overrides,
+});
+
+describe("cloud save file browser operation policy", () => {
+  it("allows closing while custom path operations continue", () => {
+    for (const operation of [
+      "isAddingCustomPath",
+      "isRebindingCustomPath",
+      "isRemovingCustomPath",
+    ] as const) {
+      assert.deepEqual(
+        getCloudSaveFileBrowserOperationPolicy(
+          operationState({ [operation]: true })
+        ),
+        {
+          actionsAreDisabled: true,
+          closeIsBlocked: false,
+        }
+      );
+    }
+  });
+
+  it("keeps the modal open while all saves are being deleted", () => {
+    assert.deepEqual(
+      getCloudSaveFileBrowserOperationPolicy(
+        operationState({ isDeletingCloudSave: true })
+      ),
+      {
+        actionsAreDisabled: true,
+        closeIsBlocked: true,
+      }
+    );
+  });
+
+  it("disables concurrent actions without blocking ordinary closing", () => {
+    for (const operation of [
+      "isLoading",
+      "isGameRunning",
+      "isSyncing",
+    ] as const) {
+      assert.deepEqual(
+        getCloudSaveFileBrowserOperationPolicy(
+          operationState({ [operation]: true })
+        ),
+        {
+          actionsAreDisabled: true,
+          closeIsBlocked: false,
+        }
+      );
+    }
+  });
+});

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-policy.ts
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2-file-browser-policy.ts
@@ -1,0 +1,29 @@
+interface CloudSaveFileBrowserOperationState {
+  isAddingCustomPath: boolean;
+  isRebindingCustomPath: boolean;
+  isRemovingCustomPath: boolean;
+  isDeletingCloudSave: boolean;
+  isLoading: boolean;
+  isGameRunning: boolean;
+  isSyncing: boolean;
+}
+
+export const getCloudSaveFileBrowserOperationPolicy = ({
+  isAddingCustomPath,
+  isRebindingCustomPath,
+  isRemovingCustomPath,
+  isDeletingCloudSave,
+  isLoading,
+  isGameRunning,
+  isSyncing,
+}: CloudSaveFileBrowserOperationState) => ({
+  actionsAreDisabled:
+    isAddingCustomPath ||
+    isRebindingCustomPath ||
+    isRemovingCustomPath ||
+    isDeletingCloudSave ||
+    isLoading ||
+    isGameRunning ||
+    isSyncing,
+  closeIsBlocked: isDeletingCloudSave,
+});

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2.scss
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2.scss
@@ -39,6 +39,33 @@
     gap: calc(globals.$spacing-unit * 2);
   }
 
+  &__dialog-content {
+    display: flex;
+    flex-direction: column;
+    gap: calc(globals.$spacing-unit * 2);
+  }
+
+  &__feedback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: calc(globals.$spacing-unit / 2);
+    margin: 0;
+    color: globals.$muted-color;
+    font-size: globals.$small-font-size;
+    line-height: 1.4;
+    text-align: center;
+  }
+
+  &__feedback-link,
+  &__feedback-link:hover,
+  &__feedback-link:focus-visible {
+    text-decoration-line: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
   &__path-approval-modal {
     width: min(560px, calc(100vw - 32px));
   }

--- a/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2.scss
+++ b/src/renderer/src/pages/game-details/cloud-save-v2/cloud-save-v2.scss
@@ -514,6 +514,10 @@
     margin-left: -2px;
   }
 
+  &__browser-operation-count {
+    color: globals.$muted-color;
+  }
+
   &__browser-filter {
     margin-left: auto;
     flex-shrink: 0;


### PR DESCRIPTION
## Summary

- keep background custom-path operations visible in the main modal and file browser
- show consistent operation progress while allowing non-destructive dialogs to close
- add the Cloud Save V2 feedback affordance
- validate restore-root candidates against the full manifest rule before accepting filesystem evidence

## Impact

Background work no longer appears idle after closing or reopening the file list. Restore resolution ignores incompatible legacy layouts instead of letting them redirect a valid wildcard-derived target, while preserving every existing file.

## Validation

- Rust: 162 passed
- Node: 372 passed, 4 skipped
- Node/Web typechecks: passed
- Prettier and `cargo fmt --check`: passed
- ESLint: 0 errors; 80 existing warnings
- Known non-blocking Windows failure: `EPERM` while cleaning the notification icon test fixture

## PR chain

Depends on #2646 (`codex/cloud-saves-v2-custom-path-reconciliation`).