### PR TITLE
feat(linux): run native executables without Proton

### DIFF
--- a/src/main/events/library/get-game-installer-action-type.ts
+++ b/src/main/events/library/get-game-installer-action-type.ts
@@ -35,12 +35,6 @@ const getGameInstallerActionType = async (
     return "open-folder";
   }
 
-  if (process.platform === "linux") {
-    if (fs.existsSync(path.join(gamePath, "setup.sh"))) {
-      return "install";
-    }
-  }
-
   // Check for setup.exe
   const setupPath = path.join(gamePath, "setup.exe");
   if (fs.existsSync(setupPath)) {
@@ -49,6 +43,17 @@ const getGameInstallerActionType = async (
 
   // Check if there's exactly one .exe file
   const gamePathFileNames = fs.readdirSync(gamePath);
+
+  if (process.platform === "linux") {
+    const hasSetupSh = gamePathFileNames.some(
+      (fileName: string) => fileName.toLowerCase() === "setup.sh"
+    );
+
+    if (hasSetupSh) {
+      return "install";
+    }
+  }
+
   const gamePathExecutableFiles = gamePathFileNames.filter(
     (fileName: string) => path.extname(fileName).toLowerCase() === ".exe"
   );

--- a/src/main/events/library/get-game-installer-action-type.ts
+++ b/src/main/events/library/get-game-installer-action-type.ts
@@ -35,6 +35,12 @@ const getGameInstallerActionType = async (
     return "open-folder";
   }
 
+  if (process.platform === "linux") {
+    if (fs.existsSync(path.join(gamePath, "setup.sh"))) {
+      return "install";
+    }
+  }
+
   // Check for setup.exe
   const setupPath = path.join(gamePath, "setup.exe");
   if (fs.existsSync(setupPath)) {
@@ -47,15 +53,7 @@ const getGameInstallerActionType = async (
     (fileName: string) => path.extname(fileName).toLowerCase() === ".exe"
   );
 
-  if (gamePathExecutableFiles.length === 1) {
-    return "install";
-  }
-
   if (process.platform === "linux") {
-    if (fs.existsSync(path.join(gamePath, "setup.sh"))) {
-      return "install";
-    }
-
     const shellFiles = gamePathFileNames.filter(
       (fileName: string) => path.extname(fileName).toLowerCase() === ".sh"
     );
@@ -63,6 +61,10 @@ const getGameInstallerActionType = async (
     if (shellFiles.length === 1) {
       return "install";
     }
+  }
+
+  if (gamePathExecutableFiles.length === 1) {
+    return "install";
   }
 
   // Otherwise, opens folder

--- a/src/main/events/library/get-game-installer-action-type.ts
+++ b/src/main/events/library/get-game-installer-action-type.ts
@@ -51,6 +51,20 @@ const getGameInstallerActionType = async (
     return "install";
   }
 
+  if (process.platform === "linux") {
+    if (fs.existsSync(path.join(gamePath, "setup.sh"))) {
+      return "install";
+    }
+
+    const shellFiles = gamePathFileNames.filter(
+      (fileName: string) => path.extname(fileName).toLowerCase() === ".sh"
+    );
+
+    if (shellFiles.length === 1) {
+      return "install";
+    }
+  }
+
   // Otherwise, opens folder
   return "open-folder";
 };

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -8,6 +8,10 @@ import { registerEvent } from "../register-event";
 import { downloadsSublevel, gamesSublevel, levelKeys } from "@main/level";
 import { GameShop } from "@types";
 import { logger, Umu, Wine } from "@main/services";
+import {
+  isLinuxNativeExecutable,
+  isLinuxShellScript,
+} from "@main/helpers/linux-native-executable";
 
 const launchInstallerWithWine = async (filePath: string): Promise<boolean> => {
   return await new Promise<boolean>((resolve) => {
@@ -31,11 +35,17 @@ const launchInstallerWithWine = async (filePath: string): Promise<boolean> => {
 
 const launchInstallerDirectly = async (filePath: string): Promise<boolean> => {
   return await new Promise<boolean>((resolve) => {
-    const child = spawn(filePath, [], {
-      detached: true,
-      stdio: "ignore",
-      shell: false,
-    });
+    const useBash =
+      process.platform === "linux" && isLinuxShellScript(filePath);
+    const child = spawn(
+      useBash ? "/bin/bash" : filePath,
+      useBash ? [filePath] : [],
+      {
+        detached: true,
+        stdio: "ignore",
+        shell: false,
+      }
+    );
 
     child.once("spawn", () => {
       child.unref();
@@ -72,6 +82,15 @@ const executeGameInstaller = async (
   }
 
   if (process.platform === "linux") {
+    if (isLinuxNativeExecutable(filePath)) {
+      const launchedDirectly = await launchInstallerDirectly(filePath);
+      if (launchedDirectly) {
+        return true;
+      }
+
+      return await openPathAndCheck(filePath);
+    }
+
     try {
       await Umu.launchExecutable(filePath, [], {
         gameId: options?.gameId,
@@ -151,6 +170,23 @@ const openGameInstaller = async (
         protonPath: game?.protonPath,
       }
     );
+  }
+
+  if (process.platform === "linux") {
+    const setupShPath = path.join(gamePath, "setup.sh");
+    if (fs.existsSync(setupShPath)) {
+      return await executeGameInstaller(setupShPath, { gameId: objectId });
+    }
+
+    const shellFiles = gamePathFileNames.filter(
+      (fileName: string) => path.extname(fileName).toLowerCase() === ".sh"
+    );
+
+    if (shellFiles.length === 1) {
+      return await executeGameInstaller(path.join(gamePath, shellFiles[0]), {
+        gameId: objectId,
+      });
+    }
   }
 
   shell.openPath(gamePath);

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -38,7 +38,7 @@ const launchInstallerDirectly = async (filePath: string): Promise<boolean> => {
     const useBash =
       process.platform === "linux" && isLinuxShellScript(filePath);
     const child = spawn(
-      useBash ? "/bin/bash" : filePath,
+      useBash ? "bash" : filePath,
       useBash ? [filePath] : [],
       {
         detached: true,

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -148,10 +148,16 @@ const openGameInstaller = async (
     return true;
   }
 
+  const gamePathFileNames = fs.readdirSync(gamePath);
+
   if (process.platform === "linux") {
-    const setupShPath = path.join(gamePath, "setup.sh");
-    if (fs.existsSync(setupShPath)) {
-      return await executeGameInstaller(setupShPath, { gameId: objectId });
+    const setupShFileName = gamePathFileNames.find(
+      (fileName: string) => fileName.toLowerCase() === "setup.sh"
+    );
+    if (setupShFileName) {
+      return await executeGameInstaller(path.join(gamePath, setupShFileName), {
+        gameId: objectId,
+      });
     }
   }
 
@@ -164,7 +170,6 @@ const openGameInstaller = async (
     });
   }
 
-  const gamePathFileNames = fs.readdirSync(gamePath);
   const gamePathExecutableFiles = gamePathFileNames.filter(
     (fileName: string) => path.extname(fileName).toLowerCase() === ".exe"
   );

--- a/src/main/events/library/open-game-installer.ts
+++ b/src/main/events/library/open-game-installer.ts
@@ -44,6 +44,7 @@ const launchInstallerDirectly = async (filePath: string): Promise<boolean> => {
         detached: true,
         stdio: "ignore",
         shell: false,
+        cwd: path.dirname(filePath),
       }
     );
 
@@ -147,6 +148,13 @@ const openGameInstaller = async (
     return true;
   }
 
+  if (process.platform === "linux") {
+    const setupShPath = path.join(gamePath, "setup.sh");
+    if (fs.existsSync(setupShPath)) {
+      return await executeGameInstaller(setupShPath, { gameId: objectId });
+    }
+  }
+
   const setupPath = path.join(gamePath, "setup.exe");
   if (fs.existsSync(setupPath)) {
     return await executeGameInstaller(setupPath, {
@@ -161,23 +169,7 @@ const openGameInstaller = async (
     (fileName: string) => path.extname(fileName).toLowerCase() === ".exe"
   );
 
-  if (gamePathExecutableFiles.length === 1) {
-    return await executeGameInstaller(
-      path.join(gamePath, gamePathExecutableFiles[0]),
-      {
-        gameId: objectId,
-        winePrefixPath: effectiveWinePrefixPath,
-        protonPath: game?.protonPath,
-      }
-    );
-  }
-
   if (process.platform === "linux") {
-    const setupShPath = path.join(gamePath, "setup.sh");
-    if (fs.existsSync(setupShPath)) {
-      return await executeGameInstaller(setupShPath, { gameId: objectId });
-    }
-
     const shellFiles = gamePathFileNames.filter(
       (fileName: string) => path.extname(fileName).toLowerCase() === ".sh"
     );
@@ -187,6 +179,17 @@ const openGameInstaller = async (
         gameId: objectId,
       });
     }
+  }
+
+  if (gamePathExecutableFiles.length === 1) {
+    return await executeGameInstaller(
+      path.join(gamePath, gamePathExecutableFiles[0]),
+      {
+        gameId: objectId,
+        winePrefixPath: effectiveWinePrefixPath,
+        protonPath: game?.protonPath,
+      }
+    );
   }
 
   shell.openPath(gamePath);

--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -32,6 +32,7 @@ import { parseExecutablePath } from "../events/helpers/parse-executable-path";
 import { isGamemodeAvailable } from "./is-gamemode-available";
 import { isMangohudAvailable } from "./is-mangohud-available";
 import { resolveLaunchCommand } from "./resolve-launch-command";
+import { isLinuxShellScript } from "./linux-native-executable";
 import {
   buildWindowsBatchCommand,
   isWindowsBatchFile,
@@ -72,8 +73,11 @@ const launchNatively = (
   useGamemode = false
 ): number | null => {
   const workingDirectory = path.dirname(executablePath);
+  const useBash =
+    process.platform === "linux" && isLinuxShellScript(executablePath);
   const resolvedLaunchCommand = resolveLaunchCommand({
-    baseCommand: executablePath,
+    baseCommand: useBash ? "/bin/bash" : executablePath,
+    baseArgs: useBash ? [executablePath] : [],
     launchOptions,
     wrapperCommands: [
       ...(useGamemode ? ["gamemoderun"] : []),

--- a/src/main/helpers/launch-game.ts
+++ b/src/main/helpers/launch-game.ts
@@ -76,7 +76,7 @@ const launchNatively = (
   const useBash =
     process.platform === "linux" && isLinuxShellScript(executablePath);
   const resolvedLaunchCommand = resolveLaunchCommand({
-    baseCommand: useBash ? "/bin/bash" : executablePath,
+    baseCommand: useBash ? "bash" : executablePath,
     baseArgs: useBash ? [executablePath] : [],
     launchOptions,
     wrapperCommands: [

--- a/src/main/helpers/linux-native-executable.test.ts
+++ b/src/main/helpers/linux-native-executable.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  isElfBinary,
+  isLinuxNativeExecutable,
+  isLinuxShellScript,
+} from "./linux-native-executable.ts";
+
+let tmpDir: string;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hydra-native-exec-"));
+  fs.writeFileSync(path.join(tmpDir, "game.sh"), "#!/bin/bash\necho hi\n");
+  fs.writeFileSync(path.join(tmpDir, "GAME.SH"), "#!/bin/bash\necho hi\n");
+  fs.writeFileSync(
+    path.join(tmpDir, "game-noext"),
+    Buffer.concat([
+      Buffer.from([0x7f, 0x45, 0x4c, 0x46]),
+      Buffer.from("fake-elf-body"),
+    ])
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, "game.elf"),
+    Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01])
+  );
+  fs.writeFileSync(path.join(tmpDir, "game.exe"), "MZ-fake-windows-binary");
+  fs.writeFileSync(
+    path.join(tmpDir, "notes.txt"),
+    "#!/bin/bash\nnot-a-script\n"
+  );
+  fs.writeFileSync(path.join(tmpDir, "empty"), "");
+});
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("isLinuxShellScript", () => {
+  it("matches .sh case-insensitively", () => {
+    assert.strictEqual(isLinuxShellScript("/games/doom/game.sh"), true);
+    assert.strictEqual(isLinuxShellScript("/games/doom/GAME.SH"), true);
+  });
+
+  it("rejects other extensions and extensionless files", () => {
+    assert.strictEqual(isLinuxShellScript("/games/doom/game.exe"), false);
+    assert.strictEqual(isLinuxShellScript("/games/doom/game"), false);
+  });
+});
+
+describe("isElfBinary", () => {
+  it("detects ELF magic regardless of extension", () => {
+    assert.strictEqual(isElfBinary(path.join(tmpDir, "game-noext")), true);
+    assert.strictEqual(isElfBinary(path.join(tmpDir, "game.elf")), true);
+  });
+
+  it("rejects non-ELF files, empty files and missing files", () => {
+    assert.strictEqual(isElfBinary(path.join(tmpDir, "game.sh")), false);
+    assert.strictEqual(isElfBinary(path.join(tmpDir, "game.exe")), false);
+    assert.strictEqual(isElfBinary(path.join(tmpDir, "empty")), false);
+    assert.strictEqual(isElfBinary(path.join(tmpDir, "does-not-exist")), false);
+  });
+});
+
+describe("isLinuxNativeExecutable", () => {
+  it("treats .sh and ELF binaries as native on linux", () => {
+    if (process.platform !== "linux") return;
+    assert.strictEqual(
+      isLinuxNativeExecutable(path.join(tmpDir, "game.sh")),
+      true
+    );
+    assert.strictEqual(
+      isLinuxNativeExecutable(path.join(tmpDir, "game-noext")),
+      true
+    );
+    assert.strictEqual(
+      isLinuxNativeExecutable(path.join(tmpDir, "game.elf")),
+      true
+    );
+  });
+
+  it("never routes .exe or plain text through the native path", () => {
+    if (process.platform !== "linux") return;
+    assert.strictEqual(
+      isLinuxNativeExecutable(path.join(tmpDir, "game.exe")),
+      false
+    );
+    assert.strictEqual(
+      isLinuxNativeExecutable(path.join(tmpDir, "notes.txt")),
+      false
+    );
+    assert.strictEqual(
+      isLinuxNativeExecutable(path.join(tmpDir, "does-not-exist")),
+      false
+    );
+  });
+});

--- a/src/main/helpers/linux-native-executable.test.ts
+++ b/src/main/helpers/linux-native-executable.test.ts
@@ -63,8 +63,11 @@ describe("isElfBinary", () => {
 });
 
 describe("isLinuxNativeExecutable", () => {
-  it("treats .sh and ELF binaries as native on linux", () => {
-    if (process.platform !== "linux") return;
+  it("treats .sh and ELF binaries as native on linux", (t) => {
+    if (process.platform !== "linux") {
+      t.skip();
+      return;
+    }
     assert.strictEqual(
       isLinuxNativeExecutable(path.join(tmpDir, "game.sh")),
       true
@@ -79,8 +82,11 @@ describe("isLinuxNativeExecutable", () => {
     );
   });
 
-  it("never routes .exe or plain text through the native path", () => {
-    if (process.platform !== "linux") return;
+  it("never routes .exe or plain text through the native path", (t) => {
+    if (process.platform !== "linux") {
+      t.skip();
+      return;
+    }
     assert.strictEqual(
       isLinuxNativeExecutable(path.join(tmpDir, "game.exe")),
       false

--- a/src/main/helpers/linux-native-executable.test.ts
+++ b/src/main/helpers/linux-native-executable.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  ELF_MAGIC,
   isElfBinary,
   isLinuxNativeExecutable,
   isLinuxShellScript,
@@ -17,14 +18,11 @@ before(() => {
   fs.writeFileSync(path.join(tmpDir, "GAME.SH"), "#!/bin/bash\necho hi\n");
   fs.writeFileSync(
     path.join(tmpDir, "game-noext"),
-    Buffer.concat([
-      Buffer.from([0x7f, 0x45, 0x4c, 0x46]),
-      Buffer.from("fake-elf-body"),
-    ])
+    Buffer.concat([ELF_MAGIC, Buffer.from("fake-elf-body")])
   );
   fs.writeFileSync(
     path.join(tmpDir, "game.elf"),
-    Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01])
+    Buffer.concat([ELF_MAGIC, Buffer.from([0x02, 0x01])])
   );
   fs.writeFileSync(path.join(tmpDir, "game.exe"), "MZ-fake-windows-binary");
   fs.writeFileSync(

--- a/src/main/helpers/linux-native-executable.ts
+++ b/src/main/helpers/linux-native-executable.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+
+export const isLinuxShellScript = (executablePath: string) =>
+  path.extname(executablePath).toLowerCase() === ".sh";
+
+export const isElfBinary = (executablePath: string): boolean => {
+  try {
+    const fd = fs.openSync(executablePath, "r");
+    try {
+      const header = Buffer.alloc(4);
+      const bytesRead = fs.readSync(fd, header, 0, 4, 0);
+      return bytesRead === 4 && header.equals(ELF_MAGIC);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+};
+
+export const isLinuxNativeExecutable = (executablePath: string): boolean => {
+  if (process.platform !== "linux") return false;
+  if (path.extname(executablePath).toLowerCase() === ".exe") return false;
+  if (isLinuxShellScript(executablePath)) return true;
+  return isElfBinary(executablePath);
+};

--- a/src/main/helpers/linux-native-executable.ts
+++ b/src/main/helpers/linux-native-executable.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+export const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
 
 export const isLinuxShellScript = (executablePath: string) =>
   path.extname(executablePath).toLowerCase() === ".sh";

--- a/src/main/services/linux-process-match.test.ts
+++ b/src/main/services/linux-process-match.test.ts
@@ -1,7 +1,22 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { isLinuxGameWindowProcess } from "./linux-process-match.js";
+import {
+  hasLaunchedPidMatch,
+  isLinuxGameWindowProcess,
+} from "./linux-process-match.js";
+import type { LinuxProcessInfo } from "./linux-process-match.js";
+
+const toProcess = (
+  overrides: Partial<LinuxProcessInfo> & { pid: number }
+): LinuxProcessInfo => ({
+  name: "bash",
+  cwd: "",
+  exe: "/bin/bash",
+  appImagePath: null,
+  steamCompatDataPath: null,
+  ...overrides,
+});
 
 describe("Linux game window process matching", () => {
   it("accepts a descendant of the process launched by Hydra", () => {
@@ -79,6 +94,44 @@ describe("Linux game window process matching", () => {
         10,
         ["/games/game"]
       ),
+      false
+    );
+  });
+});
+
+describe("hasLaunchedPidMatch", () => {
+  const executablePath = "/games/game/start.sh";
+
+  it("matches the launched pid sitting in the game directory", () => {
+    const pidToProcess = new Map([
+      [100, toProcess({ pid: 100, cwd: "/games/game" })],
+    ]);
+
+    assert.equal(hasLaunchedPidMatch(100, executablePath, pidToProcess), true);
+  });
+
+  it("matches the launched pid sitting in a game subdirectory", () => {
+    const pidToProcess = new Map([
+      [100, toProcess({ pid: 100, cwd: "/games/game/game" })],
+    ]);
+
+    assert.equal(hasLaunchedPidMatch(100, executablePath, pidToProcess), true);
+  });
+
+  it("rejects the launched pid sitting outside the game directory", () => {
+    const pidToProcess = new Map([
+      [100, toProcess({ pid: 100, cwd: "/tmp" })],
+      [101, toProcess({ pid: 101, cwd: "/games/unrelated" })],
+    ]);
+
+    assert.equal(hasLaunchedPidMatch(100, executablePath, pidToProcess), false);
+    assert.equal(hasLaunchedPidMatch(101, executablePath, pidToProcess), false);
+  });
+
+  it("rejects unknown or missing pids", () => {
+    assert.equal(hasLaunchedPidMatch(999, executablePath, new Map()), false);
+    assert.equal(
+      hasLaunchedPidMatch(undefined, executablePath, new Map()),
       false
     );
   });

--- a/src/main/services/linux-process-match.test.ts
+++ b/src/main/services/linux-process-match.test.ts
@@ -46,6 +46,18 @@ describe("Linux game window process matching", () => {
     );
   });
 
+  it("accepts a process sitting in a game subdirectory", () => {
+    assert.equal(
+      isLinuxGameWindowProcess(
+        [{ pid: 20, exe: "/bin/bash", cwd: "/games/game/subdir" }],
+        20,
+        undefined,
+        ["/games/game/start.sh"]
+      ),
+      true
+    );
+  });
+
   it("accepts a Wine process from the configured compatibility prefix", () => {
     assert.equal(
       isLinuxGameWindowProcess(

--- a/src/main/services/linux-process-match.test.ts
+++ b/src/main/services/linux-process-match.test.ts
@@ -46,7 +46,7 @@ describe("Linux game window process matching", () => {
     );
   });
 
-  it("accepts a process sitting in a game subdirectory", () => {
+  it("rejects a window merely sitting in a game subdirectory", () => {
     assert.equal(
       isLinuxGameWindowProcess(
         [{ pid: 20, exe: "/bin/bash", cwd: "/games/game/subdir" }],
@@ -54,7 +54,7 @@ describe("Linux game window process matching", () => {
         undefined,
         ["/games/game/start.sh"]
       ),
-      true
+      false
     );
   });
 

--- a/src/main/services/linux-process-match.ts
+++ b/src/main/services/linux-process-match.ts
@@ -39,16 +39,15 @@ export const processReferencesExecutable = (
 ) => {
   const target = executablePath.toLowerCase();
   const gameDirectory = path.dirname(executablePath).toLowerCase();
-  const cwd = (matchedProcess.cwd ?? "").toLowerCase();
 
   return (
-    isInGameDirectory(cwd, gameDirectory) ||
+    (matchedProcess.cwd ?? "").toLowerCase() === gameDirectory ||
     (matchedProcess.exe ?? "").toLowerCase() === target ||
     (matchedProcess.appImagePath ?? "").toLowerCase() === target
   );
 };
 
-const isInGameDirectory = (cwd: string, gameDirectory: string) => {
+const isInGameDirectoryTree = (cwd: string, gameDirectory: string) => {
   if (cwd === gameDirectory) return true;
 
   const relative = path.relative(gameDirectory, cwd);
@@ -68,7 +67,15 @@ export const hasLaunchedPidMatch = (
   const matchedProcess = pidToProcess.get(launchedPid);
   if (!matchedProcess) return false;
 
-  return processReferencesExecutable(matchedProcess, executablePath);
+  if (processReferencesExecutable(matchedProcess, executablePath)) return true;
+
+  // Only the pid Hydra itself launched may match by subtree: wrapper scripts
+  // often cd into a game subdirectory. Window matching stays exact-cwd so an
+  // unrelated window merely sitting under the game tree is never accepted.
+  return isInGameDirectoryTree(
+    (matchedProcess.cwd ?? "").toLowerCase(),
+    path.dirname(executablePath).toLowerCase()
+  );
 };
 
 const processMatchesWinePrefix = (

--- a/src/main/services/linux-process-match.ts
+++ b/src/main/services/linux-process-match.ts
@@ -57,7 +57,15 @@ export const hasLaunchedPidMatch = (
   const matchedProcess = pidToProcess.get(launchedPid);
   if (!matchedProcess) return false;
 
-  return processReferencesExecutable(matchedProcess, executablePath);
+  if (processReferencesExecutable(matchedProcess, executablePath)) return true;
+
+  const cwd = (matchedProcess.cwd ?? "").toLowerCase();
+  const gameDirectory = path.dirname(executablePath).toLowerCase();
+  const relative = path.relative(gameDirectory, cwd);
+
+  return (
+    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+  );
 };
 
 const processMatchesWinePrefix = (

--- a/src/main/services/linux-process-match.ts
+++ b/src/main/services/linux-process-match.ts
@@ -39,11 +39,22 @@ export const processReferencesExecutable = (
 ) => {
   const target = executablePath.toLowerCase();
   const gameDirectory = path.dirname(executablePath).toLowerCase();
+  const cwd = (matchedProcess.cwd ?? "").toLowerCase();
 
   return (
-    (matchedProcess.cwd ?? "").toLowerCase() === gameDirectory ||
+    isInGameDirectory(cwd, gameDirectory) ||
     (matchedProcess.exe ?? "").toLowerCase() === target ||
     (matchedProcess.appImagePath ?? "").toLowerCase() === target
+  );
+};
+
+const isInGameDirectory = (cwd: string, gameDirectory: string) => {
+  if (cwd === gameDirectory) return true;
+
+  const relative = path.relative(gameDirectory, cwd);
+
+  return (
+    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
   );
 };
 
@@ -57,15 +68,7 @@ export const hasLaunchedPidMatch = (
   const matchedProcess = pidToProcess.get(launchedPid);
   if (!matchedProcess) return false;
 
-  if (processReferencesExecutable(matchedProcess, executablePath)) return true;
-
-  const cwd = (matchedProcess.cwd ?? "").toLowerCase();
-  const gameDirectory = path.dirname(executablePath).toLowerCase();
-  const relative = path.relative(gameDirectory, cwd);
-
-  return (
-    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
-  );
+  return processReferencesExecutable(matchedProcess, executablePath);
 };
 
 const processMatchesWinePrefix = (

--- a/src/main/services/process-watcher.ts
+++ b/src/main/services/process-watcher.ts
@@ -22,6 +22,7 @@ import {
   type LinuxProcessInfo,
 } from "./linux-process-match";
 import { isWindowsBatchFile } from "@main/helpers/windows-batch-command";
+import { isLinuxNativeExecutable } from "@main/helpers/linux-native-executable";
 import {
   getCloudSaveAutomaticSyncMode,
   runAutomaticCloudSavePostExit,
@@ -384,8 +385,13 @@ function onOpenGame(game: Game) {
     performanceNow: now,
   });
 
-  // On Linux, keep the launcher visible briefly and let it auto-close itself.
-  if (process.platform !== "linux") {
+  // On Linux the launcher auto-closes itself, except for native executables
+  // which start instantly and close it as soon as the game is detected.
+  if (
+    process.platform !== "linux" ||
+    (game.executablePath != null &&
+      isLinuxNativeExecutable(game.executablePath))
+  ) {
     WindowManager.closeGameLauncherWindow();
   }
 


### PR DESCRIPTION
**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

## What

Run Linux-native executables (`.sh`, ELF binaries) natively instead of routing them through Proton/Wine.

- New `src/main/helpers/linux-native-executable.ts`: `.sh` matched by extension, ELF matched by magic bytes (`7F 45 4C 46`), `.exe` never classified as native.
- `launch-game.ts`: `.sh` launches via `/bin/bash` (immune to missing shebang/`+x`); ELF spawns directly. Proton/Wine path untouched for Windows binaries.
- `open-game-installer.ts` + `get-game-installer-action-type.ts`: the installer previously forced `umu-run` for every file on Linux; native files now launch directly, and `setup.sh`/single `.sh` are detected as installers.
- `process-watcher.ts`: the "Launching..." modal closes as soon as a native game is detected (Proton keeps the existing auto-close timer).
- `linux-process-match.ts`: launched-pid matching also accepts the pid sitting in a game subdirectory (GOG-style `start.sh` wrappers that `cd` into `game/` before running).

## Why

Native Linux games shipped as `.sh` launchers or extensionless ELF binaries were treated as Windows software on Linux, forcing them through umu/Proton instead of running natively.

## Testing

- `yarn typecheck`, `eslint`, `prettier`: clean.
- `yarn test`: 518/518 passing, including new suites for the native-executable helper (extension + magic-byte fixtures) and launched-pid subdirectory matching.
- Manual E2E on Linux: `.sh` launcher and extensionless ELF both start natively (no `umu-run`/`WINEPREFIX` in the launch), playtime tracking opens/closes sessions correctly.
