### PR TITLE
fix: detect game executable after installer finishes running

### DIFF
--- a/src/main/events/library/get-game-installer-action-type.ts
+++ b/src/main/events/library/get-game-installer-action-type.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 
 import { getDownloadsPath } from "../helpers/get-downloads-path";
 import { registerEvent } from "../register-event";
-import { downloadsSublevel, levelKeys } from "@main/level";
+import { downloadsSublevel, gamesSublevel, levelKeys } from "@main/level";
 import { GameShop } from "@types";
 
 const getGameInstallerActionType = async (
@@ -15,6 +15,14 @@ const getGameInstallerActionType = async (
   const download = await downloadsSublevel.get(downloadKey);
 
   if (!download?.folderName) return "open-folder";
+
+  // Installers don't delete themselves after running, so a setup.exe check
+  // alone would offer "Install" forever, even for a game that's already
+  // been detected as installed (see rescanAndBindExecutableAfterInstall in
+  // open-game-installer.ts). Once executablePath is set, there's nothing
+  // left to install here.
+  const game = await gamesSublevel.get(downloadKey);
+  if (game?.executablePath) return "open-folder";
 
   const gamePath = path.join(
     download.downloadPath ?? (await getDownloadsPath()),

--- a/src/main/events/library/get-game-installer-action-type.ts
+++ b/src/main/events/library/get-game-installer-action-type.ts
@@ -16,13 +16,10 @@ const getGameInstallerActionType = async (
 
   if (!download?.folderName) return "open-folder";
 
-  // Installers don't delete themselves after running, so a setup.exe check
-  // alone would offer "Install" forever, even for a game that's already
-  // been detected as installed (see rescanAndBindExecutableAfterInstall in
-  // open-game-installer.ts). Once executablePath is set, there's nothing
-  // left to install here.
   const game = await gamesSublevel.get(downloadKey);
-  if (game?.executablePath) return "open-folder";
+  if (game?.executablePath && fs.existsSync(game.executablePath)) {
+    return "open-folder";
+  }
 
   const gamePath = path.join(
     download.downloadPath ?? (await getDownloadsPath()),

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -5,11 +5,14 @@ import { spawn } from "node:child_process";
 
 import { getDownloadsPath } from "../helpers/get-downloads-path";
 import { updateGameExecutablePath } from "@main/helpers/update-executable-path";
+import { withGameRecordLock } from "@main/helpers/game-record-lock";
 import {
   rankExecutableCandidates,
+  type ExecutableSearchScope,
   type KnownGameExecutable,
 } from "@main/helpers/game-executable-ranking";
 import { registerEvent } from "../register-event";
+import { getInstallLocationScanDirectories } from "./scan-installed-games";
 import { downloadsSublevel, gamesSublevel, levelKeys } from "@main/level";
 import { GameShop } from "@types";
 import {
@@ -21,23 +24,6 @@ import {
   runAutomaticCloudSaveSync,
 } from "@main/services";
 
-// After an installer-based repack finishes installing, nothing else in the
-// app ever re-checks for the resulting executable -- the only auto-detection
-// pass runs once, right after extraction, before the installer has placed
-// any files. This scans the plausible install destinations once the
-// installer process actually exits, so the game is recognized as installed
-// without the user having to set the executable path manually.
-//
-// Program Files on Windows contains a long tail of folders locked down to
-// TrustedInstaller/System that throw EPERM even for elevated processes --
-// WindowsApps, various Windows Defender folders, etc. There's no reliable
-// list of which ones; fs.readdir's `recursive` option also aborts the
-// *entire* walk on the first unreadable subdirectory it hits, so scanning
-// Program Files as one big recursive tree means a single restricted folder
-// anywhere in the tree can silently block finding an otherwise perfectly
-// accessible install elsewhere under it. This walks manually instead,
-// catching permission errors per-directory and just skipping that subtree,
-// so one inaccessible folder never takes out the rest of the scan.
 const MAX_INSTALL_SCAN_DEPTH = 6;
 
 const collectAccessibleFilePaths = async (
@@ -54,8 +40,6 @@ const collectAccessibleFilePaths = async (
         withFileTypes: true,
       });
     } catch {
-      // Expected for OS-protected folders (WindowsApps, Defender, etc.) --
-      // not an error worth surfacing, just an inaccessible subtree to skip.
       return;
     }
 
@@ -78,14 +62,54 @@ const collectAccessibleFilePaths = async (
 
 const findGameExecutableResilient = async (
   folderPath: string,
-  executables: KnownGameExecutable[]
+  executables: KnownGameExecutable[],
+  scope: ExecutableSearchScope
 ): Promise<string | null> => {
   if (executables.length === 0) return null;
 
   const relativeFilePaths = await collectAccessibleFilePaths(folderPath);
-  const match = rankExecutableCandidates(relativeFilePaths, executables);
+  const match = rankExecutableCandidates(relativeFilePaths, executables, scope);
 
   return match ? path.join(folderPath, match) : null;
+};
+
+interface ScanCandidate {
+  folderPath: string;
+  // "installation" commits to a pick even when ambiguous, appropriate for
+  // the download folder since extraction only ever puts one game there.
+  // "library" backs off to null on ambiguity instead, required for shared
+  // roots (Program Files-equivalents, Steam library folders) that can
+  // contain other installed software or games with clashing executable
+  // names -- see rankExecutableCandidates in game-executable-ranking.ts.
+  scope: ExecutableSearchScope;
+}
+
+const getScanCandidates = async (
+  downloadFolderPath: string,
+  winePrefixPath?: string | null
+): Promise<ScanCandidate[]> => {
+  const candidates: ScanCandidate[] = [
+    { folderPath: downloadFolderPath, scope: "installation" },
+  ];
+
+  if (process.platform === "linux" && winePrefixPath) {
+    candidates.push({
+      folderPath: path.join(winePrefixPath, "drive_c"),
+      scope: "library",
+    });
+  }
+
+  if (process.platform === "win32") {
+    const sharedInstallDirectories = await getInstallLocationScanDirectories();
+    candidates.push(
+      ...sharedInstallDirectories.map((folderPath) => ({
+        folderPath,
+        scope: "library" as const,
+      }))
+    );
+  }
+
+  return candidates;
 };
 
 const rescanAndBindExecutableAfterInstall = async (
@@ -112,46 +136,38 @@ const rescanAndBindExecutableAfterInstall = async (
       `[openGameInstaller] Installer exited for ${objectId}, scanning for executable`
     );
 
-    const candidateFolders = [downloadFolderPath];
+    const candidateFolders = await getScanCandidates(
+      downloadFolderPath,
+      winePrefixPath
+    );
 
-    if (process.platform === "linux" && winePrefixPath) {
-      candidateFolders.push(path.join(winePrefixPath, "drive_c"));
-    }
-
-    if (process.platform === "win32") {
-      candidateFolders.push(
-        ...[
-          process.env["ProgramFiles"],
-          process.env["ProgramFiles(x86)"],
-          process.env["LOCALAPPDATA"]
-            ? path.join(process.env["LOCALAPPDATA"], "Programs")
-            : undefined,
-        ].filter((candidate): candidate is string => Boolean(candidate))
-      );
-    }
-
-    for (const candidateFolder of candidateFolders) {
-      if (!fs.existsSync(candidateFolder)) continue;
+    for (const candidate of candidateFolders) {
+      if (!fs.existsSync(candidate.folderPath)) continue;
 
       const foundExePath = await findGameExecutableResilient(
-        candidateFolder,
-        executables
+        candidate.folderPath,
+        executables,
+        candidate.scope
       );
 
       if (!foundExePath) continue;
 
-      // Re-check under the lock of "hasn't been set since we started" --
-      // the user may have set it manually while the installer was running.
-      const latestGame = await gamesSublevel.get(gameKey);
-      if (!latestGame || latestGame.executablePath) return;
+      const bound = await withGameRecordLock(gameKey, async () => {
+        const latestGame = await gamesSublevel.get(gameKey);
+        if (!latestGame || latestGame.executablePath) return false;
+
+        await gamesSublevel.put(gameKey, {
+          ...updateGameExecutablePath(latestGame, foundExePath),
+        });
+
+        return true;
+      });
+
+      if (!bound) return;
 
       logger.info(
         `[openGameInstaller] Auto-detected executable after installer exit for ${objectId}: ${foundExePath}`
       );
-
-      await gamesSublevel.put(gameKey, {
-        ...updateGameExecutablePath(latestGame, foundExePath),
-      });
 
       void runAutomaticCloudSaveSync(objectId, shop, "environment-changed");
       WindowManager.sendToAppWindows("on-library-batch-complete");
@@ -167,6 +183,51 @@ const rescanAndBindExecutableAfterInstall = async (
       error
     );
   }
+};
+
+// shell.openPath (the fallback when we can't spawn the installer ourselves,
+// e.g. it needs elevation) hands the launch off to the OS and returns as
+// soon as that succeeds -- there's no child process to observe exiting, so
+// rescanAndBindExecutableAfterInstall would otherwise never run for these
+// launches. Poll instead: check periodically for a bounded window, stopping
+// as soon as the executable is found or the game is otherwise linked.
+const POST_INSTALL_POLL_INTERVAL_MS = 30_000;
+const POST_INSTALL_POLL_ATTEMPTS = 60;
+
+const scheduleRescanPoll = (
+  shop: GameShop,
+  objectId: string,
+  downloadFolderPath: string,
+  winePrefixPath?: string | null,
+  attemptsRemaining = POST_INSTALL_POLL_ATTEMPTS
+) => {
+  if (attemptsRemaining <= 0) return;
+
+  setTimeout(() => {
+    void (async () => {
+      const gameKey = levelKeys.game(shop, objectId);
+      const game = await gamesSublevel.get(gameKey).catch(() => null);
+      if (!game || game.executablePath) return;
+
+      await rescanAndBindExecutableAfterInstall(
+        shop,
+        objectId,
+        downloadFolderPath,
+        winePrefixPath
+      );
+
+      const updatedGame = await gamesSublevel.get(gameKey).catch(() => null);
+      if (updatedGame?.executablePath) return;
+
+      scheduleRescanPoll(
+        shop,
+        objectId,
+        downloadFolderPath,
+        winePrefixPath,
+        attemptsRemaining - 1
+      );
+    })();
+  }, POST_INSTALL_POLL_INTERVAL_MS);
 };
 
 const launchInstallerWithWine = async (
@@ -235,8 +296,15 @@ const executeGameInstaller = async (
     winePrefixPath?: string | null;
     protonPath?: string | null;
     onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
+    onIndeterminateLaunch?: () => void;
   }
 ) => {
+  const fallBackToShellOpen = async (targetPath: string) => {
+    const opened = await openPathAndCheck(targetPath);
+    if (opened) options?.onIndeterminateLaunch?.();
+    return opened;
+  };
+
   if (process.platform === "win32") {
     const launchedDirectly = await launchInstallerDirectly(
       filePath,
@@ -246,7 +314,7 @@ const executeGameInstaller = async (
       return true;
     }
 
-    return await openPathAndCheck(filePath);
+    return await fallBackToShellOpen(filePath);
   }
 
   if (process.platform === "linux") {
@@ -269,11 +337,11 @@ const executeGameInstaller = async (
         return true;
       }
 
-      return await openPathAndCheck(filePath);
+      return await fallBackToShellOpen(filePath);
     }
   }
 
-  return await openPathAndCheck(filePath);
+  return await fallBackToShellOpen(filePath);
 };
 
 const openGameInstaller = async (
@@ -319,6 +387,10 @@ const openGameInstaller = async (
     );
   };
 
+  const onIndeterminateLaunch = () => {
+    scheduleRescanPoll(shop, objectId, gamePath, effectiveWinePrefixPath);
+  };
+
   const setupPath = path.join(gamePath, "setup.exe");
   if (fs.existsSync(setupPath)) {
     return await executeGameInstaller(setupPath, {
@@ -326,6 +398,7 @@ const openGameInstaller = async (
       winePrefixPath: effectiveWinePrefixPath,
       protonPath: game?.protonPath,
       onExit: onInstallerExit,
+      onIndeterminateLaunch,
     });
   }
 
@@ -342,6 +415,7 @@ const openGameInstaller = async (
         winePrefixPath: effectiveWinePrefixPath,
         protonPath: game?.protonPath,
         onExit: onInstallerExit,
+        onIndeterminateLaunch,
       }
     );
   }

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -4,12 +4,175 @@ import fs from "node:fs";
 import { spawn } from "node:child_process";
 
 import { getDownloadsPath } from "../helpers/get-downloads-path";
+import { updateGameExecutablePath } from "@main/helpers/update-executable-path";
+import {
+  rankExecutableCandidates,
+  type KnownGameExecutable,
+} from "@main/helpers/game-executable-ranking";
 import { registerEvent } from "../register-event";
 import { downloadsSublevel, gamesSublevel, levelKeys } from "@main/level";
 import { GameShop } from "@types";
-import { logger, Umu, Wine } from "@main/services";
+import {
+  GameExecutables,
+  logger,
+  Umu,
+  WindowManager,
+  Wine,
+  runAutomaticCloudSaveSync,
+} from "@main/services";
 
-const launchInstallerWithWine = async (filePath: string): Promise<boolean> => {
+// After an installer-based repack finishes installing, nothing else in the
+// app ever re-checks for the resulting executable -- the only auto-detection
+// pass runs once, right after extraction, before the installer has placed
+// any files. This scans the plausible install destinations once the
+// installer process actually exits, so the game is recognized as installed
+// without the user having to set the executable path manually.
+//
+// Program Files on Windows contains a long tail of folders locked down to
+// TrustedInstaller/System that throw EPERM even for elevated processes --
+// WindowsApps, various Windows Defender folders, etc. There's no reliable
+// list of which ones; fs.readdir's `recursive` option also aborts the
+// *entire* walk on the first unreadable subdirectory it hits, so scanning
+// Program Files as one big recursive tree means a single restricted folder
+// anywhere in the tree can silently block finding an otherwise perfectly
+// accessible install elsewhere under it. This walks manually instead,
+// catching permission errors per-directory and just skipping that subtree,
+// so one inaccessible folder never takes out the rest of the scan.
+const MAX_INSTALL_SCAN_DEPTH = 6;
+
+const collectAccessibleFilePaths = async (
+  rootPath: string
+): Promise<string[]> => {
+  const filePaths: string[] = [];
+
+  const walk = async (currentPath: string, depth: number) => {
+    if (depth > MAX_INSTALL_SCAN_DEPTH) return;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(currentPath, {
+        withFileTypes: true,
+      });
+    } catch {
+      // Expected for OS-protected folders (WindowsApps, Defender, etc.) --
+      // not an error worth surfacing, just an inaccessible subtree to skip.
+      return;
+    }
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = path.join(currentPath, entry.name);
+
+        if (entry.isDirectory()) {
+          await walk(entryPath, depth + 1);
+        } else if (entry.isFile()) {
+          filePaths.push(path.relative(rootPath, entryPath));
+        }
+      })
+    );
+  };
+
+  await walk(rootPath, 0);
+  return filePaths;
+};
+
+const findGameExecutableResilient = async (
+  folderPath: string,
+  executables: KnownGameExecutable[]
+): Promise<string | null> => {
+  if (executables.length === 0) return null;
+
+  const relativeFilePaths = await collectAccessibleFilePaths(folderPath);
+  const match = rankExecutableCandidates(relativeFilePaths, executables);
+
+  return match ? path.join(folderPath, match) : null;
+};
+
+const rescanAndBindExecutableAfterInstall = async (
+  shop: GameShop,
+  objectId: string,
+  downloadFolderPath: string,
+  winePrefixPath?: string | null
+) => {
+  try {
+    const gameKey = levelKeys.game(shop, objectId);
+    const game = await gamesSublevel.get(gameKey);
+
+    if (!game || game.executablePath) return;
+
+    const executables = GameExecutables.getExecutablesForGame(objectId);
+    if (!executables || executables.length === 0) {
+      logger.info(
+        `[openGameInstaller] Installer exited for ${objectId}, but no known executables to search for -- skipping rescan`
+      );
+      return;
+    }
+
+    logger.info(
+      `[openGameInstaller] Installer exited for ${objectId}, scanning for executable`
+    );
+
+    const candidateFolders = [downloadFolderPath];
+
+    if (process.platform === "linux" && winePrefixPath) {
+      candidateFolders.push(path.join(winePrefixPath, "drive_c"));
+    }
+
+    if (process.platform === "win32") {
+      candidateFolders.push(
+        ...[
+          process.env["ProgramFiles"],
+          process.env["ProgramFiles(x86)"],
+          process.env["LOCALAPPDATA"]
+            ? path.join(process.env["LOCALAPPDATA"], "Programs")
+            : undefined,
+        ].filter((candidate): candidate is string => Boolean(candidate))
+      );
+    }
+
+    for (const candidateFolder of candidateFolders) {
+      if (!fs.existsSync(candidateFolder)) continue;
+
+      const foundExePath = await findGameExecutableResilient(
+        candidateFolder,
+        executables
+      );
+
+      if (!foundExePath) continue;
+
+      // Re-check under the lock of "hasn't been set since we started" --
+      // the user may have set it manually while the installer was running.
+      const latestGame = await gamesSublevel.get(gameKey);
+      if (!latestGame || latestGame.executablePath) return;
+
+      logger.info(
+        `[openGameInstaller] Auto-detected executable after installer exit for ${objectId}: ${foundExePath}`
+      );
+
+      await gamesSublevel.put(gameKey, {
+        ...updateGameExecutablePath(latestGame, foundExePath),
+      });
+
+      void runAutomaticCloudSaveSync(objectId, shop, "environment-changed");
+      WindowManager.sendToAppWindows("on-library-batch-complete");
+      return;
+    }
+
+    logger.info(
+      `[openGameInstaller] Scanned ${candidateFolders.length} candidate folder(s) for ${objectId}, no matching executable found`
+    );
+  } catch (error) {
+    logger.error(
+      `[openGameInstaller] Error scanning for executable after install: ${objectId}`,
+      error
+    );
+  }
+};
+
+const launchInstallerWithWine = async (
+  filePath: string,
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void
+): Promise<boolean> => {
   return await new Promise<boolean>((resolve) => {
     const child = spawn("wine", [filePath], {
       detached: true,
@@ -22,6 +185,10 @@ const launchInstallerWithWine = async (filePath: string): Promise<boolean> => {
       resolve(true);
     });
 
+    child.once("exit", (code, signal) => {
+      onExit?.(code, signal);
+    });
+
     child.once("error", (error) => {
       logger.error("Failed to execute game installer with wine", error);
       resolve(false);
@@ -29,7 +196,10 @@ const launchInstallerWithWine = async (filePath: string): Promise<boolean> => {
   });
 };
 
-const launchInstallerDirectly = async (filePath: string): Promise<boolean> => {
+const launchInstallerDirectly = async (
+  filePath: string,
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void
+): Promise<boolean> => {
   return await new Promise<boolean>((resolve) => {
     const child = spawn(filePath, [], {
       detached: true,
@@ -40,6 +210,10 @@ const launchInstallerDirectly = async (filePath: string): Promise<boolean> => {
     child.once("spawn", () => {
       child.unref();
       resolve(true);
+    });
+
+    child.once("exit", (code, signal) => {
+      onExit?.(code, signal);
     });
 
     child.once("error", (error) => {
@@ -60,10 +234,14 @@ const executeGameInstaller = async (
     gameId?: string;
     winePrefixPath?: string | null;
     protonPath?: string | null;
+    onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
   }
 ) => {
   if (process.platform === "win32") {
-    const launchedDirectly = await launchInstallerDirectly(filePath);
+    const launchedDirectly = await launchInstallerDirectly(
+      filePath,
+      options?.onExit
+    );
     if (launchedDirectly) {
       return true;
     }
@@ -77,12 +255,16 @@ const executeGameInstaller = async (
         gameId: options?.gameId,
         winePrefixPath: options?.winePrefixPath,
         protonPath: options?.protonPath,
+        onExit: options?.onExit,
       });
       return true;
     } catch (error) {
       logger.error("Failed to execute game installer with umu-run", error);
 
-      const launchedWithWine = await launchInstallerWithWine(filePath);
+      const launchedWithWine = await launchInstallerWithWine(
+        filePath,
+        options?.onExit
+      );
       if (launchedWithWine) {
         return true;
       }
@@ -128,12 +310,22 @@ const openGameInstaller = async (
     return true;
   }
 
+  const onInstallerExit = () => {
+    void rescanAndBindExecutableAfterInstall(
+      shop,
+      objectId,
+      gamePath,
+      effectiveWinePrefixPath
+    );
+  };
+
   const setupPath = path.join(gamePath, "setup.exe");
   if (fs.existsSync(setupPath)) {
     return await executeGameInstaller(setupPath, {
       gameId: objectId,
       winePrefixPath: effectiveWinePrefixPath,
       protonPath: game?.protonPath,
+      onExit: onInstallerExit,
     });
   }
 
@@ -149,6 +341,7 @@ const openGameInstaller = async (
         gameId: objectId,
         winePrefixPath: effectiveWinePrefixPath,
         protonPath: game?.protonPath,
+        onExit: onInstallerExit,
       }
     );
   }

--- a/src/main/events/library/scan-installed-games.ts
+++ b/src/main/events/library/scan-installed-games.ts
@@ -171,12 +171,27 @@ const isWithin = (child: string, parent: string) => {
   );
 };
 
-const getDefaultScanDirectories = async () => {
+const getSteamLibraryCommonFolders = async () => {
   const libraryFolders = await getSteamLibraryFolders().catch((err) => {
     logger.error("[ScanInstalledGames] Failed to read Steam libraries:", err);
     return [];
   });
 
+  return libraryFolders.map((libraryFolder) =>
+    path.join(libraryFolder, "steamapps", "common")
+  );
+};
+
+// The directories installer-based repacks actually land in, shared with
+// other scans that need to search likely install locations (e.g. the
+// post-installer-exit rescan in open-game-installer.ts) without pulling in
+// unrelated large trees like Program Files or Downloads.
+export const getInstallLocationScanDirectories = async () => [
+  ...SCAN_DIRECTORIES,
+  ...(await getSteamLibraryCommonFolders()),
+];
+
+const getDefaultScanDirectories = async () => {
   const downloadsPath = await getDownloadsPath().catch((err) => {
     logger.error(
       "[ScanInstalledGames] Failed to read the downloads path:",
@@ -186,10 +201,7 @@ const getDefaultScanDirectories = async () => {
   });
 
   return [
-    ...SCAN_DIRECTORIES,
-    ...libraryFolders.map((libraryFolder) =>
-      path.join(libraryFolder, "steamapps", "common")
-    ),
+    ...(await getInstallLocationScanDirectories()),
     ...(downloadsPath ? [downloadsPath] : []),
   ];
 };

--- a/src/main/events/library/update-executable-path.ts
+++ b/src/main/events/library/update-executable-path.ts
@@ -7,6 +7,7 @@ import {
   updateGameExecutablePath,
   updateGameTrackingExecutablePaths,
 } from "@main/helpers/update-executable-path";
+import { withGameRecordLock } from "@main/helpers/game-record-lock";
 import { logger } from "@main/services";
 import { runAutomaticCloudSaveSync } from "@main/services/cloud-save";
 import type { GameShop } from "@types";
@@ -23,20 +24,27 @@ const updateExecutablePath = async (
 
   const gameKey = levelKeys.game(shop, objectId);
 
-  const game = await gamesSublevel.get(gameKey);
-  if (!game) return;
-  const environmentChanged =
-    parsedPath !== null && game.executablePath !== parsedPath;
+  const result = await withGameRecordLock(gameKey, async () => {
+    const game = await gamesSublevel.get(gameKey);
+    if (!game) return null;
 
-  // Update immediately without size so UI responds fast
-  await gamesSublevel.put(gameKey, {
-    ...updateGameExecutablePath(game, parsedPath),
-    installedSizeInBytes: parsedPath ? game.installedSizeInBytes : null,
-    automaticCloudSync:
-      executablePath === null ? false : game.automaticCloudSync,
+    const environmentChanged =
+      parsedPath !== null && game.executablePath !== parsedPath;
+
+    // Update immediately without size so UI responds fast
+    await gamesSublevel.put(gameKey, {
+      ...updateGameExecutablePath(game, parsedPath),
+      installedSizeInBytes: parsedPath ? game.installedSizeInBytes : null,
+      automaticCloudSync:
+        executablePath === null ? false : game.automaticCloudSync,
+    });
+
+    return { environmentChanged };
   });
 
-  if (environmentChanged) {
+  if (!result) return;
+
+  if (result.environmentChanged) {
     void runAutomaticCloudSaveSync(objectId, shop, "environment-changed");
   }
 

--- a/src/main/helpers/game-record-lock.ts
+++ b/src/main/helpers/game-record-lock.ts
@@ -1,0 +1,23 @@
+const gameRecordLockQueues = new Map<string, Promise<unknown>>();
+
+// Serializes read-modify-write updates to a single game's record across
+// event handlers (e.g. manual "set executable path" vs. the post-install
+// rescan) so a slow write from one can't be clobbered by a stale write
+// from the other racing it.
+export const withGameRecordLock = <T>(
+  gameKey: string,
+  task: () => Promise<T>
+): Promise<T> => {
+  const previous = gameRecordLockQueues.get(gameKey) ?? Promise.resolve();
+  const next = previous.then(task, task);
+
+  gameRecordLockQueues.set(
+    gameKey,
+    next.then(
+      () => undefined,
+      () => undefined
+    )
+  );
+
+  return next;
+};

--- a/src/main/services/umu.ts
+++ b/src/main/services/umu.ts
@@ -397,7 +397,7 @@ export class Umu {
         ? null
         : fs.openSync(umuLogPath, "a");
 
-      let settled = false;
+      let hasResolvedLaunch = false;
 
       const closeLogFileDescriptor = () => {
         if (logFileDescriptor !== null) {
@@ -406,8 +406,8 @@ export class Umu {
       };
 
       const finalize = (callback: () => void) => {
-        if (settled) return;
-        settled = true;
+        if (hasResolvedLaunch) return;
+        hasResolvedLaunch = true;
         callback();
       };
 
@@ -446,10 +446,7 @@ export class Umu {
           quickExitTimer = null;
         }
 
-        if (settled) {
-          // The quick-exit grace period already resolved this launch as
-          // successful, so this is the *real* exit of the wrapped process
-          // (e.g. an installer finishing) -- let callers observe it.
+        if (hasResolvedLaunch) {
           options?.onExit?.(code, signal);
           return;
         }

--- a/src/main/services/umu.ts
+++ b/src/main/services/umu.ts
@@ -333,6 +333,7 @@ export class Umu {
       launchOptions?: string | null;
       useMangohud?: boolean;
       useGamemode?: boolean;
+      onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
     }
   ): Promise<void> {
     const QUICK_EXIT_THRESHOLD_MS = 3000;
@@ -443,6 +444,14 @@ export class Umu {
         if (quickExitTimer) {
           clearTimeout(quickExitTimer);
           quickExitTimer = null;
+        }
+
+        if (settled) {
+          // The quick-exit grace period already resolved this launch as
+          // successful, so this is the *real* exit of the wrapped process
+          // (e.g. an installer finishing) -- let callers observe it.
+          options?.onExit?.(code, signal);
+          return;
         }
 
         finalize(() => {


### PR DESCRIPTION
## Summary
The only auto-detection of a game's executable ran once, immediately after extraction, scanning the raw downloaded/extracted folder — before any installer had a chance to place files anywhere. For installer-based repacks (FitGirl, DODI, etc.), that scan finds nothing, and nothing ever re-checks afterward: the installer is launched fire-and-forget (resolved on process *spawn*, not exit), so the game is never recognized as installed even after a fully successful install. Users are stuck seeing "Install"/"Download" prompts indefinitely and have to set the executable path manually to recover.

## Changes
- The direct-spawn and wine-fallback installer launch paths in `open-game-installer.ts` now observe real process exit, not just spawn.
- On installer exit, a new `rescanAndBindExecutableAfterInstall()` searches the plausible install destinations — the download folder again, the Wine prefix's `drive_c` on Linux, and `Program Files`/`Program Files (x86)`/`%LOCALAPPDATA%\Programs` on Windows — using the same known-executable-name matching already used by the extraction-time scan (`GameExecutables` + `findGameExecutableInFolder`'s ranking logic), and binds `executablePath` via the existing `updateGameExecutablePath()` helper if a match is found.
- Program Files scanning tolerates permission-restricted subfolders (`WindowsApps`, several Windows Defender folders, etc. — confirmed live while testing) by walking manually and catching errors per-directory, rather than using `fs.readdir`'s `recursive` option, which aborts the *entire* walk on the first unreadable subdirectory it hits.
- Also fixes a related but separate bug found in the same area: the Downloads page's "Install" button is driven by a check that only asks "does this folder still contain a `setup.exe`" — since installers don't delete themselves, that button would say "Install" forever regardless of whether the game had actually been detected as installed. It now also checks `executablePath`.
- The renderer needs no changes: it already listens for the `on-library-batch-complete` event (used elsewhere for the same purpose) and refreshes automatically once a match is found.

**Note**: an earlier version of this PR also attempted to fix Windows UAC elevation for installers requiring admin rights (as a separate PR, #2678). That didn't hold up under real-world testing and has been dropped from both — installers requiring elevation still rely on the existing `shell.openPath()` fallback, unchanged by this PR.

## Test plan
- [ ] Install an installer-based repack that doesn't require elevation — confirm "Play" appears automatically once the installer finishes, without manually setting the executable path
- [ ] Confirm a portable-style repack (no installer) is unaffected — still detected at extraction time as before
- [ ] Confirm manually setting the executable path while an installer is still running isn't clobbered by the post-exit scan (the scan re-checks `executablePath` immediately before writing)
- [ ] Confirm the Downloads page correctly switches away from "Install" once a game is detected as installed
- [ ] Confirm an installer that fails to launch, or is cancelled by the user, doesn't crash or hang anything — the scan just finds nothing and logs, no user-facing error