### PR TITLE
feat: scan additional drive letters (E-I) for Games and SteamLibrary …

### DIFF
--- a/src/main/events/library/scan-installed-games.ts
+++ b/src/main/events/library/scan-installed-games.ts
@@ -28,9 +28,19 @@ import type { Game, GameShop } from "@types";
 const SCAN_DIRECTORIES = [
   String.raw`C:\Games`,
   String.raw`D:\Games`,
+  String.raw`E:\Games`,
+  String.raw`F:\Games`,
+  String.raw`G:\Games`,
+  String.raw`H:\Games`,
+  String.raw`I:\Games`,
   String.raw`C:\Program Files (x86)\Steam\steamapps\common`,
   String.raw`C:\Program Files\Steam\steamapps\common`,
   String.raw`D:\SteamLibrary\steamapps\common`,
+  String.raw`E:\SteamLibrary\steamapps\common`,
+  String.raw`F:\SteamLibrary\steamapps\common`,
+  String.raw`G:\SteamLibrary\steamapps\common`,
+  String.raw`H:\SteamLibrary\steamapps\common`,
+  String.raw`I:\SteamLibrary\steamapps\common`,
 ];
 
 const DISCOVERED_GAMES_SHOP: GameShop = "steam";


### PR DESCRIPTION
…folders

<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

## What
Adds drive letters E: through I: to the default `SCAN_DIRECTORIES` list used
by the installed-games scanner, for both:
- `\Games`
- `\SteamLibrary\steamapps\common`

## Why
The current defaults only check `C:` and `D:`. Users with more than two
drives/partitions dedicated to games (common with multi-SSD or SSD+HDD
setups) won't get their libraries auto-detected on those extra drives
unless they add each folder manually every time.

## Testing
- Ran the project locally and confirmed no TypeScript errors were
  introduced by this change.
