### PR TITLE
fix: allow creating a Steam shortcut for custom games from the General tab

### DIFF
--- a/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal.tsx
@@ -297,12 +297,10 @@ export function GameOptionsModal({
   }, [visible]);
 
   useEffect(() => {
-    if (game.shop !== "custom") {
-      globalThis.window.electron
-        .checkSteamShortcut(game.shop, game.objectId)
-        .then(setSteamShortcutExists)
-        .catch(() => setSteamShortcutExists(false));
-    }
+    globalThis.window.electron
+      .checkSteamShortcut(game.shop, game.objectId)
+      .then(setSteamShortcutExists)
+      .catch(() => setSteamShortcutExists(false));
   }, [game.shop, game.objectId]);
 
   useEffect(() => {

--- a/src/renderer/src/pages/game-details/modals/game-options-modal/general-section.tsx
+++ b/src/renderer/src/pages/game-details/modals/game-options-modal/general-section.tsx
@@ -373,32 +373,33 @@ export function GeneralSettingsSection({
       Boolean(game.discs?.some((disc) => disc.path)));
   const transferGameLabel =
     gameSize > 0 ? `${game.title} (${fmt(gameSize)})` : game.title;
+  // Mirrors the context menu's gate (game-context-menu.tsx), which only
+  // requires an executable path — custom games have always been able to
+  // create a Steam shortcut from there, this tab just didn't offer it too.
   let steamShortcutButton: ReactNode = null;
 
-  if (game.shop !== "custom") {
-    if (steamShortcutExists) {
-      steamShortcutButton = (
-        <Button
-          onClick={onDeleteSteamShortcut}
-          theme="danger"
-          disabled={creatingSteamShortcut}
-        >
-          <SteamLogo />
-          {t("delete_steam_shortcut")}
-        </Button>
-      );
-    } else if (hasShortcutLaunchTarget) {
-      steamShortcutButton = (
-        <Button
-          onClick={onCreateSteamShortcut}
-          theme="outline"
-          disabled={creatingSteamShortcut}
-        >
-          <SteamLogo />
-          {t("create_steam_shortcut")}
-        </Button>
-      );
-    }
+  if (steamShortcutExists) {
+    steamShortcutButton = (
+      <Button
+        onClick={onDeleteSteamShortcut}
+        theme="danger"
+        disabled={creatingSteamShortcut}
+      >
+        <SteamLogo />
+        {t("delete_steam_shortcut")}
+      </Button>
+    );
+  } else if (hasShortcutLaunchTarget) {
+    steamShortcutButton = (
+      <Button
+        onClick={onCreateSteamShortcut}
+        theme="outline"
+        disabled={creatingSteamShortcut}
+      >
+        <SteamLogo />
+        {t("create_steam_shortcut")}
+      </Button>
+    );
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
The right-click context menu has always let a custom game create a Steam shortcut (it only checks for an executable path), but the Properties > General tab's shortcut button was unconditionally hidden for `shop === "custom"`, making the two entry points inconsistent.

This makes the General tab use the same executable-path-only gate as the context menu.

## Test plan
- [ ] Add a custom game with an executable path set — confirm "Create Steam Shortcut" now appears in Properties > General, matching the context menu
- [ ] Confirm the button still behaves correctly for regular catalogue games (unchanged)