### PR TITLE
fix: resolve gofile website token script from its current path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydralauncher",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Hydra",
   "main": "./out/main/index.js",
   "author": "Los Broxas",

--- a/src/main/services/download/download-manager.ts
+++ b/src/main/services/download/download-manager.ts
@@ -1398,28 +1398,38 @@ export class DownloadManager {
     url: string;
     headers?: Record<string, string>;
   }> {
-    const alternateCdnDownloadLink =
-      await GofileApi.getAlternateCdnDownloadLinkIfAvailable(id);
+    try {
+      const downloadLink = await GofileApi.getDownloadLink(id, password);
+      await GofileApi.checkDownloadUrl(downloadLink);
+      const token = await GofileApi.authorize();
 
-    if (alternateCdnDownloadLink) {
+      logger.log(
+        `[DownloadManager] GoFile download ${id} will use the official downloader`
+      );
+
+      return {
+        url: downloadLink,
+        headers: { Cookie: `accountToken=${token}` },
+      };
+    } catch (error) {
+      logger.warn(
+        `[DownloadManager] Official GoFile downloader failed for ${id}; checking alternate CDN`,
+        error
+      );
+
+      const alternateCdnDownloadLink =
+        await GofileApi.getAlternateCdnDownloadLinkIfAvailable(id);
+
+      if (!alternateCdnDownloadLink) {
+        throw error;
+      }
+
       logger.log(
         `[DownloadManager] GoFile download ${id} will use alternate CDN`
       );
+
       return { url: alternateCdnDownloadLink };
     }
-
-    logger.log(
-      `[DownloadManager] GoFile download ${id} will use official GoFile fallback`
-    );
-
-    const downloadLink = await GofileApi.getDownloadLink(id, password);
-    await GofileApi.checkDownloadUrl(downloadLink);
-    const token = await GofileApi.authorize();
-
-    return {
-      url: downloadLink,
-      headers: { Cookie: `accountToken=${token}` },
-    };
   }
 
   private static async getPixelDrainDownloadOptions(

--- a/src/main/services/hosters/gofile.ts
+++ b/src/main/services/hosters/gofile.ts
@@ -54,8 +54,11 @@ export class GofileApi {
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
   private static readonly language = "en-US";
   private static readonly timeoutMs = 15000;
-  private static readonly websiteTokenScriptUrl =
-    "https://gofile.io/dist/js/wt.obf.js";
+  private static readonly websiteUrl = "https://gofile.io/";
+  private static readonly websiteTokenScriptUrls = [
+    "https://gofile.io/js/wt.obf.js",
+    "https://gofile.io/dist/js/wt.obf.js",
+  ];
   private static readonly alternateCdnBaseUrl = "https://gofilecdn.eu.cc";
   private static readonly alternateCdnProbeTimeoutMs = 5000;
   private static readonly alternateCdnProbeTtlMs = 15000;
@@ -196,6 +199,59 @@ export class GofileApi {
     return secret;
   }
 
+  private static async discoverWebsiteTokenScriptUrl() {
+    try {
+      const response = await this.fetchWithTimeout(this.websiteUrl, {
+        method: "GET",
+        headers: {
+          "User-Agent": this.userAgent,
+          Accept: "text/html,application/xhtml+xml",
+        },
+      });
+
+      if (!response.ok) {
+        return undefined;
+      }
+
+      const html = await response.text();
+      const match = html.match(
+        /<script[^>]+src=["']([^"']*wt[^"'/]*\.js)["']/i
+      );
+
+      if (!match) {
+        return undefined;
+      }
+
+      return new URL(match[1], this.websiteUrl).href;
+    } catch (error) {
+      logger.warn("[Gofile] Failed to discover WT script URL", error);
+      return undefined;
+    }
+  }
+
+  private static async fetchWebsiteTokenScript(url: string) {
+    const response = await this.fetchWithTimeout(url, {
+      method: "GET",
+      headers: {
+        "User-Agent": this.userAgent,
+        Accept: "application/javascript, text/javascript, */*;q=0.8",
+        Referer: this.websiteUrl,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to load Gofile WT script: ${response.status}`);
+    }
+
+    const script = await response.text();
+
+    if (script.trimStart().startsWith("<")) {
+      throw new Error(`Gofile WT script URL returned markup: ${url}`);
+    }
+
+    return script;
+  }
+
   private static async getWebsiteTokenSecret() {
     if (this.websiteTokenSecret) {
       return this.websiteTokenSecret;
@@ -206,22 +262,33 @@ export class GofileApi {
     }
 
     this.websiteTokenSecretPromise = (async () => {
-      const response = await this.fetchWithTimeout(this.websiteTokenScriptUrl, {
-        method: "GET",
-        headers: {
-          "User-Agent": this.userAgent,
-          Accept: "application/javascript, text/javascript, */*;q=0.8",
-          Referer: "https://gofile.io/",
-        },
-      });
+      const discoveredUrl = await this.discoverWebsiteTokenScriptUrl();
+      const urls = [
+        ...new Set(
+          discoveredUrl
+            ? [discoveredUrl, ...this.websiteTokenScriptUrls]
+            : this.websiteTokenScriptUrls
+        ),
+      ];
 
-      if (!response.ok) {
-        throw new Error(`Failed to load Gofile WT script: ${response.status}`);
+      let lastError: unknown;
+
+      for (const url of urls) {
+        try {
+          const secret = this.extractWebsiteTokenSecret(
+            await this.fetchWebsiteTokenScript(url)
+          );
+          logger.log(`[Gofile] Loaded website token secret from ${url}`);
+          return secret;
+        } catch (error) {
+          lastError = error;
+          logger.warn(`[Gofile] Failed to load WT script from ${url}`, error);
+        }
       }
 
-      const secret = this.extractWebsiteTokenSecret(await response.text());
-      logger.log("[Gofile] Loaded website token secret");
-      return secret;
+      throw lastError instanceof Error
+        ? lastError
+        : new Error("Failed to load Gofile WT script");
     })()
       .then((secret) => {
         this.websiteTokenSecret = secret;

--- a/src/main/services/hosters/gofile.ts
+++ b/src/main/services/hosters/gofile.ts
@@ -222,7 +222,20 @@ export class GofileApi {
         return undefined;
       }
 
-      return new URL(match[1], this.websiteUrl).href;
+      const scriptUrl = new URL(match[1], this.websiteUrl);
+      const websiteHostname = new URL(this.websiteUrl).hostname;
+      const isWebsiteHost =
+        scriptUrl.hostname === websiteHostname ||
+        scriptUrl.hostname.endsWith(`.${websiteHostname}`);
+
+      if (scriptUrl.protocol !== "https:" || !isWebsiteHost) {
+        logger.warn(
+          `[Gofile] Ignoring WT script URL outside the Gofile origin: ${scriptUrl.href}`
+        );
+        return undefined;
+      }
+
+      return scriptUrl.href;
     } catch (error) {
       logger.warn("[Gofile] Failed to discover WT script URL", error);
       return undefined;


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Gofile downloads have been failing since sometime on Aug 10. They die immediately after `[Gofile] Fetching content <id>` shows up in the log.

Gofile moved `wt.obf.js` from `/dist/js/` to `/js/`. The old path still answers, but it serves the site's HTML shell with a 200, so the `response.ok` guard in `getWebsiteTokenSecret` passed and the HTML went straight into `vm.runInContext`:

```
wt.obf.js status: 200 text/html; charset=utf-8
script head: <!doctype html> <html lang="en" class="h-full">...
SyntaxError: Unexpected token '<'
    at extractWebsiteTokenSecret
```

Without the secret there is no `X-Website-Token`, so every content request fails. The failure lands after the content fetch begins because a cached guest token short-circuits `authorize()`, which means the first call to `generateWebsiteToken` happens inside `getContentPage`. On a fresh install with no cached token it fails earlier, during guest token creation at startup.

The script URL is now read from the `<script>` tag on the homepage, with the new and old paths kept as fallbacks, so the next time they move it this keeps working. Each candidate is tried in order, and a response body that starts with markup is rejected before it can reach the VM.

Log from a real download on this branch, the official path that was broken:

```
[Gofile] Fetching content <id>
[Gofile] Loaded website token secret from https://gofile.io/js/wt.obf.js
[Gofile] Found file in content <id>
[Gofile] Download link resolved for content <id>
[Gofile] Download URL HEAD check returned 200
```

The second change is ordering. `resolveGofileDownload` probed the alternate CDN first and only used the official downloader when the probe came back empty, so every download paid for that probe up front, up to the full 5 second timeout when the host was unreachable:

```
[Gofile] Alternate CDN check failed for <id>; falling back to official downloader Error: Request timed out: GET https://gofilecdn.eu.cc/<id>
```

Now the official resolution runs first and the CDN is only probed if it throws. When the CDN has nothing to offer either, the original error is rethrown so the user still sees the real reason, `Content not found`, `RATE_LIMIT`, password required, rather than a CDN probe failure that tells them nothing.
