### PR TITLE
Enable souvenirs by default

### DIFF
--- a/src/big-picture/src/pages/settings/content.tsx
+++ b/src/big-picture/src/pages/settings/content.tsx
@@ -49,7 +49,7 @@ const DEFAULT_FORM: ContentForm = {
   disableNsfwAlert: false,
   showHiddenAchievementsDescription: false,
   enableSteamAchievements: false,
-  enableAchievementSouvenirs: false,
+  enableAchievementSouvenirs: true,
 };
 
 export function ContentSettingsSection({
@@ -79,7 +79,7 @@ export function ContentSettingsSection({
         userPreferences.showHiddenAchievementsDescription ?? false,
       enableSteamAchievements: userPreferences.enableSteamAchievements ?? false,
       enableAchievementSouvenirs:
-        userPreferences.enableAchievementSouvenirs ?? false,
+        userPreferences.enableAchievementSouvenirs ?? true,
     });
   }, [userPreferences]);
 

--- a/src/main/services/achievements/merge-achievements.ts
+++ b/src/main/services/achievements/merge-achievements.ts
@@ -43,7 +43,7 @@ const captureAchievementSouvenirs = async (
     !newAchievements.length ||
     !publishNotification ||
     !game.remoteId ||
-    userPreferences.enableAchievementSouvenirs !== true ||
+    userPreferences.enableAchievementSouvenirs === false ||
     !HydraApi.hasActiveSubscription()
   ) {
     return null;

--- a/src/main/services/emulators/emulator-souvenir-watcher.ts
+++ b/src/main/services/emulators/emulator-souvenir-watcher.ts
@@ -47,7 +47,7 @@ const isSouvenirCaptureEnabled = async () => {
     { valueEncoding: "json" }
   );
 
-  return userPreferences?.enableAchievementSouvenirs === true;
+  return userPreferences?.enableAchievementSouvenirs !== false;
 };
 
 const queueGroupedSouvenir = async (

--- a/src/main/services/emulators/prepare-emulator-souvenirs.ts
+++ b/src/main/services/emulators/prepare-emulator-souvenirs.ts
@@ -19,7 +19,7 @@ export const prepareEmulatorSouvenirs = async (
     { valueEncoding: "json" }
   );
 
-  if (userPreferences?.enableAchievementSouvenirs !== true) return null;
+  if (userPreferences?.enableAchievementSouvenirs === false) return null;
 
   if (system === "ps1") {
     await enableDuckStationFileLogging();

--- a/src/main/services/linux-game-capture-session.ts
+++ b/src/main/services/linux-game-capture-session.ts
@@ -103,7 +103,7 @@ export const prepareLinuxGameCaptureSession = async (gameKey: string) => {
     );
 
     if (
-      userPreferences?.enableAchievementSouvenirs !== true ||
+      userPreferences?.enableAchievementSouvenirs === false ||
       !HydraApi.hasActiveSubscription()
     ) {
       if (sessions.get(gameKey)?.token === token) sessions.delete(gameKey);

--- a/src/renderer/src/pages/profile/profile-content/profile-content.tsx
+++ b/src/renderer/src/pages/profile/profile-content/profile-content.tsx
@@ -123,7 +123,7 @@ export function ProfileContent() {
   const requestedSouvenir = searchParams.get("souvenir");
   const attemptedDeepLinkPagesRef = useRef(new Set<string>());
   const souvenirsEnabled = useAppSelector(
-    (state) => state.userPreferences.value?.enableAchievementSouvenirs === true
+    (state) => state.userPreferences.value?.enableAchievementSouvenirs !== false
   );
   const disableNsfwAlert = useAppSelector(
     (state) => state.userPreferences.value?.disableNsfwAlert === true

--- a/src/renderer/src/pages/settings/settings-context-content-gameplay.tsx
+++ b/src/renderer/src/pages/settings/settings-context-content-gameplay.tsx
@@ -35,7 +35,7 @@ export function SettingsContextContentGameplay() {
     disableNsfwAlert: false,
     showHiddenAchievementsDescription: false,
     enableSteamAchievements: false,
-    enableAchievementSouvenirs: false,
+    enableAchievementSouvenirs: true,
     enableNewDownloadOptionsBadges: true,
     hideClassicsBookmark: false,
     classicsUseHeroLayout: false,
@@ -60,7 +60,7 @@ export function SettingsContextContentGameplay() {
         userPreferences.showHiddenAchievementsDescription ?? false,
       enableSteamAchievements: userPreferences.enableSteamAchievements ?? false,
       enableAchievementSouvenirs:
-        userPreferences.enableAchievementSouvenirs ?? false,
+        userPreferences.enableAchievementSouvenirs ?? true,
       enableNewDownloadOptionsBadges:
         userPreferences.enableNewDownloadOptionsBadges ?? true,
       hideClassicsBookmark: userPreferences.hideClassicsBookmark ?? false,


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## Summary

- enable achievement souvenirs when the preference has not been set
- default the souvenir toggle to on in desktop and Big Picture settings
- preserve explicit user opt-outs

## Testing

- yarn typecheck
- Prettier check on changed files
- yarn test: 490 passed; 2 unrelated macOS cloud-save path failures reproduced on main