### PR TITLE
fix: split oversized grouped souvenirs

### DIFF
--- a/src/main/services/achievements/grouped-souvenir-payload.test.ts
+++ b/src/main/services/achievements/grouped-souvenir-payload.test.ts
@@ -5,6 +5,7 @@ import type { PendingSouvenirAchievement } from "@types";
 
 import {
   buildGroupedSouvenirSyncPayload,
+  chunkGroupedSouvenirAchievements,
   getGroupedSouvenirAchievementNames,
   MAX_ACHIEVEMENTS_PER_SOUVENIR,
 } from "./grouped-souvenir-payload.js";
@@ -51,5 +52,26 @@ describe("grouped souvenir payload", () => {
       `ACHIEVEMENT_${MAX_ACHIEVEMENTS_PER_SOUVENIR}`
     );
     assert.equal(payload.achievements.length, BULK_UNLOCK_COUNT);
+  });
+
+  it("splits oversized unlock batches without dropping achievements", () => {
+    const achievements = buildAchievements(BULK_UNLOCK_COUNT);
+    const chunks = chunkGroupedSouvenirAchievements(achievements);
+
+    assert.deepEqual(
+      chunks.map((chunk) => chunk.length),
+      [50, 50, 25]
+    );
+    assert.deepEqual(chunks.flat(), achievements);
+  });
+
+  it("starts a new souvenir when the batch exceeds the limit by one", () => {
+    const achievements = buildAchievements(MAX_ACHIEVEMENTS_PER_SOUVENIR + 1);
+    const chunks = chunkGroupedSouvenirAchievements(achievements);
+
+    assert.deepEqual(
+      chunks.map((chunk) => chunk.length),
+      [MAX_ACHIEVEMENTS_PER_SOUVENIR, 1]
+    );
   });
 });

