### PR TITLE
fix: launch games that require elevation on Windows

### DIFF
--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -62,7 +62,12 @@ const ensureExecutablePermission = (executablePath: string) => {
   }
 };
 
-const quotePowerShellString = (value: string) => `'${value.replace(/'/g, "''")}'`;
+const quotePowerShellString = (value: string) => `'${value.replaceAll("'", "''")}'`;
+
+const getTrustedPowerShellPath = () => {
+  const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return path.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+};
 
 const buildElevatedStartProcessCommand = (
   command: string,
@@ -103,7 +108,7 @@ const spawnElevatedOnWindows = (
   const encodedCommand = Buffer.from(psCommand, "utf16le").toString("base64");
 
   return spawn(
-    "powershell.exe",
+    getTrustedPowerShellPath(),
     ["-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
     {
       shell: false,

--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -31,6 +31,7 @@ import { parseExecutablePath } from "../events/helpers/parse-executable-path";
 import { isGamemodeAvailable } from "./is-gamemode-available";
 import { isMangohudAvailable } from "./is-mangohud-available";
 import { resolveLaunchCommand } from "./resolve-launch-command";
+import { spawnElevatedOnWindows } from "./spawn-elevated-windows";
 import {
   buildWindowsBatchCommand,
   isWindowsBatchFile,
@@ -60,64 +61,6 @@ const ensureExecutablePermission = (executablePath: string) => {
       error,
     });
   }
-};
-
-const quotePowerShellString = (value: string) => `'${value.replaceAll("'", "''")}'`;
-
-const getTrustedPowerShellPath = () => {
-  const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
-  return path.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-};
-
-const buildElevatedStartProcessCommand = (
-  command: string,
-  args: string[],
-  workingDirectory: string
-): string => {
-  const argumentListPart =
-    args.length > 0
-      ? ` -ArgumentList @(${args.map(quotePowerShellString).join(",")})`
-      : "";
-
-  return (
-    `Start-Process -FilePath ${quotePowerShellString(command)}` +
-    ` -WorkingDirectory ${quotePowerShellString(workingDirectory)}` +
-    `${argumentListPart} -Verb RunAs`
-  );
-};
-
-// Windows requires games whose executable manifest declares
-// requestedExecutionLevel="requireAdministrator" to be launched through a
-// mechanism capable of showing the UAC elevation prompt. A plain spawn()
-// can't do that -- Windows returns ERROR_ELEVATION_REQUIRED, which Node
-// reports as EACCES -- so we retry through PowerShell's Start-Process
-// -Verb RunAs, which elevates the same way double-clicking the exe (or a
-// shortcut to it) in Explorer does. The command is passed base64-encoded
-// via -EncodedCommand to sidestep quoting issues with paths/args.
-const spawnElevatedOnWindows = (
-  command: string,
-  args: string[],
-  workingDirectory: string,
-  env: NodeJS.ProcessEnv
-) => {
-  const psCommand = buildElevatedStartProcessCommand(
-    command,
-    args,
-    workingDirectory
-  );
-  const encodedCommand = Buffer.from(psCommand, "utf16le").toString("base64");
-
-  return spawn(
-    getTrustedPowerShellPath(),
-    ["-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
-    {
-      shell: false,
-      detached: true,
-      stdio: "ignore",
-      cwd: workingDirectory,
-      env,
-    }
-  );
 };
 
 const launchNatively = (

--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -62,12 +62,65 @@ const ensureExecutablePermission = (executablePath: string) => {
   }
 };
 
+const quotePowerShellString = (value: string) => `'${value.replace(/'/g, "''")}'`;
+
+const buildElevatedStartProcessCommand = (
+  command: string,
+  args: string[],
+  workingDirectory: string
+): string => {
+  const argumentListPart =
+    args.length > 0
+      ? ` -ArgumentList @(${args.map(quotePowerShellString).join(",")})`
+      : "";
+
+  return (
+    `Start-Process -FilePath ${quotePowerShellString(command)}` +
+    ` -WorkingDirectory ${quotePowerShellString(workingDirectory)}` +
+    `${argumentListPart} -Verb RunAs`
+  );
+};
+
+// Windows requires games whose executable manifest declares
+// requestedExecutionLevel="requireAdministrator" to be launched through a
+// mechanism capable of showing the UAC elevation prompt. A plain spawn()
+// can't do that -- Windows returns ERROR_ELEVATION_REQUIRED, which Node
+// reports as EACCES -- so we retry through PowerShell's Start-Process
+// -Verb RunAs, which elevates the same way double-clicking the exe (or a
+// shortcut to it) in Explorer does. The command is passed base64-encoded
+// via -EncodedCommand to sidestep quoting issues with paths/args.
+const spawnElevatedOnWindows = (
+  command: string,
+  args: string[],
+  workingDirectory: string,
+  env: NodeJS.ProcessEnv
+) => {
+  const psCommand = buildElevatedStartProcessCommand(
+    command,
+    args,
+    workingDirectory
+  );
+  const encodedCommand = Buffer.from(psCommand, "utf16le").toString("base64");
+
+  return spawn(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
+    {
+      shell: false,
+      detached: true,
+      stdio: "ignore",
+      cwd: workingDirectory,
+      env,
+    }
+  );
+};
+
 const launchNatively = (
   executablePath: string,
   launchOptions?: string | null,
   useMangohud = false,
   useGamemode = false
-): number | null => {
+): Promise<number | null> => {
   const workingDirectory = path.dirname(executablePath);
   const resolvedLaunchCommand = resolveLaunchCommand({
     baseCommand: executablePath,
@@ -86,61 +139,97 @@ const launchNatively = (
     Object.keys(resolvedLaunchCommand.env).length === 0
   ) {
     shell.openPath(executablePath);
-    return null;
+    return Promise.resolve(null);
   }
 
   if (
     process.platform === "win32" &&
     isWindowsBatchFile(resolvedLaunchCommand.command)
   ) {
+    return new Promise((resolve) => {
+      const processRef = spawn(
+        buildWindowsBatchCommand(
+          resolvedLaunchCommand.command,
+          resolvedLaunchCommand.args
+        ),
+        {
+          shell: true,
+          detached: true,
+          stdio: "ignore",
+          cwd: workingDirectory,
+          env: {
+            ...process.env,
+            ...resolvedLaunchCommand.env,
+          },
+        }
+      );
+
+      processRef.on("error", (error) => {
+        logger.error("Failed to launch game", error);
+      });
+
+      processRef.unref();
+      resolve(processRef.pid ?? null);
+    });
+  }
+
+  const env = {
+    ...process.env,
+    ...resolvedLaunchCommand.env,
+  };
+
+  return new Promise((resolve) => {
     const processRef = spawn(
-      buildWindowsBatchCommand(
-        resolvedLaunchCommand.command,
-        resolvedLaunchCommand.args
-      ),
+      resolvedLaunchCommand.command,
+      resolvedLaunchCommand.args,
       {
-        shell: true,
+        shell: false,
         detached: true,
         stdio: "ignore",
         cwd: workingDirectory,
-        env: {
-          ...process.env,
-          ...resolvedLaunchCommand.env,
-        },
+        env,
       }
     );
 
-    processRef.on("error", (error) => {
-      logger.error("Failed to launch game", error);
+    let settled = false;
+
+    processRef.once("spawn", () => {
+      if (settled) return;
+      settled = true;
+      processRef.unref();
+      resolve(processRef.pid ?? null);
     });
 
-    processRef.unref();
+    processRef.once("error", (error: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
 
-    return processRef.pid ?? null;
-  }
+      if (process.platform === "win32" && error.code === "EACCES") {
+        logger.warn(
+          "Game executable requires elevation, retrying with UAC prompt",
+          { executablePath: resolvedLaunchCommand.command }
+        );
 
-  const processRef = spawn(
-    resolvedLaunchCommand.command,
-    resolvedLaunchCommand.args,
-    {
-      shell: false,
-      detached: true,
-      stdio: "ignore",
-      cwd: workingDirectory,
-      env: {
-        ...process.env,
-        ...resolvedLaunchCommand.env,
-      },
-    }
-  );
+        const elevatedProcessRef = spawnElevatedOnWindows(
+          resolvedLaunchCommand.command,
+          resolvedLaunchCommand.args,
+          workingDirectory,
+          env
+        );
 
-  processRef.on("error", (error) => {
-    logger.error("Failed to launch game", error);
+        elevatedProcessRef.on("error", (elevatedError) => {
+          logger.error("Failed to launch elevated game", elevatedError);
+        });
+
+        elevatedProcessRef.unref();
+        resolve(null);
+        return;
+      }
+
+      logger.error("Failed to launch game", error);
+      resolve(null);
+    });
   });
-
-  processRef.unref();
-
-  return processRef.pid ?? null;
 };
 
 const launchWithWine = async (
@@ -551,7 +640,7 @@ const launchResolvedGame = async (
     clearCloudSaveLaunchGuard(objectId, shop);
   }
 
-  const pid = launchNatively(
+  const pid = await launchNatively(
     parsedPath,
     launchOptions,
     useMangohud,

--- a/src/main/helpers/spawn-elevated-windows.ts
+++ b/src/main/helpers/spawn-elevated-windows.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const quotePowerShellString = (value: string) =>
+  `'${value.replaceAll("'", "''")}'`;
+
+const getTrustedPowerShellPath = () => {
+  const systemRoot =
+    process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return path.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe"
+  );
+};
+
+const buildElevatedStartProcessCommand = (
+  command: string,
+  args: string[],
+  workingDirectory: string
+): string => {
+  const argumentListPart =
+    args.length > 0
+      ? ` -ArgumentList @(${args.map(quotePowerShellString).join(",")})`
+      : "";
+
+  return (
+    `Start-Process -FilePath ${quotePowerShellString(command)}` +
+    ` -WorkingDirectory ${quotePowerShellString(workingDirectory)}` +
+    `${argumentListPart} -Verb RunAs`
+  );
+};
+
+// Windows requires executables whose manifest declares
+// requestedExecutionLevel="requireAdministrator" (common for both games and
+// their installers) to be launched through a mechanism capable of showing
+// the UAC elevation prompt. A plain spawn() can't do that -- Windows returns
+// ERROR_ELEVATION_REQUIRED, which Node reports as EACCES -- so we retry
+// through PowerShell's Start-Process -Verb RunAs, which elevates the same
+// way double-clicking the exe (or a shortcut to it) in Explorer does. The
+// command is passed base64-encoded via -EncodedCommand to sidestep quoting
+// issues with paths/args.
+export const spawnElevatedOnWindows = (
+  command: string,
+  args: string[],
+  workingDirectory: string,
+  env: NodeJS.ProcessEnv
+) => {
+  const psCommand = buildElevatedStartProcessCommand(
+    command,
+    args,
+    workingDirectory
+  );
+  const encodedCommand = Buffer.from(psCommand, "utf16le").toString("base64");
+
+  return spawn(
+    getTrustedPowerShellPath(),
+    ["-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
+    {
+      shell: false,
+      detached: true,
+      stdio: "ignore",
+      cwd: workingDirectory,
+      env,
+    }
+  );
+};


### PR DESCRIPTION
## Summary
Games spawned with launch options (or wrapper commands like gamemode/mangohud) go through `child_process.spawn()` directly instead of the `shell.openPath()` fallback used when there are no launch options. `spawn()` can't show the UAC elevation prompt, so any game whose executable manifest declares `requestedExecutionLevel="requireAdministrator"` fails to launch with `spawn ... EACCES` the moment launch options are involved — Windows maps `ERROR_ELEVATION_REQUIRED` to `EACCES`. The same game launches fine from a desktop shortcut because Explorer elevates it automatically.

When `spawn()` fails with `EACCES` on Windows, this now retries through PowerShell's `Start-Process -Verb RunAs`, which shows the same UAC prompt Explorer would and passes launch arguments through `-ArgumentList` (base64-encoded via `-EncodedCommand` to avoid quoting issues with paths that contain spaces). This mirrors the elevation behavior the no-args `shell.openPath()` path already had.

Found this while testing a game that needs a launch flag (`-savetouserdir`) and also requires admin rights — it launched fine via a manual shortcut but failed from inside Hydra with exactly this error.

## Test plan
- [ ] Add a game whose executable requires admin rights (manifest `requireAdministrator`) with a launch option set — confirm it now shows the UAC prompt and launches instead of failing with EACCES
- [ ] Confirm a game with launch options that does *not* require elevation still launches normally (no UAC prompt, no regression)
- [ ] Confirm a game with no launch options still launches via the existing `shell.openPath()` path unchanged
- [ ] Confirm closing the game still works correctly afterward (this PR doesn't change the returned pid used for elevation-launched games, matching the existing null-pid convention already used by the `shell.openPath()` fallback)