### PR TITLE
fix: show description, HLTB and achievements for Classics in Big Picture

### DIFF
--- a/src/big-picture/src/hooks/use-game-details.hook.ts
+++ b/src/big-picture/src/hooks/use-game-details.hook.ts
@@ -18,6 +18,7 @@ import {
 import { useBigPictureToast } from "./use-big-picture-toast.hook";
 import { NavigationAudioService } from "../services";
 import { useBigPictureRunningGame } from "./use-big-picture-running-games.hook";
+import { useUserPreferences } from "./use-user-preferences.hook";
 
 export function useGameDetails(objectId: string, shop: GameShop) {
   const { i18n } = useTranslation();
@@ -39,6 +40,10 @@ export function useGameDetails(objectId: string, shop: GameShop) {
   const [achievements, setAchievements] = useState<UserAchievement[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const userPreferences = useUserPreferences();
+  const shouldUseRetroAchievements =
+    shop === "launchbox" &&
+    Boolean(userPreferences?.retroAchievementsWebApiKey);
 
   const updateGame = useCallback(async () => {
     if (!IS_DESKTOP) return;
@@ -118,21 +123,35 @@ export function useGameDetails(objectId: string, shop: GameShop) {
         })
         .then(setProtonDBData)
         .catch(() => setProtonDBData(null));
-
-      globalThis.window.electron
-        .getUnlockedAchievements(objectId, shop)
-        .then((result) => {
-          if (result) {
-            setAchievements(result);
-          }
-        })
-        .catch(() => setAchievements([]));
     } else {
       setHowLongToBeat(null);
       setProtonDBData(null);
-      setAchievements([]);
     }
   }, [objectId, refreshGameDetails, shop]);
+
+  useEffect(() => {
+    if (!IS_DESKTOP || shop === "custom") {
+      setAchievements([]);
+      return;
+    }
+
+    if (shouldUseRetroAchievements) {
+      globalThis.window.electron
+        .getRetroAchievementsAchievements(objectId, shop)
+        .then((result) => setAchievements(result ?? []))
+        .catch(() => setAchievements([]));
+      return;
+    }
+
+    globalThis.window.electron
+      .getUnlockedAchievements(objectId, shop)
+      .then((result) => {
+        if (result) {
+          setAchievements(result);
+        }
+      })
+      .catch(() => setAchievements([]));
+  }, [objectId, shop, shouldUseRetroAchievements]);
 
   useEffect(() => {
     if (!IS_DESKTOP) return;

--- a/src/big-picture/src/hooks/use-game-details.hook.ts
+++ b/src/big-picture/src/hooks/use-game-details.hook.ts
@@ -135,22 +135,28 @@ export function useGameDetails(objectId: string, shop: GameShop) {
       return;
     }
 
-    if (shouldUseRetroAchievements) {
-      globalThis.window.electron
-        .getRetroAchievementsAchievements(objectId, shop)
-        .then((result) => setAchievements(result ?? []))
-        .catch(() => setAchievements([]));
-      return;
-    }
+    let isCurrentRequest = true;
 
-    globalThis.window.electron
-      .getUnlockedAchievements(objectId, shop)
+    const request = shouldUseRetroAchievements
+      ? globalThis.window.electron.getRetroAchievementsAchievements(
+          objectId,
+          shop
+        )
+      : globalThis.window.electron.getUnlockedAchievements(objectId, shop);
+
+    request
       .then((result) => {
-        if (result) {
-          setAchievements(result);
-        }
+        if (!isCurrentRequest) return;
+        setAchievements(result ?? []);
       })
-      .catch(() => setAchievements([]));
+      .catch(() => {
+        if (!isCurrentRequest) return;
+        setAchievements([]);
+      });
+
+    return () => {
+      isCurrentRequest = false;
+    };
   }, [objectId, shop, shouldUseRetroAchievements]);
 
   useEffect(() => {

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -92,6 +92,7 @@ const DESCRIPTION_DISALLOWED_SELECTORS = [
   "link",
   "meta",
 ].join(", ");
+const DESCRIPTION_PARAGRAPH_BREAK = /(?:\r?\n){2,}/;
 const DESCRIPTION_LINE_BREAK = /\r?\n/;
 const DESCRIPTION_SCROLL_STEP = 180;
 const DESCRIPTION_SCROLL_EDGE_TOLERANCE = 4;
@@ -224,6 +225,33 @@ function normalizeDescriptionMediaElement(
   mediaElement.style.boxSizing = "border-box";
 }
 
+function appendDescriptionParagraph(
+  document: Document,
+  fragment: DocumentFragment,
+  block: string
+) {
+  const lines = block
+    .split(DESCRIPTION_LINE_BREAK)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return;
+  }
+
+  const paragraph = document.createElement("p");
+
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      paragraph.appendChild(document.createElement("br"));
+    }
+
+    paragraph.appendChild(document.createTextNode(line));
+  });
+
+  fragment.appendChild(paragraph);
+}
+
 function wrapLooseDescriptionText(document: Document) {
   const looseTextNodes = Array.from(document.body.childNodes).filter(
     (node) =>
@@ -231,21 +259,16 @@ function wrapLooseDescriptionText(document: Document) {
   );
 
   for (const textNode of looseTextNodes) {
-    const lines = (textNode.textContent ?? "")
-      .split(DESCRIPTION_LINE_BREAK)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-
-    if (lines.length === 0) {
-      continue;
-    }
-
     const fragment = document.createDocumentFragment();
 
-    for (const line of lines) {
-      const paragraph = document.createElement("p");
-      paragraph.textContent = line;
-      fragment.appendChild(paragraph);
+    for (const block of (textNode.textContent ?? "").split(
+      DESCRIPTION_PARAGRAPH_BREAK
+    )) {
+      appendDescriptionParagraph(document, fragment, block);
+    }
+
+    if (fragment.childNodes.length === 0) {
+      continue;
     }
 
     textNode.replaceWith(fragment);

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -92,6 +92,7 @@ const DESCRIPTION_DISALLOWED_SELECTORS = [
   "link",
   "meta",
 ].join(", ");
+const DESCRIPTION_LINE_BREAK = /\r?\n/;
 const DESCRIPTION_SCROLL_STEP = 180;
 const DESCRIPTION_SCROLL_EDGE_TOLERANCE = 4;
 const DESCRIPTION_FOCUS_ENTRY_MARGIN = 32;
@@ -223,6 +224,34 @@ function normalizeDescriptionMediaElement(
   mediaElement.style.boxSizing = "border-box";
 }
 
+function wrapLooseDescriptionText(document: Document) {
+  const looseTextNodes = Array.from(document.body.childNodes).filter(
+    (node) =>
+      node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim())
+  );
+
+  for (const textNode of looseTextNodes) {
+    const lines = (textNode.textContent ?? "")
+      .split(DESCRIPTION_LINE_BREAK)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    if (lines.length === 0) {
+      continue;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    for (const line of lines) {
+      const paragraph = document.createElement("p");
+      paragraph.textContent = line;
+      fragment.appendChild(paragraph);
+    }
+
+    textNode.replaceWith(fragment);
+  }
+}
+
 function preprocessSteamDescriptionDocument(html: string) {
   if (!html) {
     return null;
@@ -262,6 +291,8 @@ function preprocessSteamDescriptionDocument(html: string) {
     video.setAttribute("playsinline", "");
     normalizeDescriptionMediaElement(video);
   });
+
+  wrapLooseDescriptionText(document);
 
   return document;
 }
@@ -1382,7 +1413,7 @@ export default function Game() {
                   </section>
                 </FocusItem>
 
-                {!isLaunchboxGame && (howLongToBeat?.length ?? 0) > 0 && (
+                {(howLongToBeat?.length ?? 0) > 0 && (
                   <HowLongToBeatBox
                     howLongToBeat={howLongToBeat ?? []}
                     focusId={GAME_SIDEBAR_HLTB_ID}
@@ -1412,7 +1443,7 @@ export default function Game() {
                   focusNavigationOverrides={sidebarCarouselNavigationOverrides}
                 />
 
-                {!isLaunchboxGame && (game?.achievementCount ?? 0) > 0 && (
+                {achievements.length > 0 && (
                   <AchievementsBox
                     achievements={achievements ?? []}
                     focusId={GAME_SIDEBAR_ACHIEVEMENTS_ID}


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Classics game pages in Big Picture were missing three things the desktop game page shows: the description, the How Long to Beat box and the achievements box. Three separate causes.

**Description.** `buildDescriptionSections` in `src/big-picture/src/pages/game/game.tsx` splits a description into blocks by iterating `document.body.children`, which only yields elements. LaunchBox descriptions come back as plain text with no markup, so the iteration found nothing, `hasDescription` stayed false and the section never rendered. `preprocessSteamDescriptionDocument` now wraps loose top-level text nodes in paragraphs before the split, breaking on line breaks so the source paragraphing survives (LaunchBox separates paragraphs with `\r\n\r\n`). Steam descriptions are unaffected since their body children are already elements. I checked the resulting blocks against live shop-details responses: LaunchBox objectIds 9445 and 3 now produce one block each with paragraphs intact, and a Steam-shaped `<h2>/<p>/<img>/<p>` input still produces the same three blocks it did before.

**How Long to Beat.** The box was gated behind `!isLaunchboxGame`, but `/games/launchbox/:objectId/how-long-to-beat` does return data:

```
$ curl .../games/launchbox/9445/how-long-to-beat
[{"title":"Main Story","accuracy":"100","duration":"12 Hours"},{"title":"Main + Sides","accuracy":"100","duration":"18 Hours"},{"title":"Completionist","accuracy":"100","duration":"35 Hours"}]
```

So the data was already loaded and the box hidden anyway. Dropped the shop check and kept the existing length check.

**Achievements.** Two problems stacked. The box was gated on `game.achievementCount`, which is only populated from remote library sync and is never set for Classics. And `useGameDetails` only ever called `getUnlockedAchievements`, while Classics achievements come from RetroAchievements. The hook now mirrors `game-details.context.tsx` and calls `getRetroAchievementsAchievements` when the shop is `launchbox` and a RetroAchievements web API key is set. The id argument is left off because `resolveRetroAchievementsGameId` already resolves it from the shop-details cache, which avoids re-running the effect when `shopDetails` lands. The box renders entirely from the `achievements` array, so it is now gated on that array being non-empty, which also stops an empty `0 / 0` box from rendering for Steam games when the achievements request comes back with nothing.

This overlaps part of LBX-958 but is scoped to the game page only. The RetroAchievements connection UI in Big Picture settings and the notification handling from that issue are not touched here.
