### PR TITLE
fix: stop hanging big picture on a failed shop details fetch

### DIFF
--- a/src/big-picture/src/components/pages/game/controller-support/index.tsx
+++ b/src/big-picture/src/components/pages/game/controller-support/index.tsx
@@ -11,7 +11,7 @@ import PlayStationLogo from "@renderer/assets/PlayStation Logo Wordmark.svg?reac
 
 export interface ControllerSupportBoxProps {
   shop?: GameShop;
-  shopDetails: ShopDetails;
+  shopDetails: ShopDetails | null;
   focusId?: string;
   focusNavigationOverrides?: FocusOverrides;
   focusNavigationOrder?: number;
@@ -26,7 +26,7 @@ export function ControllerSupportBox({
 }: Readonly<ControllerSupportBoxProps>) {
   const { t } = useTranslation("game_details");
 
-  if (shop !== "steam") return null;
+  if (shop !== "steam" || !shopDetails) return null;
 
   const controllerSupport = resolveControllerSupport(shopDetails);
 

--- a/src/big-picture/src/components/pages/game/hero/index.tsx
+++ b/src/big-picture/src/components/pages/game/hero/index.tsx
@@ -36,7 +36,7 @@ import { useHeroBackgroundLayers } from "../../library/hero/use-hero-background-
 import cn from "classnames";
 
 export interface HeroProps {
-  shopDetails: ShopDetailsWithAssets;
+  shopDetails: ShopDetailsWithAssets | null;
   game: LibraryGame | null;
   isGameRunning: boolean;
   isFavorite: boolean;
@@ -95,8 +95,8 @@ export function Hero({
 }: Readonly<HeroProps>) {
   const { t } = useTranslation("game_details");
   const preferredAssets = useMemo(
-    () => resolvePreferredGameAssets(game, shopDetails.assets),
-    [game, shopDetails.assets]
+    () => resolvePreferredGameAssets(game, shopDetails?.assets),
+    [game, shopDetails?.assets]
   );
   const dominantColor = useDominantColor(preferredAssets.heroSrc || null);
   const { backgroundLayers, getLayerEventHandlers } = useHeroBackgroundLayers(
@@ -388,7 +388,7 @@ export function Hero({
         <Typography
           className="game-page__hero-description"
           dangerouslySetInnerHTML={{
-            __html: shopDetails.short_description || "",
+            __html: shopDetails?.short_description || "",
           }}
         />
 

--- a/src/big-picture/src/components/pages/game/navigation.ts
+++ b/src/big-picture/src/components/pages/game/navigation.ts
@@ -1,4 +1,5 @@
 export const GAME_PAGE_REGION_ID = "game-page";
+export const GAME_DETAILS_ERROR_RETRY_ID = "game-details-error-retry";
 export const GAME_HERO_ACTIONS_REGION_ID = "game-hero-actions";
 export const GAME_HERO_PRIMARY_ACTION_ID = "game-hero-primary-action";
 export const GAME_HERO_DOWNLOAD_OPTIONS_ID = "game-hero-download-options";

--- a/src/big-picture/src/components/pages/game/requirements-to-play/index.tsx
+++ b/src/big-picture/src/components/pages/game/requirements-to-play/index.tsx
@@ -8,7 +8,7 @@ import { useNavigationIsFocused } from "../../../../stores";
 import { FocusItem, Typography } from "../../../common";
 
 export interface RequirementsToPlayProps {
-  shopDetails: ShopDetails;
+  shopDetails: ShopDetails | null;
   focusId?: string;
   focusNavigationOverrides?: FocusOverrides;
   focusNavigationOrder?: number;
@@ -74,11 +74,11 @@ export function RequirementsToPlay({
   const normalizedHtml = useMemo(() => {
     const raw =
       activeRequirement === "minimum"
-        ? shopDetails.pc_requirements.minimum
-        : shopDetails.pc_requirements.recommended;
+        ? shopDetails?.pc_requirements?.minimum
+        : shopDetails?.pc_requirements?.recommended;
 
-    return normalizeRequirementsHtml(raw);
-  }, [activeRequirement, shopDetails.pc_requirements]);
+    return normalizeRequirementsHtml(raw ?? "");
+  }, [activeRequirement, shopDetails?.pc_requirements]);
 
   const requirementRows = useMemo(
     () => parseRequirementRows(normalizedHtml),
@@ -127,6 +127,8 @@ export function RequirementsToPlay({
     selectRequirementByIndex,
     selectedTabIndex,
   ]);
+
+  if (!shopDetails) return null;
 
   return (
     <FocusItem

--- a/src/big-picture/src/components/pages/game/supported-languages/index.tsx
+++ b/src/big-picture/src/components/pages/game/supported-languages/index.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon, XIcon } from "@phosphor-icons/react";
 import { ShopDetails } from "@types";
+import { parseSupportedLanguages } from "@shared";
 import { useMemo } from "react";
 import type { FocusOverrides } from "../../../../services";
 import { FocusItem, Typography } from "../../../common";
@@ -17,18 +18,10 @@ export function SupportedLanguages({
   focusNavigationOverrides,
   focusNavigationOrder,
 }: Readonly<SupportedLanguagesProps>) {
-  const languages = useMemo(() => {
-    const supportedLanguages = shopDetails?.supported_languages;
-    if (!supportedLanguages) return [];
-
-    const languagesString = supportedLanguages.split("<br>")[0];
-    const languageArray = languagesString?.split(",") || [];
-
-    return languageArray.map((lang) => ({
-      language: lang.replace("<strong>*</strong>", "").trim(),
-      hasAudio: lang.includes("*"),
-    }));
-  }, [shopDetails?.supported_languages]);
+  const languages = useMemo(
+    () => parseSupportedLanguages(shopDetails?.supported_languages),
+    [shopDetails?.supported_languages]
+  );
 
   if (languages.length === 0) {
     return null;

--- a/src/big-picture/src/components/pages/game/supported-languages/index.tsx
+++ b/src/big-picture/src/components/pages/game/supported-languages/index.tsx
@@ -5,7 +5,7 @@ import type { FocusOverrides } from "../../../../services";
 import { FocusItem, Typography } from "../../../common";
 
 export interface SupportedLanguagesProps {
-  shopDetails: ShopDetails;
+  shopDetails: ShopDetails | null;
   focusId?: string;
   focusNavigationOverrides?: FocusOverrides;
   focusNavigationOrder?: number;
@@ -18,7 +18,7 @@ export function SupportedLanguages({
   focusNavigationOrder,
 }: Readonly<SupportedLanguagesProps>) {
   const languages = useMemo(() => {
-    const supportedLanguages = shopDetails.supported_languages;
+    const supportedLanguages = shopDetails?.supported_languages;
     if (!supportedLanguages) return [];
 
     const languagesString = supportedLanguages.split("<br>")[0];
@@ -28,7 +28,7 @@ export function SupportedLanguages({
       language: lang.replace("<strong>*</strong>", "").trim(),
       hasAudio: lang.includes("*"),
     }));
-  }, [shopDetails.supported_languages]);
+  }, [shopDetails?.supported_languages]);
 
   if (languages.length === 0) {
     return null;

--- a/src/big-picture/src/hooks/use-game-details.hook.ts
+++ b/src/big-picture/src/hooks/use-game-details.hook.ts
@@ -40,6 +40,7 @@ export function useGameDetails(objectId: string, shop: GameShop) {
   const [achievements, setAchievements] = useState<UserAchievement[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasDetailsFetchError, setHasDetailsFetchError] = useState(false);
   const userPreferences = useUserPreferences();
   const shouldUseRetroAchievements =
     shop === "launchbox" &&
@@ -62,9 +63,12 @@ export function useGameDetails(objectId: string, shop: GameShop) {
 
       if (showLoadingState) {
         setIsLoading(true);
+        setHasDetailsFetchError(false);
       } else {
         setIsRefreshing(true);
       }
+
+      let fetchFailed = false;
 
       try {
         const shopDetailsPromise =
@@ -72,7 +76,10 @@ export function useGameDetails(objectId: string, shop: GameShop) {
             ? Promise.resolve(null)
             : globalThis.window.electron
                 .getGameShopDetails(objectId, shop, language)
-                .catch(() => null);
+                .catch(() => {
+                  fetchFailed = true;
+                  return null;
+                });
 
         const [statsResult, assets, shopDetailsResult] = await Promise.all([
           shop === "custom"
@@ -88,7 +95,10 @@ export function useGameDetails(objectId: string, shop: GameShop) {
 
         setShopDetails(shopDetailsResult);
         setStats(statsResult);
+      } catch {
+        fetchFailed = true;
       } finally {
+        setHasDetailsFetchError(fetchFailed);
         setIsLoading(false);
         setIsRefreshing(false);
       }
@@ -269,6 +279,7 @@ export function useGameDetails(objectId: string, shop: GameShop) {
     runningSessionDurationInMillis,
     isLoading,
     isRefreshing,
+    hasDetailsFetchError,
     howLongToBeat,
     protonDBData,
     achievements,

--- a/src/big-picture/src/pages/game/game.scss
+++ b/src/big-picture/src/pages/game/game.scss
@@ -8,6 +8,13 @@
   overflow-y: auto;
   background: var(--background);
 
+  &--details-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: var(--big-picture-header-height);
+  }
+
   &__how-long-to-beat {
     display: flex;
     flex-direction: column;

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -12,6 +12,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { buildLibraryToastOptions, getItemFocusTarget } from "../../helpers";
 import type { LibraryToastSource } from "../../helpers/library-toast";
 import {
+  Button,
+  EmptyState,
   Typography,
   VerticalFocusGroup,
   Divider,
@@ -49,6 +51,7 @@ import {
 } from "../../layout";
 import {
   GAME_COMMENTS_ACTION_ROWS_REGION_ID,
+  GAME_DETAILS_ERROR_RETRY_ID,
   GAME_DESCRIPTION_BOTTOM_ENTRY_ID,
   GAME_DESCRIPTION_BODY_ID,
   GAME_DESCRIPTION_REGION_ID,
@@ -492,6 +495,7 @@ export default function Game() {
     isGameRunning,
     runningSessionDurationInMillis,
     isLoading,
+    hasDetailsFetchError,
     howLongToBeat,
     protonDBData,
     achievements,
@@ -673,6 +677,10 @@ export default function Game() {
     heroActionsLeftNavigationTarget,
   ]);
   useHeaderTitle(resolvedGameTitle);
+
+  const handleRetryGameDetails = useCallback(() => {
+    refreshGameDetails({ showLoadingState: true }).catch(() => {});
+  }, [refreshGameDetails]);
 
   const handleOpenDownloadModal = useCallback(() => {
     setIsDownloadModalOpen(true);
@@ -1252,6 +1260,28 @@ export default function Game() {
       <VerticalFocusGroup regionId={GAME_PAGE_REGION_ID} asChild>
         <div className="game-page">
           <p style={{ color: "white" }}>Loading...</p>
+        </div>
+      </VerticalFocusGroup>
+    );
+  }
+
+  if (hasDetailsFetchError && !game && !shopDetails && shop !== "custom") {
+    return (
+      <VerticalFocusGroup regionId={GAME_PAGE_REGION_ID} asChild>
+        <div className="game-page game-page--details-error">
+          <EmptyState
+            title="Couldn't load game details"
+            description="Check your internet connection and try again."
+            actions={
+              <Button
+                focusId={GAME_DETAILS_ERROR_RETRY_ID}
+                stealFocusOnAppear
+                onClick={handleRetryGameDetails}
+              >
+                Try again
+              </Button>
+            }
+          />
         </div>
       </VerticalFocusGroup>
     );

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -1246,7 +1246,7 @@ export default function Game() {
     };
   }, [descriptionBlocks]);
 
-  if (isLoading || !shopDetails) {
+  if (isLoading || (shop !== "custom" && !shopDetails)) {
     return (
       <VerticalFocusGroup regionId={GAME_PAGE_REGION_ID} asChild>
         <div className="game-page">
@@ -1305,8 +1305,8 @@ export default function Game() {
           <div className="game-page__main-layout">
             <div className="game-page__main-column">
               <ScreenshotCarousel
-                videos={shopDetails.movies ?? []}
-                screenshots={shopDetails.screenshots ?? []}
+                videos={shopDetails?.movies ?? []}
+                screenshots={shopDetails?.screenshots ?? []}
                 onActiveItemChange={setActiveMediaItemId}
                 nextContentEntryTarget={
                   descriptionEntryTarget ?? commentsEntryTarget
@@ -1487,7 +1487,7 @@ export default function Game() {
                     className="game-page__sidebar-section game-page__metadata"
                     aria-label="Game info"
                   >
-                    {isLaunchboxGame && shopDetails.platform ? (
+                    {isLaunchboxGame && shopDetails?.platform ? (
                       <div className="game-page__metadata-row">
                         <Typography className="game-page__metadata-label">
                           Platform

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -1247,7 +1247,7 @@ export default function Game() {
     };
   }, [descriptionBlocks]);
 
-  if (isLoading || (shop !== "custom" && !shopDetails)) {
+  if (isLoading) {
     return (
       <VerticalFocusGroup regionId={GAME_PAGE_REGION_ID} asChild>
         <div className="game-page">

--- a/src/big-picture/src/pages/game/game.tsx
+++ b/src/big-picture/src/pages/game/game.tsx
@@ -614,10 +614,11 @@ export default function Game() {
     };
   }, [activeMediaItemId, hasMedia]);
   const sidebarStatsEntryTarget = useMemo(
-    () => getItemFocusTarget(GAME_SIDEBAR_STATS_ID),
-    []
+    () =>
+      shop === "custom" ? undefined : getItemFocusTarget(GAME_SIDEBAR_STATS_ID),
+    [shop]
   );
-  const bodyRightNavigationTarget = useMemo<FocusOverrideTarget>(
+  const bodyRightNavigationTarget = useMemo<FocusOverrideTarget | undefined>(
     () => sidebarStatsEntryTarget,
     [sidebarStatsEntryTarget]
   );
@@ -1373,215 +1374,233 @@ export default function Game() {
                 </VerticalFocusGroup>
               )}
 
-              <Divider />
+              {shop !== "custom" && (
+                <>
+                  <Divider />
 
-              <GameReviews
-                shop={shop!}
-                objectId={objectId!}
-                topNavigationTarget={commentsTopNavigationTarget}
-                onHasNavigableActionsChange={setHasNavigableComments}
-              />
+                  <GameReviews
+                    shop={shop!}
+                    objectId={objectId!}
+                    topNavigationTarget={commentsTopNavigationTarget}
+                    onHasNavigableActionsChange={setHasNavigableComments}
+                  />
+                </>
+              )}
             </div>
 
-            <VerticalFocusGroup regionId={GAME_SIDEBAR_REGION_ID} asChild>
-              <div className="game-page__sidebar">
-                <FocusItem
-                  id={GAME_SIDEBAR_STATS_ID}
-                  navigationOrder={0}
-                  navigationOverrides={sidebarStatsNavigationOverrides}
-                  asChild
-                >
-                  <section
-                    className="game-page__sidebar-section game-page__stats"
-                    aria-label="Game stats"
+            {shop !== "custom" && (
+              <VerticalFocusGroup regionId={GAME_SIDEBAR_REGION_ID} asChild>
+                <div className="game-page__sidebar">
+                  <FocusItem
+                    id={GAME_SIDEBAR_STATS_ID}
+                    navigationOrder={0}
+                    navigationOverrides={sidebarStatsNavigationOverrides}
+                    asChild
                   >
-                    <div className="game-page__stats-title">
-                      <Typography>Game Stats</Typography>
-                    </div>
-
-                    <div className="game-page__stats-row">
-                      <Typography className="game-page__stats-label">
-                        Rating
-                      </Typography>
-                      <div className="game-page__stats-rating-value">
-                        <StarIcon
-                          size={16}
-                          weight="fill"
-                          aria-hidden="true"
-                          className="game-page__stats-rating-icon"
-                        />
-                        <Typography className="game-page__stats-value">
-                          {formatNumber(stats?.averageScore ?? 0)}
-                        </Typography>
+                    <section
+                      className="game-page__sidebar-section game-page__stats"
+                      aria-label="Game stats"
+                    >
+                      <div className="game-page__stats-title">
+                        <Typography>Game Stats</Typography>
                       </div>
-                    </div>
 
-                    <div className="game-page__stats-row">
-                      <Typography className="game-page__stats-label">
-                        Downloads
-                      </Typography>
-                      <Typography className="game-page__stats-value">
-                        {formatNumber(stats?.downloadCount ?? 0)}
-                      </Typography>
-                    </div>
-
-                    <div className="game-page__stats-row">
-                      <Typography className="game-page__stats-label">
-                        Playing now
-                      </Typography>
-                      <Typography className="game-page__stats-value">
-                        {formatNumber(stats?.playerCount ?? 0)}
-                      </Typography>
-                    </div>
-                  </section>
-                </FocusItem>
-
-                {(howLongToBeat?.length ?? 0) > 0 && (
-                  <HowLongToBeatBox
-                    howLongToBeat={howLongToBeat ?? []}
-                    focusId={GAME_SIDEBAR_HLTB_ID}
-                    focusNavigationOrder={1}
-                    focusNavigationOverrides={
-                      sidebarCarouselNavigationOverrides
-                    }
-                  />
-                )}
-
-                {shouldShowProtonSection && (
-                  <ProtonDBSection
-                    protonDBData={protonDBData}
-                    focusId={GAME_SIDEBAR_PROTONDB_ID}
-                    focusNavigationOrder={2}
-                    focusNavigationOverrides={
-                      sidebarCarouselNavigationOverrides
-                    }
-                  />
-                )}
-
-                <ControllerSupportBox
-                  shop={shop}
-                  shopDetails={shopDetails}
-                  focusId={GAME_SIDEBAR_CONTROLLER_SUPPORT_ID}
-                  focusNavigationOrder={3}
-                  focusNavigationOverrides={sidebarCarouselNavigationOverrides}
-                />
-
-                {achievements.length > 0 && (
-                  <AchievementsBox
-                    achievements={achievements ?? []}
-                    focusId={GAME_SIDEBAR_ACHIEVEMENTS_ID}
-                    focusNavigationOrder={4}
-                    focusNavigationOverrides={
-                      sidebarCarouselNavigationOverrides
-                    }
-                  />
-                )}
-
-                <FocusItem
-                  id={GAME_SIDEBAR_METADATA_ID}
-                  navigationOrder={5}
-                  navigationOverrides={sidebarCarouselNavigationOverrides}
-                  asChild
-                >
-                  <section
-                    className="game-page__sidebar-section game-page__metadata"
-                    aria-label="Game info"
-                  >
-                    {isLaunchboxGame && shopDetails?.platform ? (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Platform
+                      <div className="game-page__stats-row">
+                        <Typography className="game-page__stats-label">
+                          Rating
                         </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {shopDetails.platform}
-                        </Typography>
-                      </div>
-                    ) : null}
-
-                    {isLaunchboxGame && launchboxGenres.length > 0 ? (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Genres
-                        </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {launchboxGenres.join(", ")}
-                        </Typography>
-                      </div>
-                    ) : null}
-
-                    {isLaunchboxGame && launchboxRegions.length > 0 ? (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Regions
-                        </Typography>
-                        <div className="game-page__metadata-flags">
-                          {launchboxRegions.map((region) => (
-                            <img
-                              key={region}
-                              src={getSkuRegionFlag(region)}
-                              alt={REGION_LABELS[region]}
-                              title={REGION_LABELS[region]}
-                              className="game-page__metadata-flag"
-                            />
-                          ))}
+                        <div className="game-page__stats-rating-value">
+                          <StarIcon
+                            size={16}
+                            weight="fill"
+                            aria-hidden="true"
+                            className="game-page__stats-rating-icon"
+                          />
+                          <Typography className="game-page__stats-value">
+                            {formatNumber(stats?.averageScore ?? 0)}
+                          </Typography>
                         </div>
                       </div>
-                    ) : null}
 
-                    {developer && (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Developed by
+                      <div className="game-page__stats-row">
+                        <Typography className="game-page__stats-label">
+                          Downloads
                         </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {developer}
+                        <Typography className="game-page__stats-value">
+                          {formatNumber(stats?.downloadCount ?? 0)}
                         </Typography>
                       </div>
-                    )}
 
-                    {publisher && (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Published by
+                      <div className="game-page__stats-row">
+                        <Typography className="game-page__stats-label">
+                          Playing now
                         </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {publisher}
+                        <Typography className="game-page__stats-value">
+                          {formatNumber(stats?.playerCount ?? 0)}
                         </Typography>
                       </div>
-                    )}
+                    </section>
+                  </FocusItem>
 
-                    {releaseDate && (
-                      <div className="game-page__metadata-row">
-                        <Typography className="game-page__metadata-label">
-                          Release Date
-                        </Typography>
-                        <Typography className="game-page__metadata-value">
-                          {releaseDate}
-                        </Typography>
-                      </div>
-                    )}
-                  </section>
-                </FocusItem>
+                  {(howLongToBeat?.length ?? 0) > 0 && (
+                    <HowLongToBeatBox
+                      howLongToBeat={howLongToBeat ?? []}
+                      focusId={GAME_SIDEBAR_HLTB_ID}
+                      focusNavigationOrder={1}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  )}
 
-                {!isLaunchboxGame ? ( // NOSONAR
-                  <RequirementsToPlay
+                  {shouldShowProtonSection && (
+                    <ProtonDBSection
+                      protonDBData={protonDBData}
+                      focusId={GAME_SIDEBAR_PROTONDB_ID}
+                      focusNavigationOrder={2}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  )}
+
+                  <ControllerSupportBox
+                    shop={shop}
                     shopDetails={shopDetails}
-                    focusId={GAME_SIDEBAR_REQUIREMENTS_ID}
-                    focusNavigationOrder={6}
+                    focusId={GAME_SIDEBAR_CONTROLLER_SUPPORT_ID}
+                    focusNavigationOrder={3}
                     focusNavigationOverrides={
                       sidebarCarouselNavigationOverrides
                     }
                   />
-                ) : null}
 
-                <SupportedLanguages
-                  shopDetails={shopDetails}
-                  focusId={GAME_SIDEBAR_LANGUAGES_ID}
-                  focusNavigationOrder={7}
-                  focusNavigationOverrides={sidebarLanguagesNavigationOverrides}
-                />
-              </div>
-            </VerticalFocusGroup>
+                  {achievements.length > 0 && (
+                    <AchievementsBox
+                      achievements={achievements ?? []}
+                      focusId={GAME_SIDEBAR_ACHIEVEMENTS_ID}
+                      focusNavigationOrder={4}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  )}
+
+                  {(developer ||
+                    publisher ||
+                    releaseDate ||
+                    (isLaunchboxGame &&
+                      (shopDetails?.platform ||
+                        launchboxGenres.length > 0 ||
+                        launchboxRegions.length > 0))) && (
+                    <FocusItem
+                      id={GAME_SIDEBAR_METADATA_ID}
+                      navigationOrder={5}
+                      navigationOverrides={sidebarCarouselNavigationOverrides}
+                      asChild
+                    >
+                      <section
+                        className="game-page__sidebar-section game-page__metadata"
+                        aria-label="Game info"
+                      >
+                        {isLaunchboxGame && shopDetails?.platform ? (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Platform
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {shopDetails.platform}
+                            </Typography>
+                          </div>
+                        ) : null}
+
+                        {isLaunchboxGame && launchboxGenres.length > 0 ? (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Genres
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {launchboxGenres.join(", ")}
+                            </Typography>
+                          </div>
+                        ) : null}
+
+                        {isLaunchboxGame && launchboxRegions.length > 0 ? (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Regions
+                            </Typography>
+                            <div className="game-page__metadata-flags">
+                              {launchboxRegions.map((region) => (
+                                <img
+                                  key={region}
+                                  src={getSkuRegionFlag(region)}
+                                  alt={REGION_LABELS[region]}
+                                  title={REGION_LABELS[region]}
+                                  className="game-page__metadata-flag"
+                                />
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+
+                        {developer && (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Developed by
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {developer}
+                            </Typography>
+                          </div>
+                        )}
+
+                        {publisher && (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Published by
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {publisher}
+                            </Typography>
+                          </div>
+                        )}
+
+                        {releaseDate && (
+                          <div className="game-page__metadata-row">
+                            <Typography className="game-page__metadata-label">
+                              Release Date
+                            </Typography>
+                            <Typography className="game-page__metadata-value">
+                              {releaseDate}
+                            </Typography>
+                          </div>
+                        )}
+                      </section>
+                    </FocusItem>
+                  )}
+
+                  {!isLaunchboxGame ? ( // NOSONAR
+                    <RequirementsToPlay
+                      shopDetails={shopDetails}
+                      focusId={GAME_SIDEBAR_REQUIREMENTS_ID}
+                      focusNavigationOrder={6}
+                      focusNavigationOverrides={
+                        sidebarCarouselNavigationOverrides
+                      }
+                    />
+                  ) : null}
+
+                  <SupportedLanguages
+                    shopDetails={shopDetails}
+                    focusId={GAME_SIDEBAR_LANGUAGES_ID}
+                    focusNavigationOrder={7}
+                    focusNavigationOverrides={
+                      sidebarLanguagesNavigationOverrides
+                    }
+                  />
+                </div>
+              </VerticalFocusGroup>
+            )}
           </div>
         </section>
 

--- a/src/renderer/src/pages/game-details/sidebar/game-language-section.tsx
+++ b/src/renderer/src/pages/game-details/sidebar/game-language-section.tsx
@@ -1,6 +1,7 @@
 import { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CheckIcon, XIcon } from "@primer/octicons-react";
+import { parseSupportedLanguages } from "@shared";
 import { gameDetailsContext } from "@renderer/context/game-details/game-details.context";
 import { SidebarSection } from "../sidebar-section/sidebar-section";
 import "./game-language-section.scss";
@@ -9,18 +10,10 @@ export function GameLanguageSection() {
   const { t } = useTranslation("game_details");
   const { shopDetails } = useContext(gameDetailsContext);
 
-  const languages = useMemo(() => {
-    const supportedLanguages = shopDetails?.supported_languages;
-    if (!supportedLanguages) return [];
-
-    const languagesString = supportedLanguages.split("<br>")[0];
-    const languageArray = languagesString?.split(",") || [];
-
-    return languageArray.map((lang) => ({
-      language: lang.replace("<strong>*</strong>", "").trim(),
-      hasAudio: lang.includes("*"),
-    }));
-  }, [shopDetails?.supported_languages]);
+  const languages = useMemo(
+    () => parseSupportedLanguages(shopDetails?.supported_languages),
+    [shopDetails?.supported_languages]
+  );
 
   if (languages.length === 0) {
     return null;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -31,6 +31,7 @@ export * from "./artwork-resolver";
 export * from "./download-directories";
 export * from "./html-sanitizer";
 export * from "./language-flags";
+export * from "./supported-languages";
 export * from "./use-hls-video";
 export * from "./retroarch-platform";
 export * from "./tracker-list";

--- a/src/shared/supported-languages.ts
+++ b/src/shared/supported-languages.ts
@@ -1,0 +1,18 @@
+export interface SupportedLanguage {
+  language: string;
+  hasAudio: boolean;
+}
+
+export function parseSupportedLanguages(
+  supportedLanguages: string | null | undefined
+): SupportedLanguage[] {
+  if (!supportedLanguages) return [];
+
+  const languagesString = supportedLanguages.split("<br>")[0];
+  const languageArray = languagesString?.split(",") || [];
+
+  return languageArray.map((lang) => ({
+    language: lang.replace("<strong>*</strong>", "").trim(),
+    hasAudio: lang.includes("*"),
+  }));
+}


### PR DESCRIPTION
Follow-up from https://github.com/hydralauncher/hydra/pull/2639#discussion_r3722832843, taking the gate and the retry as the design.

Stacked on #2639 — the first three commits are that PR; the two to review here are the last ones.

- `6c91af8` drops the loading gate to plain `isLoading`. Every consumer downstream is null-safe after #2639, so a library game still opens with the API down instead of sitting on Loading forever.
- `b96159f` tracks the fetch failure in the hook and renders an error state with a Retry button when `!game && !shopDetails && shop !== "custom"` — the catalogue case that would otherwise render an empty shell ("Download Game" title, catalogue actions, silent Add to Library). Library and custom stay on the normal page, and the `handleAddToLibrary` guard is untouched; loosening it would add a library row titled "Download Game".

The failure flag covers all three ways into the state from the thread: the swallowed `.catch` on `getGameShopDetails`, plus `getGameStats` and `getGameAssets` rejections that previously escaped through the `finally`. Retry re-runs `refreshGameDetails` with the loading state, and the flag resets when a loading fetch starts, so retrying shows Loading rather than the stale error.
