### PR TITLE
fix: allow selecting and copying review text

### DIFF
--- a/src/renderer/src/pages/game-details/review-item.scss
+++ b/src/renderer/src/pages/game-details/review-item.scss
@@ -255,6 +255,8 @@
   }
 
   &__review-content {
+    user-select: text;
+    cursor: text;
     color: globals.$body-color;
     line-height: 1.5;
     word-wrap: break-word;

--- a/src/renderer/src/pages/profile/profile-content/profile-content.scss
+++ b/src/renderer/src/pages/profile/profile-content/profile-content.scss
@@ -362,6 +362,8 @@
 }
 
 .user-reviews__review-content {
+  user-select: text;
+  cursor: text;
   color: rgba(255, 255, 255, 0.85);
   line-height: 1.5;
   word-wrap: break-word;


### PR DESCRIPTION
Review bodies inherited the global user-select: none set on body, so they could not be highlighted or copied. Opt the review content back in on game pages (reviews and replies) and on profile review lists.

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Adds the ability to select text in reviews on both game pages and user profiles