--- a/src/main/services/achievements/grouped-souvenir-payload.ts
+++ b/src/main/services/achievements/grouped-souvenir-payload.ts
@@ -5,6 +5,24 @@ import type {
 
 export const MAX_ACHIEVEMENTS_PER_SOUVENIR = 50;
 
+export const chunkGroupedSouvenirAchievements = (
+  achievements: PendingSouvenirAchievement[]
+) => {
+  const chunks: PendingSouvenirAchievement[][] = [];
+
+  for (
+    let index = 0;
+    index < achievements.length;
+    index += MAX_ACHIEVEMENTS_PER_SOUVENIR
+  ) {
+    chunks.push(
+      achievements.slice(index, index + MAX_ACHIEVEMENTS_PER_SOUVENIR)
+    );
+  }
+
+  return chunks;
+};
+
 export const getGroupedSouvenirAchievementNames = (
   achievements: PendingSouvenirAchievement[]
 ) =>

--- a/src/main/services/achievements/grouped-souvenir-store.ts
+++ b/src/main/services/achievements/grouped-souvenir-store.ts
@@ -12,6 +12,18 @@ export const PendingGroupedSouvenirStore = {
   put: (souvenir: PendingAchievementSouvenir) =>
     pendingGroupedAchievementSouvenirsSublevel.put(souvenir.clientId, souvenir),
 
+  async putMany(souvenirs: PendingAchievementSouvenir[]) {
+    const batch = db.batch();
+
+    for (const souvenir of souvenirs) {
+      batch.put(souvenir.clientId, souvenir, {
+        sublevel: pendingGroupedAchievementSouvenirsSublevel,
+      });
+    }
+
+    await batch.write();
+  },
+
   delete: (clientId: string) =>
     pendingGroupedAchievementSouvenirsSublevel.del(clientId),
 
@@ -36,6 +48,18 @@ export const PendingGroupedSouvenirStore = {
       .values()
       .all();
     return new Set(pending.map((souvenir) => souvenir.screenshotPath));
+  },
+
+  async hasScreenshotPathReference(screenshotPath: string) {
+    const [pending, assets] = await Promise.all([
+      pendingGroupedAchievementSouvenirsSublevel.values().all(),
+      localSouvenirAssetsSublevel.values().all(),
+    ]);
+
+    return (
+      pending.some((souvenir) => souvenir.screenshotPath === screenshotPath) ||
+      assets.some((asset) => asset.screenshotPath === screenshotPath)
+    );
   },
 
   async acknowledge(pending: PendingAchievementSouvenir, souvenirId: string) {

--- a/src/main/services/achievements/grouped-souvenir-worker.ts
+++ b/src/main/services/achievements/grouped-souvenir-worker.ts
@@ -168,6 +168,13 @@ const cleanupExpiredTerminalRecords = async (
     }
 
     await PendingGroupedSouvenirStore.delete(souvenir.clientId);
+    if (
+      await PendingGroupedSouvenirStore.hasScreenshotPathReference(
+        souvenir.screenshotPath
+      )
+    ) {
+      continue;
+    }
     await fs.promises
       .rm(souvenir.screenshotPath, { force: true })
       .catch((error) => {
@@ -733,6 +740,14 @@ export const cleanupAchievementSouvenirSync =
     const failedFilePaths: string[] = [];
 
     for (const souvenir of ownedSouvenirs) {
+      await PendingGroupedSouvenirStore.delete(souvenir.clientId);
+
+      const isReferenced =
+        await PendingGroupedSouvenirStore.hasScreenshotPathReference(
+          souvenir.screenshotPath
+        );
+      if (isReferenced) continue;
+
       try {
         await fs.promises.rm(souvenir.screenshotPath, { force: true });
       } catch (error) {
@@ -742,8 +757,6 @@ export const cleanupAchievementSouvenirSync =
           { clientId: souvenir.clientId, error }
         );
       }
-
-      await PendingGroupedSouvenirStore.delete(souvenir.clientId);
     }
 
     const status = await publishAchievementSouvenirSyncStatus();
@@ -763,8 +776,14 @@ export const deleteLocalSouvenirAsset = async (souvenirId: string) => {
   const asset = await LocalSouvenirAssetStore.get(souvenirId).catch(() => null);
   if (!asset) return;
 
-  await fs.promises.rm(asset.screenshotPath, { force: true });
   await LocalSouvenirAssetStore.delete(souvenirId);
+  const isReferenced =
+    await PendingGroupedSouvenirStore.hasScreenshotPathReference(
+      asset.screenshotPath
+    );
+  if (!isReferenced) {
+    await fs.promises.rm(asset.screenshotPath, { force: true });
+  }
 };
 
 const deletePendingSouvenirs = async (
@@ -775,6 +794,13 @@ const deletePendingSouvenirs = async (
   for (const souvenir of pending) {
     if (!matches(souvenir)) continue;
     await PendingGroupedSouvenirStore.delete(souvenir.clientId);
+    if (
+      await PendingGroupedSouvenirStore.hasScreenshotPathReference(
+        souvenir.screenshotPath
+      )
+    ) {
+      continue;
+    }
     await fs.promises
       .rm(souvenir.screenshotPath, { force: true })
       .catch((error) => {

--- a/src/main/services/achievements/merge-achievements.ts
+++ b/src/main/services/achievements/merge-achievements.ts
@@ -24,6 +24,7 @@ import { ScreenshotService } from "../screenshot";
 import { PendingAchievementSouvenirStore } from "./pending-achievement-souvenir-store";
 import { PendingGroupedSouvenirStore } from "./grouped-souvenir-store";
 import { groupedSouvenirWorker } from "./grouped-souvenir-worker";
+import { chunkGroupedSouvenirAchievements } from "./grouped-souvenir-payload";
 import { launchedGamePids } from "../launched-game-pids";
 import { Wine } from "../wine";
 
@@ -50,11 +51,10 @@ const captureAchievementSouvenirs = async (
     ) ||
     !HydraApi.hasActiveSubscription()
   ) {
-    return null;
+    return [];
   }
 
   const gameKey = levelKeys.game(game.shop, game.objectId);
-  const clientId = randomUUID();
   const capturedAt = Date.now();
   let screenshotPath: string | null = null;
 
@@ -62,7 +62,16 @@ const captureAchievementSouvenirs = async (
     const owner = await db.get<string, User>(levelKeys.user, {
       valueEncoding: "json",
     });
-    if (!owner?.id) return null;
+    if (!owner?.id) return [];
+
+    const achievementChunks = chunkGroupedSouvenirAchievements(
+      newAchievements.map((achievement) => ({
+        name: achievement.name,
+        unlockTime: achievement.unlockTime,
+        ...(achievement.hardcoreUnlockTime != null && { hardcore: true }),
+      }))
+    );
+    const clientIds = achievementChunks.map(() => randomUUID());
 
     const primaryAchievement = newAchievements[0];
     const displayName =
@@ -99,7 +108,7 @@ const captureAchievementSouvenirs = async (
       game.title,
       displayName,
       game.remoteId,
-      clientId,
+      clientIds[0]!,
       {
         processId: expectedProcessId,
         executablePaths,
@@ -108,23 +117,26 @@ const captureAchievementSouvenirs = async (
       }
     );
 
-    const pending = {
-      clientId,
+    const pendingSouvenirs = achievementChunks.map((achievements, index) => ({
+      clientId: clientIds[index]!,
       ownerId: owner.id,
-      remoteGameId: game.remoteId,
+      remoteGameId: game.remoteId!,
       gameKey,
-      screenshotPath,
+      screenshotPath: screenshotPath!,
       capturedAt,
-      achievements: newAchievements.map((achievement) => ({
-        name: achievement.name,
-        unlockTime: achievement.unlockTime,
-        ...(achievement.hardcoreUnlockTime != null && { hardcore: true }),
-      })),
+      achievements,
       status: "pending" as const,
       attemptCount: 0,
-    };
-    await PendingGroupedSouvenirStore.put(pending);
-    return pending;
+    }));
+    await PendingGroupedSouvenirStore.putMany(pendingSouvenirs);
+    achievementsLogger.info("Queued grouped achievement souvenirs", {
+      gameObjectId: game.objectId,
+      souvenirCount: pendingSouvenirs.length,
+      achievementCounts: pendingSouvenirs.map(
+        (souvenir) => souvenir.achievements.length
+      ),
+    });
+    return pendingSouvenirs;
   } catch (error) {
     if (screenshotPath) {
       await ScreenshotService.deleteScreenshot(screenshotPath).catch(() => {});
@@ -135,7 +147,7 @@ const captureAchievementSouvenirs = async (
       newAchievements.map((achievement) => achievement.name),
       error
     );
-    return null;
+    return [];
   }
 };
 
@@ -317,7 +329,7 @@ export const mergeAchievements = async (
       return imageKey ? { ...achievement, imageKey } : achievement;
     });
 
-  const pendingGroupedSouvenir = await captureAchievementSouvenirs(
+  const pendingGroupedSouvenirs = await captureAchievementSouvenirs(
     game,
     newAchievements,
     achievementsData,
@@ -397,7 +409,7 @@ export const mergeAchievements = async (
     );
   }
 
-  if (pendingGroupedSouvenir) void groupedSouvenirWorker.trigger();
+  if (pendingGroupedSouvenirs.length) void groupedSouvenirWorker.trigger();
 
   return newAchievements.length;
 };

--- a/src/main/services/screenshot.ts
+++ b/src/main/services/screenshot.ts
@@ -411,9 +411,12 @@ export class ScreenshotService {
       const protectedPaths =
         await PendingGroupedSouvenirStore.getProtectedScreenshotPaths();
       const assets = await LocalSouvenirAssetStore.list();
+      const uniqueAssets = Array.from(
+        new Map(assets.map((asset) => [asset.screenshotPath, asset])).values()
+      );
       const screenshots = (
         await Promise.all(
-          assets.map(async (asset) => {
+          uniqueAssets.map(async (asset) => {
             const stat = await fs.promises
               .stat(asset.screenshotPath)
               .catch(() => null);


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## Summary

- split achievement unlock batches into souvenirs containing at most 50 achievements
- capture one frame and enqueue each chunk with its own upload identity
- preserve shared local screenshot files until the final related souvenir is removed
- deduplicate shared screenshot paths during local retention cleanup

## Testing

- grouped souvenir payload, retry-policy, and sync-status tests
- focused ESLint
- Node typecheck
- full pre-push lint and Node/web typechecks