### PR TITLE
feat: add a custom game by dragging its executable onto the window

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -72,6 +72,8 @@
     "custom_game_modal_success": "Custom game added successfully",
     "custom_game_modal_failed": "Failed to add custom game",
     "custom_game_modal_executable": "Executable",
+    "custom_game_modal_drop_hint": "Drop to add as a custom game",
+    "custom_game_modal_unsupported_file": "This file type can't be added as a game executable",
     "edit_game_modal": "Customize Assets",
     "edit_game_modal_description": "Customize game assets and details",
     "edit_game_modal_title": "Title",

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 // See the Electron documentation for details on how to use preload scripts:
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { randomUUID } from "node:crypto";
 
 import type {
@@ -1267,6 +1267,7 @@ contextBridge.exposeInMainWorld("electron", {
   getCloudIframeUrl: () => ipcRenderer.invoke("getCloudIframeUrl"),
   showOpenDialog: (options: Electron.OpenDialogOptions) =>
     ipcRenderer.invoke("showOpenDialog", options),
+  getPathForFile: (file: File) => webUtils.getPathForFile(file),
   ...fileExplorerApi,
   showItemInFolder: (path: string) =>
     ipcRenderer.invoke("showItemInFolder", path),

--- a/src/renderer/src/components/header/header.scss
+++ b/src/renderer/src/components/header/header.scss
@@ -140,6 +140,34 @@
   }
 }
 
+.header__drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  pointer-events: none;
+}
+
+.header__drop-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(globals.$spacing-unit * 2);
+  padding: calc(globals.$spacing-unit * 6) calc(globals.$spacing-unit * 8);
+  border: 2px dashed globals.$muted-color;
+  border-radius: 12px;
+  background: globals.$dark-background-color;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+  text-align: center;
+}
+
 @keyframes slide-in {
   0% {
     transform: translateX(20px);

--- a/src/renderer/src/components/header/header.tsx
+++ b/src/renderer/src/components/header/header.tsx
@@ -23,6 +23,7 @@ import {
   useAppSelector,
   useSearchHistory,
   useSearchSuggestions,
+  useToast,
 } from "@renderer/hooks";
 
 import "./header.scss";
@@ -35,6 +36,36 @@ import { buildGameDetailsPath } from "@renderer/helpers";
 import type { GameShop } from "@types";
 import type { SuggestionShop } from "@renderer/hooks/use-search-suggestions";
 import { debounce } from "lodash-es";
+import {
+  DARWIN_GAME_EXECUTABLE_EXTENSIONS,
+  LINUX_GAME_EXECUTABLE_EXTENSIONS,
+  WINDOWS_GAME_EXECUTABLE_EXTENSIONS,
+} from "@shared";
+
+function getAcceptedExecutableExtensions() {
+  if (window.electron.platform === "linux") {
+    return LINUX_GAME_EXECUTABLE_EXTENSIONS;
+  }
+
+  if (window.electron.platform === "darwin") {
+    return DARWIN_GAME_EXECUTABLE_EXTENSIONS;
+  }
+
+  return WINDOWS_GAME_EXECUTABLE_EXTENSIONS;
+}
+
+function getDroppedFilePath(file: File): string | null {
+  const filePath = window.electron.getPathForFile(file);
+  if (!filePath) return null;
+
+  const extension = filePath.split(".").pop()?.toLowerCase() ?? "";
+
+  return getAcceptedExecutableExtensions()
+    .map((ext) => ext.toLowerCase())
+    .includes(extension)
+    ? filePath
+    : null;
+}
 
 const pathTitle: Record<string, string> = {
   "/": "home",
@@ -50,6 +81,11 @@ export function Header() {
   const scanButtonTooltipId = useId();
   const addCustomGameTooltipId = useId();
   const [showAddGameModal, setShowAddGameModal] = useState(false);
+  const [droppedExecutablePath, setDroppedExecutablePath] = useState<
+    string | undefined
+  >(undefined);
+  const [isDraggingExecutable, setIsDraggingExecutable] = useState(false);
+  const { showErrorToast } = useToast();
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -154,6 +190,64 @@ export function Header() {
       debouncedCatalogueSearch.cancel();
     };
   }, [debouncedCatalogueSearch, debouncedLibrarySearch]);
+
+  useEffect(() => {
+    let dragDepth = 0;
+
+    const isFileDrag = (event: DragEvent) =>
+      Array.from(event.dataTransfer?.types ?? []).includes("Files");
+
+    const handleDragEnter = (event: DragEvent) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      dragDepth += 1;
+      setIsDraggingExecutable(true);
+    };
+
+    const handleDragOver = (event: DragEvent) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
+      if (!isFileDrag(event)) return;
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) setIsDraggingExecutable(false);
+    };
+
+    const handleDrop = (event: DragEvent) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      dragDepth = 0;
+      setIsDraggingExecutable(false);
+
+      const file = event.dataTransfer?.files[0];
+      if (!file) return;
+
+      const filePath = getDroppedFilePath(file);
+      if (!filePath) {
+        showErrorToast(
+          t("custom_game_modal_unsupported_file", { ns: "sidebar" })
+        );
+        return;
+      }
+
+      setDroppedExecutablePath(filePath);
+      setShowAddGameModal(true);
+    };
+
+    window.addEventListener("dragenter", handleDragEnter);
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragleave", handleDragLeave);
+    window.addEventListener("drop", handleDrop);
+
+    return () => {
+      window.removeEventListener("dragenter", handleDragEnter);
+      window.removeEventListener("dragover", handleDragOver);
+      window.removeEventListener("dragleave", handleDragLeave);
+      window.removeEventListener("drop", handleDrop);
+    };
+  }, [showErrorToast, t]);
 
   const updateDropdownPosition = () => {
     if (searchContainerRef.current) {
@@ -405,7 +499,10 @@ export function Header() {
             <button
               type="button"
               className="header__action-button header__action-button--outlined"
-              onClick={() => setShowAddGameModal(true)}
+              onClick={() => {
+                setDroppedExecutablePath(undefined);
+                setShowAddGameModal(true);
+              }}
               data-tooltip-id={addCustomGameTooltipId}
               data-tooltip-content={t("add_custom_game_tooltip", {
                 ns: "sidebar",
@@ -523,8 +620,21 @@ export function Header() {
 
       <SidebarAddingCustomGameModal
         visible={showAddGameModal}
-        onClose={() => setShowAddGameModal(false)}
+        onClose={() => {
+          setShowAddGameModal(false);
+          setDroppedExecutablePath(undefined);
+        }}
+        initialExecutablePath={droppedExecutablePath}
       />
+
+      {isDraggingExecutable && (
+        <div className="header__drop-overlay">
+          <div className="header__drop-overlay-content">
+            <PlusIcon size={32} />
+            <p>{t("custom_game_modal_drop_hint", { ns: "sidebar" })}</p>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/src/renderer/src/components/sidebar/sidebar-adding-custom-game-modal.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-adding-custom-game-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { FileDirectoryIcon } from "@primer/octicons-react";
@@ -16,11 +16,13 @@ import "./sidebar-adding-custom-game-modal.scss";
 export interface SidebarAddingCustomGameModalProps {
   visible: boolean;
   onClose: () => void;
+  initialExecutablePath?: string;
 }
 
 export function SidebarAddingCustomGameModal({
   visible,
   onClose,
+  initialExecutablePath,
 }: Readonly<SidebarAddingCustomGameModalProps>) {
   const { t } = useTranslation("sidebar");
   const { updateLibrary } = useLibrary();
@@ -30,6 +32,16 @@ export function SidebarAddingCustomGameModal({
   const [gameName, setGameName] = useState("");
   const [executablePath, setExecutablePath] = useState("");
   const [isAdding, setIsAdding] = useState(false);
+
+  useEffect(() => {
+    if (visible && initialExecutablePath) {
+      setExecutablePath(initialExecutablePath);
+
+      const fileName = initialExecutablePath.split(/[\\/]/).pop() || "";
+      const gameNameFromFile = fileName.replace(/\.[^/.]+$/, "");
+      setGameName(gameNameFromFile);
+    }
+  }, [visible, initialExecutablePath]);
 
   const handleSelectExecutable = async () => {
     const filters =

--- a/src/renderer/src/declaration.d.ts
+++ b/src/renderer/src/declaration.d.ts
@@ -959,6 +959,7 @@ declare global {
     showOpenDialog: (
       options: Electron.OpenDialogOptions
     ) => Promise<Electron.OpenDialogReturnValue>;
+    getPathForFile: (file: File) => string;
     readDirectory: (path: string) => Promise<FileExplorerEntry[]>;
     getPathInfo: (path: string) => Promise<FileExplorerPathInfo>;
     listDrives: () => Promise<string[]>;


### PR DESCRIPTION
## Summary
Drag an executable file (.exe on Windows, or the platform-appropriate extensions) from Explorer/Finder anywhere onto the app window to open the Add Custom Game modal pre-filled with that path and a title guessed from the filename — same result as picking the file via the Browse button.

A drop overlay shows while dragging a file over the window; dropping an unsupported file type shows an error toast instead of doing nothing.

Requires exposing `webUtils.getPathForFile` through the preload bridge, since Electron no longer exposes real filesystem paths on dropped `File` objects directly. The window-level `dragover`/`drop` handlers also stop Electron's default behavior of navigating to `file://<path>` when something is dropped on it.

## Test plan
- [ ] Drag a `.exe` onto the app window from anywhere in the UI — confirm the drop overlay appears and the Add Custom Game modal opens pre-filled
- [ ] Drag an unsupported file type — confirm an error toast appears and nothing else happens
- [ ] Confirm the window doesn't navigate away/break when a file is dropped
- [ ] Confirm the regular "+" button / Browse flow still works unaffected