### PR TITLE
fix(reviews): prevent banner overflow

### DIFF
--- a/src/renderer/src/pages/game-details/review-item.scss
+++ b/src/renderer/src/pages/game-details/review-item.scss
@@ -15,6 +15,8 @@
     position: relative;
 
     &--has-bg {
+      width: 100%;
+      box-sizing: border-box;
       aspect-ratio: 388 / 56;
       min-height: 76px;
       max-height: 132px;

--- a/src/renderer/src/pages/game-details/review-replies.scss
+++ b/src/renderer/src/pages/game-details/review-replies.scss
@@ -63,6 +63,8 @@
     }
 
     &--has-bg {
+      width: 100%;
+      box-sizing: border-box;
       aspect-ratio: 388 / 56;
       min-height: 64px;
       max-height: 110px;


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## Summary

- Constrain review banners to the width of their review cards.
- Apply the same sizing fix to reply banners.
- Keep the banner minimum height without letting its aspect ratio force horizontal overflow at narrow widths.

## Testing

- yarn prettier --check src/renderer/src/pages/game-details/review-item.scss src/renderer/src/pages/game-details/review-replies.scss
- yarn typecheck:web
- Pre-push lint and full typecheck hooks
- Verified in the Electron dev app at the narrow layout shown in the report
