### PR TITLE
feat: enable crash reporter and log process lifecycle events

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,11 @@
-import { app, BrowserWindow, net, powerMonitor, protocol } from "electron";
+import {
+  app,
+  BrowserWindow,
+  crashReporter,
+  net,
+  powerMonitor,
+  protocol,
+} from "electron";
 import updater from "electron-updater";
 import i18n from "i18next";
 import path from "node:path";
@@ -21,6 +28,10 @@ import { launchGame, openClassicsGame } from "./helpers";
 import { refreshPortableShortcutLauncher } from "./helpers/shortcut-launch";
 import { lookupCachedPlatform } from "./events/library/get-library";
 import { loadState } from "./main";
+
+crashReporter.start({
+  uploadToServer: false,
+});
 
 const { autoUpdater } = updater;
 
@@ -79,6 +90,8 @@ if (process.defaultApp) {
 const initializeApp = async () => {
   refreshPortableShortcutLauncher();
   electronApp.setAppUserModelId("gg.hydralauncher.hydra");
+
+  logger.info("Crash dumps directory", app.getPath("crashDumps"));
 
   protocol.handle("local", (request) => {
     const filePath = request.url.slice("local:".length);
@@ -193,6 +206,23 @@ const initializeApp = async () => {
 
 app.on("browser-window-created", (_, window) => {
   optimizer.watchWindowShortcuts(window);
+});
+
+app.on("child-process-gone", (_event, details) => {
+  logger.error("Child process gone", {
+    type: details.type,
+    reason: details.reason,
+    exitCode: details.exitCode,
+    serviceName: details.serviceName,
+    name: details.name,
+  });
+});
+
+app.on("render-process-gone", (_event, _webContents, details) => {
+  logger.error("Render process gone", {
+    reason: details.reason,
+    exitCode: details.exitCode,
+  });
 });
 
 const handleRunGame = async (shop: GameShop, objectId: string) => {
@@ -341,6 +371,10 @@ app.on("before-quit", async (e) => {
     canAppBeClosed = true;
     app.quit();
   }
+});
+
+app.on("will-quit", () => {
+  logger.info("Application will quit");
 });
 
 app.on("activate", () => {


### PR DESCRIPTION
We had a user report where Hydra disappears with no error window, nothing useful in the logs, and no `hydra.exe` left in Task Manager. Trying to diagnose it, I found we have no way to see what happened:

- `crashReporter.start()` is never called anywhere, so Crashpad never initializes and no minidump is ever written.
- `log.errorHandler.startCatching({ showDialog: false })` in `src/main/services/logger.ts` catches `uncaughtException` and `unhandledRejection`, logs them, and returns. Nothing rethrows or exits. So JS faults can't kill the app, and never surface a dialog either.

Between those two, a silent exit leaves nothing behind at all.

This starts the crash reporter with `uploadToServer: false`. Dumps stay in the Crashpad folder under userData and nothing is transmitted anywhere. The path gets logged once at startup so we can point people at it.

It also logs three lifecycle events Electron already emits and we were discarding. `child-process-gone` and `render-process-gone` carry a reason and exit code when the GPU, a utility process, or a renderer dies. `will-quit` fires on any clean shutdown.

That last one is the useful bit for triage, because it splits a silent disappearance three ways:

| observed | meaning |
| --- | --- |
| quit line, no dump | something called `app.quit()` |
| dump, no quit line | native crash, and the dump names the module |
| neither | process was killed from outside |

Verified locally. A forced native crash writes a dump and no quit line, and the stack symbolizes off `symbols.electronjs.org` down to file and line. A deliberate `app.quit()` logs the quit line and writes no dump.

Dumps can be read with:

```
minidump-stackwalk --brief --symbols-url https://symbols.electronjs.org <dump>
```

Frames inside `hydra_native.node` will show as module plus offset rather than function names, since we don't keep a PDB per release. Module attribution still works, which is enough to tell whether a crash came from Electron, `classic_level.node`, or our own addon. Worth revisiting if dumps start pointing at the addon.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.
