### PR TITLE
fix: play the achievement notification once its window is visible

### DIFF
--- a/src/renderer/src/pages/achievements/notification/achievement-notification.tsx
+++ b/src/renderer/src/pages/achievements/notification/achievement-notification.tsx
@@ -26,6 +26,7 @@ import root from "react-shadow";
 const NOTIFICATION_TIMEOUT = 4_000;
 const CLOSING_TIMEOUT = 450;
 const IMAGE_PREPARATION_TIMEOUT = 2_000;
+const VISIBILITY_TIMEOUT = 1_000;
 
 type NotificationPhase = "idle" | "prepared" | "playing" | "closing";
 
@@ -38,6 +39,49 @@ const getErrorMessage = (error: unknown) => {
   } catch {
     return "unknown error";
   }
+};
+
+const waitForVisibleFrame = (): Promise<void> => {
+  return new Promise((resolve) => {
+    let settled = false;
+    let frame = -1;
+    let timeout = 0;
+    let removeListener = () => {};
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      cancelAnimationFrame(frame);
+      removeListener();
+      resolve();
+    };
+
+    const waitForFrames = () => {
+      frame = requestAnimationFrame(() => {
+        frame = requestAnimationFrame(finish);
+      });
+    };
+
+    timeout = window.setTimeout(finish, VISIBILITY_TIMEOUT);
+
+    if (document.visibilityState === "visible") {
+      waitForFrames();
+      return;
+    }
+
+    const listener = () => {
+      if (document.visibilityState !== "visible") return;
+      removeListener();
+      waitForFrames();
+    };
+
+    document.addEventListener("visibilitychange", listener);
+    removeListener = () => {
+      document.removeEventListener("visibilitychange", listener);
+      removeListener = () => {};
+    };
+  });
 };
 
 const resolveImageUrl = (source: string): Promise<string> => {
@@ -267,18 +311,23 @@ export function AchievementNotification() {
       (requestId) => {
         if (requestRef.current?.id !== requestId) return;
 
-        setPhase("playing");
-        if (!hasPlayedSound.current) {
-          hasPlayedSound.current = true;
-          void playAudio();
-        }
         clearAnimationTimers();
 
-        displayTimer.current = window.setTimeout(() => {
+        void waitForVisibleFrame().then(() => {
           if (requestRef.current?.id !== requestId) return;
-          setPhase("closing");
-          scheduleClosing(requestId);
-        }, NOTIFICATION_TIMEOUT);
+
+          setPhase("playing");
+          if (!hasPlayedSound.current) {
+            hasPlayedSound.current = true;
+            void playAudio();
+          }
+
+          displayTimer.current = window.setTimeout(() => {
+            if (requestRef.current?.id !== requestId) return;
+            setPhase("closing");
+            scheduleClosing(requestId);
+          }, NOTIFICATION_TIMEOUT);
+        });
       }
     );
 


### PR DESCRIPTION
<!-- Please be sure to add one of the labels in the right hand side Labels option before creating a PR: [feature], [fix], [documentation],[translation]. This will allow Actions to automatically categorize PRs when generating Releases. -->

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read the [Hydra documentation](https://docs.hydralauncher.gg/getting-started.html).
- [x] I have checked that there are no duplicate pull requests related to this request.
- [x] I have considered, and confirm that this submission is valuable to others.
- [x] I accept that this submission may not be used and the pull request may be closed at the discretion of the maintainers.

**Fill in the PR content:**

Fixes a bug where the custom achievement notification animation could be displayed twice per notification