### PR TITLE
fix: only apply Windows-only cx_Freeze options on Windows

### DIFF
--- a/python_rpc/setup.py
+++ b/python_rpc/setup.py
@@ -28,9 +28,11 @@ def get_windows_openssl_includes():
 build_exe_options = {
     "packages": ["libtorrent"],
     "build_exe": "hydra-python-rpc",
-    "include_msvcr": True,
     "include_files": get_windows_openssl_includes(),
 }
+
+if sys.platform == "win32":
+    build_exe_options["include_msvcr"] = True
 
 setup(
     name="hydra-python-rpc",
@@ -41,7 +43,9 @@ setup(
         Executable(
             "python_rpc/main.py",
             target_name="hydra-python-rpc",
-            icon="build/icon.ico",
+            # cx_Freeze only embeds the icon on Windows; elsewhere it copies
+            # the .ico into the build output, shipping a file nothing reads.
+            icon="build/icon.ico" if sys.platform == "win32" else None,
         )
     ],
 )


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

`python_rpc/setup.py` passes two Windows-only cx_Freeze options unconditionally.

**The icon has a visible effect on Linux.** cx_Freeze only *embeds* an icon into the executable on Windows — its Windows freezer calls `AddIcon(target_path, exe.icon)`. On every other platform the generic implementation is used instead, and its own comment describes what it does:

```python
def _add_resources(self, exe: Executable) -> None:
    """Add resources for an executable, platform dependent."""
    # Copy icon into application. (Overridden on Windows)
```

It copies the file into the build output. So the Linux build currently ships a 110 KB `icon.ico` inside `hydra-python-rpc/`, which is then packaged out through `extraResources`. Nothing reads it.

**`include_msvcr`** bundles the MSVC runtime and is silently ignored off Windows.

This guards both behind `sys.platform == "win32"`, matching the existing `get_windows_openssl_includes()` pattern already in the file. Windows builds are unchanged.

Verified by rebuilding before and after: the stray `icon.ico` disappears from the output directory, and the resulting binary still starts and completes its handshake (`{"event":"ready","protocolVersion":1}`).

