### PR TITLE
fix(souvenirs): cap achievements per souvenir

### DIFF
--- a/src/big-picture/src/pages/settings/content.tsx
+++ b/src/big-picture/src/pages/settings/content.tsx
@@ -23,6 +23,7 @@ import {
   SETTINGS_HEADER_RETURN_TARGET,
 } from "./settings-navigation";
 import { SettingsSection } from "./settings-section";
+import { isAchievementSouvenirsEnabled } from "@shared";
 
 interface SettingsSectionProps {
   className?: string;
@@ -49,7 +50,10 @@ const DEFAULT_FORM: ContentForm = {
   disableNsfwAlert: false,
   showHiddenAchievementsDescription: false,
   enableSteamAchievements: false,
-  enableAchievementSouvenirs: true,
+  enableAchievementSouvenirs: isAchievementSouvenirsEnabled(
+    undefined,
+    globalThis.window.electron.platform
+  ),
 };
 
 export function ContentSettingsSection({
@@ -78,8 +82,10 @@ export function ContentSettingsSection({
       showHiddenAchievementsDescription:
         userPreferences.showHiddenAchievementsDescription ?? false,
       enableSteamAchievements: userPreferences.enableSteamAchievements ?? false,
-      enableAchievementSouvenirs:
-        userPreferences.enableAchievementSouvenirs ?? true,
+      enableAchievementSouvenirs: isAchievementSouvenirsEnabled(
+        userPreferences.enableAchievementSouvenirs,
+        globalThis.window.electron.platform
+      ),
     });
   }, [userPreferences]);
 

--- a/src/main/services/achievements/grouped-souvenir-payload.test.ts
+++ b/src/main/services/achievements/grouped-souvenir-payload.test.ts
@@ -9,6 +9,10 @@ import {
   MAX_ACHIEVEMENTS_PER_SOUVENIR,
 } from "./grouped-souvenir-payload.js";
 
+const SMALL_UNLOCK_COUNT = 3;
+const BULK_UNLOCK_COUNT = 125;
+const CAPTURED_AT = 1_787_342_400_000;
+
 const buildAchievements = (count: number): PendingSouvenirAchievement[] =>
   Array.from({ length: count }, (_, index) => ({
     name: `ACHIEVEMENT_${index + 1}`,
@@ -17,7 +21,7 @@ const buildAchievements = (count: number): PendingSouvenirAchievement[] =>
 
 describe("grouped souvenir payload", () => {
   it("keeps every achievement when the souvenir is within the API limit", () => {
-    const achievements = buildAchievements(3);
+    const achievements = buildAchievements(SMALL_UNLOCK_COUNT);
 
     assert.deepEqual(getGroupedSouvenirAchievementNames(achievements), [
       "ACHIEVEMENT_1",
@@ -27,10 +31,10 @@ describe("grouped souvenir payload", () => {
   });
 
   it("limits a souvenir to 50 achievements while syncing every achievement", () => {
-    const achievements = buildAchievements(125);
+    const achievements = buildAchievements(BULK_UNLOCK_COUNT);
     const payload = buildGroupedSouvenirSyncPayload(
       {
-        capturedAt: 1,
+        capturedAt: CAPTURED_AT,
         clientId: "client-id",
         imageKey: "achievement/image.jpeg",
         remoteGameId: "game-id",
@@ -42,7 +46,10 @@ describe("grouped souvenir payload", () => {
 
     assert.equal(achievementNames?.length, MAX_ACHIEVEMENTS_PER_SOUVENIR);
     assert.equal(achievementNames?.[0], "ACHIEVEMENT_1");
-    assert.equal(achievementNames?.at(-1), "ACHIEVEMENT_50");
-    assert.equal(payload.achievements.length, 125);
+    assert.equal(
+      achievementNames?.at(-1),
+      `ACHIEVEMENT_${MAX_ACHIEVEMENTS_PER_SOUVENIR}`
+    );
+    assert.equal(payload.achievements.length, BULK_UNLOCK_COUNT);
   });
 });

--- a/src/main/services/achievements/grouped-souvenir-payload.test.ts
+++ b/src/main/services/achievements/grouped-souvenir-payload.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { PendingSouvenirAchievement } from "@types";
+
+import {
+  buildGroupedSouvenirSyncPayload,
+  getGroupedSouvenirAchievementNames,
+  MAX_ACHIEVEMENTS_PER_SOUVENIR,
+} from "./grouped-souvenir-payload.js";
+
+const buildAchievements = (count: number): PendingSouvenirAchievement[] =>
+  Array.from({ length: count }, (_, index) => ({
+    name: `ACHIEVEMENT_${index + 1}`,
+    unlockTime: index + 1,
+  }));
+
+describe("grouped souvenir payload", () => {
+  it("keeps every achievement when the souvenir is within the API limit", () => {
+    const achievements = buildAchievements(3);
+
+    assert.deepEqual(getGroupedSouvenirAchievementNames(achievements), [
+      "ACHIEVEMENT_1",
+      "ACHIEVEMENT_2",
+      "ACHIEVEMENT_3",
+    ]);
+  });
+
+  it("limits a souvenir to 50 achievements while syncing every achievement", () => {
+    const achievements = buildAchievements(125);
+    const payload = buildGroupedSouvenirSyncPayload(
+      {
+        capturedAt: 1,
+        clientId: "client-id",
+        imageKey: "achievement/image.jpeg",
+        remoteGameId: "game-id",
+      },
+      achievements,
+      true
+    );
+    const achievementNames = payload.souvenirs?.[0].achievementNames;
+
+    assert.equal(achievementNames?.length, MAX_ACHIEVEMENTS_PER_SOUVENIR);
+    assert.equal(achievementNames?.[0], "ACHIEVEMENT_1");
+    assert.equal(achievementNames?.at(-1), "ACHIEVEMENT_50");
+    assert.equal(payload.achievements.length, 125);
+  });
+});

--- a/src/main/services/achievements/grouped-souvenir-payload.ts
+++ b/src/main/services/achievements/grouped-souvenir-payload.ts
@@ -1,0 +1,37 @@
+import type {
+  PendingAchievementSouvenir,
+  PendingSouvenirAchievement,
+} from "@types";
+
+export const MAX_ACHIEVEMENTS_PER_SOUVENIR = 50;
+
+export const getGroupedSouvenirAchievementNames = (
+  achievements: PendingSouvenirAchievement[]
+) =>
+  achievements
+    .slice(0, MAX_ACHIEVEMENTS_PER_SOUVENIR)
+    .map((achievement) => achievement.name);
+
+type GroupedSouvenirPayloadSource = Pick<
+  PendingAchievementSouvenir,
+  "capturedAt" | "clientId" | "imageKey" | "remoteGameId"
+>;
+
+export const buildGroupedSouvenirSyncPayload = (
+  pending: GroupedSouvenirPayloadSource,
+  achievements: PendingSouvenirAchievement[],
+  includeSouvenir: boolean
+) => ({
+  id: pending.remoteGameId,
+  achievements,
+  ...(includeSouvenir && {
+    souvenirs: [
+      {
+        clientId: pending.clientId,
+        imageKey: pending.imageKey!,
+        capturedAt: pending.capturedAt,
+        achievementNames: getGroupedSouvenirAchievementNames(achievements),
+      },
+    ],
+  }),
+});

--- a/src/main/services/achievements/grouped-souvenir-worker.ts
+++ b/src/main/services/achievements/grouped-souvenir-worker.ts
@@ -41,6 +41,7 @@ import {
   prepareAchievementSouvenirForRetry,
 } from "./grouped-souvenir-sync-status";
 import { getGameAchievementData } from "./get-game-achievement-data";
+import { buildGroupedSouvenirSyncPayload } from "./grouped-souvenir-payload";
 
 const CONCURRENT_UPDATE_ATTEMPTS = 3;
 const CONCURRENT_UPDATE_RETRY_DELAY_MS = 250;
@@ -203,25 +204,6 @@ const reconcileAchievementMemory = async (
   }
 };
 
-const buildAchievementSyncPayload = (
-  pending: PendingAchievementSouvenir,
-  achievements: PendingSouvenirAchievement[],
-  includeSouvenir: boolean
-) => ({
-  id: pending.remoteGameId,
-  achievements,
-  ...(includeSouvenir && {
-    souvenirs: [
-      {
-        clientId: pending.clientId,
-        imageKey: pending.imageKey!,
-        capturedAt: pending.capturedAt,
-        achievementNames: achievements.map((achievement) => achievement.name),
-      },
-    ],
-  }),
-});
-
 const synchronizeAchievements = (
   pending: PendingAchievementSouvenir,
   achievements: PendingSouvenirAchievement[],
@@ -229,7 +211,7 @@ const synchronizeAchievements = (
 ) =>
   HydraApi.put<UpdatedUnlockedAchievements>(
     "/profile/games/achievements",
-    buildAchievementSyncPayload(pending, achievements, includeSouvenir)
+    buildGroupedSouvenirSyncPayload(pending, achievements, includeSouvenir)
   );
 
 const waitForConcurrentUpdate = (attempt: number) =>

--- a/src/main/services/achievements/merge-achievements.ts
+++ b/src/main/services/achievements/merge-achievements.ts
@@ -8,6 +8,7 @@ import type {
   User,
   UserPreferences,
 } from "@types";
+import { isAchievementSouvenirsEnabled } from "@shared";
 import { randomUUID } from "node:crypto";
 import { WindowManager } from "../window-manager";
 import { HydraApi } from "../hydra-api";
@@ -43,7 +44,10 @@ const captureAchievementSouvenirs = async (
     !newAchievements.length ||
     !publishNotification ||
     !game.remoteId ||
-    userPreferences.enableAchievementSouvenirs === false ||
+    !isAchievementSouvenirsEnabled(
+      userPreferences.enableAchievementSouvenirs,
+      process.platform
+    ) ||
     !HydraApi.hasActiveSubscription()
   ) {
     return null;

--- a/src/main/services/emulators/emulator-souvenir-watcher.ts
+++ b/src/main/services/emulators/emulator-souvenir-watcher.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 
 import type { Game, User, UserPreferences } from "@types";
+import { isAchievementSouvenirsEnabled } from "@shared";
 
 import { INTERVALS } from "@main/constants";
 import { db, levelKeys } from "@main/level";
@@ -47,7 +48,10 @@ const isSouvenirCaptureEnabled = async () => {
     { valueEncoding: "json" }
   );
 
-  return userPreferences?.enableAchievementSouvenirs !== false;
+  return isAchievementSouvenirsEnabled(
+    userPreferences?.enableAchievementSouvenirs,
+    process.platform
+  );
 };
 
 const queueGroupedSouvenir = async (

--- a/src/main/services/emulators/prepare-emulator-souvenirs.ts
+++ b/src/main/services/emulators/prepare-emulator-souvenirs.ts
@@ -1,4 +1,5 @@
 import type { UserPreferences } from "@types";
+import { isAchievementSouvenirsEnabled } from "@shared";
 
 import { db, levelKeys } from "@main/level";
 import { HydraApi } from "../hydra-api";
@@ -19,7 +20,14 @@ export const prepareEmulatorSouvenirs = async (
     { valueEncoding: "json" }
   );
 
-  if (userPreferences?.enableAchievementSouvenirs === false) return null;
+  if (
+    !isAchievementSouvenirsEnabled(
+      userPreferences?.enableAchievementSouvenirs,
+      process.platform
+    )
+  ) {
+    return null;
+  }
 
   if (system === "ps1") {
     await enableDuckStationFileLogging();

--- a/src/main/services/linux-game-capture-session.ts
+++ b/src/main/services/linux-game-capture-session.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, desktopCapturer, nativeImage } from "electron";
 import type { UserPreferences } from "@types";
+import { isAchievementSouvenirsEnabled } from "@shared";
 import capturePagePath from "@resources/linux-game-capture.html?asset";
 
 import { db, levelKeys } from "@main/level";
@@ -103,7 +104,10 @@ export const prepareLinuxGameCaptureSession = async (gameKey: string) => {
     );
 
     if (
-      userPreferences?.enableAchievementSouvenirs === false ||
+      !isAchievementSouvenirsEnabled(
+        userPreferences?.enableAchievementSouvenirs,
+        process.platform
+      ) ||
       !HydraApi.hasActiveSubscription()
     ) {
       if (sessions.get(gameKey)?.token === token) sessions.delete(gameKey);

--- a/src/main/services/screenshot.ts
+++ b/src/main/services/screenshot.ts
@@ -14,6 +14,7 @@ import {
   isWaylandSession,
 } from "./linux-game-capture-session";
 import {
+  getWindowsProcessAncestryDiagnostics,
   isWindowsGameForegroundProcess,
   isWindowsWindowSource,
 } from "./windows-game-window-match";
@@ -188,8 +189,13 @@ const resolveWindowsGameWindowSource = async (
 
   if (!belongsToGame) {
     logger.warn("Windows game capture rejected the foreground process", {
+      executablePaths: captureTarget.executablePaths ?? [],
       foregroundProcessId: foregroundWindow.processId,
       launchedProcessId: captureTarget.processId,
+      processAncestry: getWindowsProcessAncestryDiagnostics(
+        processes,
+        foregroundWindow.processId
+      ),
       windowHandle,
     });
     throw new Error("Tracked game does not own the foreground window");

--- a/src/main/services/windows-game-window-match.test.ts
+++ b/src/main/services/windows-game-window-match.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  getWindowsProcessAncestryDiagnostics,
   isWindowsGameForegroundProcess,
   isWindowsWindowSource,
 } from "./windows-game-window-match.js";
@@ -153,5 +154,71 @@ describe("Windows game window source matching", () => {
 
   it("rejects malformed source IDs", () => {
     assert.equal(isWindowsWindowSource("screen:12345:0", "12345"), false);
+  });
+});
+
+describe("Windows process ancestry diagnostics", () => {
+  it("describes the foreground process and its parents", () => {
+    assert.deepEqual(
+      getWindowsProcessAncestryDiagnostics(
+        [
+          {
+            pid: 20,
+            parentPid: 10,
+            exe: "C:\\Games\\game.exe",
+            name: "game.exe",
+          },
+          {
+            pid: 10,
+            parentPid: null,
+            exe: "C:\\Games\\launcher.exe",
+            name: "launcher.exe",
+          },
+        ],
+        20
+      ),
+      [
+        {
+          pid: 20,
+          parentPid: 10,
+          exe: "C:\\Games\\game.exe",
+          name: "game.exe",
+          processFound: true,
+        },
+        {
+          pid: 10,
+          parentPid: null,
+          exe: "C:\\Games\\launcher.exe",
+          name: "launcher.exe",
+          processFound: true,
+        },
+      ]
+    );
+  });
+
+  it("records when process enumeration is missing a parent", () => {
+    assert.deepEqual(
+      getWindowsProcessAncestryDiagnostics(
+        [
+          {
+            pid: 20,
+            parentPid: 10,
+            exe: "C:\\Games\\game.exe",
+            name: "game.exe",
+          },
+        ],
+        20
+      ),
+      [
+        {
+          pid: 20,
+          parentPid: 10,
+          exe: "C:\\Games\\game.exe",
+          name: "game.exe",
+          processFound: true,
+        },
+        { pid: 10, processFound: false },
+      ]
+    );
   });
 });

--- a/src/main/services/windows-game-window-match.ts
+++ b/src/main/services/windows-game-window-match.ts
@@ -45,6 +45,45 @@ export const isWindowsGameForegroundProcess = (
   return false;
 };
 
+export const getWindowsProcessAncestryDiagnostics = (
+  processes: Pick<ProcessPayload, "exe" | "name" | "pid" | "parentPid">[],
+  foregroundProcessId: number
+) => {
+  const processById = new Map(
+    processes.map((candidate) => [candidate.pid, candidate])
+  );
+  const ancestry: Array<{
+    exe?: string | null;
+    name?: string;
+    parentPid?: number | null;
+    pid: number;
+    processFound: boolean;
+  }> = [];
+  const visited = new Set<number>();
+  let currentProcessId: number | null | undefined = foregroundProcessId;
+
+  while (currentProcessId != null && !visited.has(currentProcessId)) {
+    visited.add(currentProcessId);
+    const currentProcess = processById.get(currentProcessId);
+
+    if (!currentProcess) {
+      ancestry.push({ pid: currentProcessId, processFound: false });
+      break;
+    }
+
+    ancestry.push({
+      exe: currentProcess.exe,
+      name: currentProcess.name,
+      parentPid: currentProcess.parentPid,
+      pid: currentProcess.pid,
+      processFound: true,
+    });
+    currentProcessId = currentProcess.parentPid;
+  }
+
+  return ancestry;
+};
+
 const normalizeWindowsHandle = (value: string) => {
   try {
     return BigInt(value).toString();

--- a/src/renderer/src/pages/profile/profile-content/profile-content.tsx
+++ b/src/renderer/src/pages/profile/profile-content/profile-content.tsx
@@ -17,6 +17,7 @@ import {
 import { setHeaderTitle } from "@renderer/features";
 import { useTranslation } from "react-i18next";
 import type { GameShop } from "@types";
+import { isAchievementSouvenirsEnabled } from "@shared";
 import { LockedProfile } from "./locked-profile";
 import { ReportProfile } from "../report-profile/report-profile";
 import { BadgesBox } from "./badges-box";
@@ -122,8 +123,11 @@ export function ProfileContent() {
   const requestedTab = searchParams.get("tab");
   const requestedSouvenir = searchParams.get("souvenir");
   const attemptedDeepLinkPagesRef = useRef(new Set<string>());
-  const souvenirsEnabled = useAppSelector(
-    (state) => state.userPreferences.value?.enableAchievementSouvenirs !== false
+  const souvenirsEnabled = useAppSelector((state) =>
+    isAchievementSouvenirsEnabled(
+      state.userPreferences.value?.enableAchievementSouvenirs,
+      window.electron.platform
+    )
   );
   const disableNsfwAlert = useAppSelector(
     (state) => state.userPreferences.value?.disableNsfwAlert === true

--- a/src/renderer/src/pages/profile/profile-content/profile-content.tsx
+++ b/src/renderer/src/pages/profile/profile-content/profile-content.tsx
@@ -17,7 +17,12 @@ import {
 import { setHeaderTitle } from "@renderer/features";
 import { useTranslation } from "react-i18next";
 import type { GameShop } from "@types";
-import { isAchievementSouvenirsEnabled } from "@shared";
+import {
+  AuthPage,
+  findSouvenirByNotificationTarget,
+  isAchievementSouvenirsEnabled,
+  useSouvenirContentWarning,
+} from "@shared";
 import { LockedProfile } from "./locked-profile";
 import { ReportProfile } from "../report-profile/report-profile";
 import { BadgesBox } from "./badges-box";
@@ -36,11 +41,6 @@ import { SouvenirLightbox } from "./souvenir-lightbox";
 import { useSouvenirActions } from "./use-souvenir-actions";
 import type { ProfilePlatform } from "./library-tab";
 import { AnimatePresence } from "framer-motion";
-import {
-  AuthPage,
-  findSouvenirByNotificationTarget,
-  useSouvenirContentWarning,
-} from "@shared";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { ConfirmationModal } from "@renderer/components";
 import "./profile-content.scss";

--- a/src/renderer/src/pages/settings/settings-context-content-gameplay.tsx
+++ b/src/renderer/src/pages/settings/settings-context-content-gameplay.tsx
@@ -16,6 +16,7 @@ import {
   QuestionIcon,
 } from "@primer/octicons-react";
 import { useLocation } from "react-router-dom";
+import { isAchievementSouvenirsEnabled } from "@shared";
 
 import "./settings-behavior.scss";
 
@@ -35,7 +36,10 @@ export function SettingsContextContentGameplay() {
     disableNsfwAlert: false,
     showHiddenAchievementsDescription: false,
     enableSteamAchievements: false,
-    enableAchievementSouvenirs: true,
+    enableAchievementSouvenirs: isAchievementSouvenirsEnabled(
+      undefined,
+      window.electron.platform
+    ),
     enableNewDownloadOptionsBadges: true,
     hideClassicsBookmark: false,
     classicsUseHeroLayout: false,
@@ -59,8 +63,10 @@ export function SettingsContextContentGameplay() {
       showHiddenAchievementsDescription:
         userPreferences.showHiddenAchievementsDescription ?? false,
       enableSteamAchievements: userPreferences.enableSteamAchievements ?? false,
-      enableAchievementSouvenirs:
-        userPreferences.enableAchievementSouvenirs ?? true,
+      enableAchievementSouvenirs: isAchievementSouvenirsEnabled(
+        userPreferences.enableAchievementSouvenirs,
+        window.electron.platform
+      ),
       enableNewDownloadOptionsBadges:
         userPreferences.enableNewDownloadOptionsBadges ?? true,
       hideClassicsBookmark: userPreferences.hideClassicsBookmark ?? false,

--- a/src/shared/souvenirs.test.ts
+++ b/src/shared/souvenirs.test.ts
@@ -11,6 +11,7 @@ import {
   getPrimarySouvenirAchievement,
   getSouvenirKey,
   getSouvenirVisualVariant,
+  isAchievementSouvenirsEnabled,
   findSouvenirByNotificationTarget,
   normalizeProfileSouvenir,
   normalizeSouvenirReportValues,
@@ -18,6 +19,17 @@ import {
 } from "./souvenirs.js";
 
 describe("souvenir API helpers", () => {
+  it("defaults souvenirs off on Linux and on elsewhere", () => {
+    assert.equal(isAchievementSouvenirsEnabled(undefined, "linux"), false);
+    assert.equal(isAchievementSouvenirsEnabled(undefined, "win32"), true);
+    assert.equal(isAchievementSouvenirsEnabled(undefined, "darwin"), true);
+  });
+
+  it("preserves an explicit souvenir preference on every platform", () => {
+    assert.equal(isAchievementSouvenirsEnabled(true, "linux"), true);
+    assert.equal(isAchievementSouvenirsEnabled(false, "win32"), false);
+  });
+
   it("builds an encoded paginated feed path", () => {
     const path = buildUserSouvenirsPath({
       userId: "user/id",

--- a/src/shared/souvenirs.ts
+++ b/src/shared/souvenirs.ts
@@ -9,6 +9,11 @@ import { SteamContentDescriptor } from "./constants.js";
 
 export const SOUVENIRS_PAGE_SIZE = 24;
 
+export const isAchievementSouvenirsEnabled = (
+  preference: boolean | undefined,
+  platform: string
+) => preference ?? platform !== "linux";
+
 export type SouvenirVisualVariant = "rare" | "platinum";
 
 interface SouvenirRarity {


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the Hydra documentation.
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## Summary

- Limit each grouped souvenir to 50 linked achievements.
- Keep the complete achievement list in the synchronization payload.
- Add regression coverage for a 125-achievement bulk unlock.

## Testing

- Grouped souvenir payload tests pass.
- Node and web typechecks pass.
- Focused lint and formatting checks pass.
- Full suite: 492 pass; 2 unrelated cloud-save custom-path tests fail because the worktree path resolves through a protected macOS symlink.